### PR TITLE
Add unit tests badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @copilotkit/mock-openai
+# @copilotkit/mock-openai [![Unit Tests](https://github.com/CopilotKit/mock-openai/actions/workflows/test-unit.yml/badge.svg)](https://github.com/CopilotKit/mock-openai/actions/workflows/test-unit.yml)
 
 Deterministic mock OpenAI server for testing. Streams SSE responses in real OpenAI Chat Completions and Responses API format, driven entirely by fixtures. Zero runtime dependencies — built on Node.js builtins only.
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions badge for the Unit Tests workflow to the README title

## Test plan
- [x] Badge URL points to correct workflow (test-unit.yml)
- [x] Prettier and eslint pass