### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,6 +2,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Allows manual re-runs of the release workflow via `gh workflow run`.