### PR TITLE
Add getTextContent for array-format message content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/llmock",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Deterministic mock LLM server for testing (OpenAI, Anthropic, Gemini)",
   "license": "MIT",
   "packageManager": "pnpm@10.28.2",

--- a/src/__tests__/router.test.ts
+++ b/src/__tests__/router.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { matchFixture, getLastMessageByRole } from "../router.js";
-import type { ChatCompletionRequest, ChatMessage, Fixture } from "../types.js";
+import { matchFixture, getLastMessageByRole, getTextContent } from "../router.js";
+import type { ChatCompletionRequest, ChatMessage, ContentPart, Fixture } from "../types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -55,6 +55,57 @@ describe("getLastMessageByRole", () => {
 });
 
 // ---------------------------------------------------------------------------
+// getTextContent
+// ---------------------------------------------------------------------------
+
+describe("getTextContent", () => {
+  it("returns the string as-is for string content", () => {
+    expect(getTextContent("hello world")).toBe("hello world");
+  });
+
+  it("returns null for null content", () => {
+    expect(getTextContent(null)).toBeNull();
+  });
+
+  it("extracts text from array-of-parts content", () => {
+    const parts: ContentPart[] = [{ type: "text", text: "hello world" }];
+    expect(getTextContent(parts)).toBe("hello world");
+  });
+
+  it("concatenates multiple text parts", () => {
+    const parts: ContentPart[] = [
+      { type: "text", text: "hello " },
+      { type: "text", text: "world" },
+    ];
+    expect(getTextContent(parts)).toBe("hello world");
+  });
+
+  it("ignores non-text parts in array content", () => {
+    const parts: ContentPart[] = [
+      { type: "image_url", image_url: { url: "https://example.com/img.png" } },
+      { type: "text", text: "describe this" },
+    ];
+    expect(getTextContent(parts)).toBe("describe this");
+  });
+
+  it("returns null for array with no text parts", () => {
+    const parts: ContentPart[] = [
+      { type: "image_url", image_url: { url: "https://example.com/img.png" } },
+    ];
+    expect(getTextContent(parts)).toBeNull();
+  });
+
+  it("returns null for empty array", () => {
+    expect(getTextContent([])).toBeNull();
+  });
+
+  it("returns null for array with only empty-string text parts", () => {
+    const parts: ContentPart[] = [{ type: "text", text: "" }];
+    expect(getTextContent(parts)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // matchFixture — empty / null cases
 // ---------------------------------------------------------------------------
 
@@ -102,6 +153,61 @@ describe("matchFixture — userMessage (string)", () => {
   it("does not match when there is no user message", () => {
     const fixture = makeFixture({ userMessage: "hello" });
     const req = makeReq({ messages: [{ role: "system", content: "hello system" }] });
+    expect(matchFixture([fixture], req)).toBeNull();
+  });
+});
+
+describe("matchFixture — userMessage (array content)", () => {
+  it("matches when user content is array-of-parts with matching text", () => {
+    const fixture = makeFixture({ userMessage: "hello" });
+    const req = makeReq({
+      messages: [{ role: "user", content: [{ type: "text", text: "say hello world" }] }],
+    });
+    expect(matchFixture([fixture], req)).toBe(fixture);
+  });
+
+  it("does not match when array-of-parts text does not include the string", () => {
+    const fixture = makeFixture({ userMessage: "goodbye" });
+    const req = makeReq({
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    });
+    expect(matchFixture([fixture], req)).toBeNull();
+  });
+
+  it("matches regexp against array-of-parts text", () => {
+    const fixture = makeFixture({ userMessage: /^hello/i });
+    const req = makeReq({
+      messages: [{ role: "user", content: [{ type: "text", text: "Hello world" }] }],
+    });
+    expect(matchFixture([fixture], req)).toBe(fixture);
+  });
+
+  it("concatenates multiple text parts for matching", () => {
+    const fixture = makeFixture({ userMessage: "hello world" });
+    const req = makeReq({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hello " },
+            { type: "text", text: "world" },
+          ],
+        },
+      ],
+    });
+    expect(matchFixture([fixture], req)).toBe(fixture);
+  });
+
+  it("skips array content with no text parts", () => {
+    const fixture = makeFixture({ userMessage: "hello" });
+    const req = makeReq({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "image_url", image_url: { url: "https://example.com" } }],
+        },
+      ],
+    });
     expect(matchFixture([fixture], req)).toBeNull();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export { loadFixtureFile, loadFixturesFromDir } from "./fixture-loader.js";
 export { Journal } from "./journal.js";
 
 // Router
-export { matchFixture } from "./router.js";
+export { matchFixture, getTextContent } from "./router.js";
 
 // Provider handlers
 export { handleResponses } from "./responses.js";
@@ -35,6 +35,7 @@ export { writeSSEStream, writeErrorResponse } from "./sse-writer.js";
 export type {
   ChatMessage,
   ChatCompletionRequest,
+  ContentPart,
   ToolDefinition,
   FixtureMatch,
   TextResponse,

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,8 +1,24 @@
-import type { ChatCompletionRequest, ChatMessage, Fixture } from "./types.js";
+import type { ChatCompletionRequest, ChatMessage, ContentPart, Fixture } from "./types.js";
 
 export function getLastMessageByRole(messages: ChatMessage[], role: string): ChatMessage | null {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].role === role) return messages[i];
+  }
+  return null;
+}
+
+/**
+ * Extract the text content from a message's content field.
+ * Handles both plain string content and array-of-parts content
+ * (e.g. `[{type: "text", text: "..."}]` as sent by some SDKs).
+ */
+export function getTextContent(content: string | ContentPart[] | null): string | null {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const texts = content
+      .filter((p) => p.type === "text" && typeof p.text === "string" && p.text !== "")
+      .map((p) => p.text as string);
+    return texts.length > 0 ? texts.join("") : null;
   }
   return null;
 }
@@ -19,11 +35,12 @@ export function matchFixture(fixtures: Fixture[], req: ChatCompletionRequest): F
     // userMessage — match against the last user message content
     if (match.userMessage !== undefined) {
       const msg = getLastMessageByRole(req.messages, "user");
-      if (!msg || typeof msg.content !== "string") continue;
+      const text = msg ? getTextContent(msg.content) : null;
+      if (!text) continue;
       if (typeof match.userMessage === "string") {
-        if (!msg.content.includes(match.userMessage)) continue;
+        if (!text.includes(match.userMessage)) continue;
       } else {
-        if (!match.userMessage.test(msg.content)) continue;
+        if (!match.userMessage.test(text)) continue;
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,14 @@
 // OpenAI Chat Completion request types (subset we care about)
 
+export interface ContentPart {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
 export interface ChatMessage {
   role: "system" | "user" | "assistant" | "tool";
-  content: string | null;
+  content: string | ContentPart[] | null;
   name?: string;
   tool_calls?: ToolCallMessage[];
   tool_call_id?: string;


### PR DESCRIPTION
## Summary
- `matchFixture` now handles message content sent as `[{type: "text", text: "..."}]` (used by Strands SDK and others) in addition to plain strings
- Previously rejected non-string content with `typeof msg.content !== "string"`, causing all array-content requests to fall through to the catch-all fixture
- Exports `getTextContent` from the package index for external consumers
- Adds typed `ContentPart` to `ChatMessage.content` type union

## Test plan
- [x] 390 existing + new tests pass
- [x] New tests cover: array content matching, regexp matching, multi-part concatenation, non-text parts skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)