### PR TITLE
Add changeset for 1.1.0 release (prependFixture/getFixtures)

### DIFF
--- a/.changeset/add-prepend-and-get-fixtures.md
+++ b/.changeset/add-prepend-and-get-fixtures.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/llmock": minor
+---
+
+Add `prependFixture()` and `getFixtures()` public API methods


### PR DESCRIPTION
## Summary

Adds a minor changeset to trigger the 1.1.0 release including `prependFixture()` and `getFixtures()` from PR #14.

Once merged, the Release workflow will create a "Version Packages" PR (or publish directly if configured).