### PR TITLE
docs: update CLAUDE.md for conventional commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,5 +36,5 @@ entire repo, not just staged files.
 
 ## Commit Messages
 
-- Plain English, no conventional commit prefixes (no feat:, fix:, chore:, etc.)
+- This repo enforces conventional commit prefixes via commitlint: `fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, etc.
 - No Co-Authored-By lines


### PR DESCRIPTION
## Summary
- CLAUDE.md previously said "no conventional commit prefixes" — but Tyler added commitlint enforcement, so update to match reality

## Test plan
- [x] Prettier and eslint pass