### PR TITLE
Make husky prepare script graceful for fresh installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint": "eslint .",
     "format:check": "prettier --check .",
     "release": "pnpm build && changeset publish",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "lint-staged": {
     "*.{ts,mts,js,mjs,cjs,json,html,css,md}": "prettier --write",


### PR DESCRIPTION
## Summary
- Change `"prepare": "husky"` to `"prepare": "husky || true"`
- Prevents `ELIFECYCLE` failure when husky binary isn't available yet (fresh clone, CI, package consumers running `pnpm install`)

## Test plan
- [x] `pnpm install` succeeds on fresh clone
- [x] Pre-commit hook still works after install