### PR TITLE
Rewrite 'Why llmock' to lead with the problem

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -946,10 +946,11 @@
     <section id="features" class="reveal">
       <div class="container">
         <span class="section-label">Why llmock</span>
-        <h2 class="section-title">Everything you need to test AI integrations</h2>
+        <h2 class="section-title">Stop paying for flaky tests</h2>
         <p class="section-desc">
-          Built for E2E test suites where multiple processes — your app, agent workers, framework
-          runtimes — all need to hit the same mock endpoint.
+          Tests that hit real LLM APIs — OpenAI, Gemini, Anthropic — cost money, time out, and
+          produce non-deterministic results. llmock replaces those calls with immediate,
+          deterministic responses from a real HTTP server any process on the machine can reach.
         </p>
 
         <div class="features-grid">


### PR DESCRIPTION
## Summary

- Rewrites the "Why llmock" section title and description on the website
- Old: "Everything you need to test AI integrations" / multi-process architecture focus
- New: "Stop paying for flaky tests" / leads with the actual pain point: tests hitting real LLM APIs cost money, time out, and produce non-deterministic results

Feature cards underneath are unchanged.