### PR TITLE
Add function call IDs to Gemini tool call responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/llmock",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Deterministic mock LLM server for testing (OpenAI, Anthropic, Gemini)",
   "license": "MIT",
   "packageManager": "pnpm@10.28.2",

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -14,7 +14,12 @@ import type {
   ToolCall,
   ToolDefinition,
 } from "./types.js";
-import { isTextResponse, isToolCallResponse, isErrorResponse } from "./helpers.js";
+import {
+  isTextResponse,
+  isToolCallResponse,
+  isErrorResponse,
+  generateToolCallId,
+} from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse } from "./sse-writer.js";
 import type { Journal } from "./journal.js";
@@ -23,7 +28,7 @@ import type { Journal } from "./journal.js";
 
 interface GeminiPart {
   text?: string;
-  functionCall?: { name: string; args: Record<string, unknown> };
+  functionCall?: { name: string; args: Record<string, unknown>; id?: string };
   functionResponse?: { name: string; response: unknown };
 }
 
@@ -232,7 +237,7 @@ function buildGeminiToolCallStreamChunks(toolCalls: ToolCall[]): GeminiResponseC
       argsObj = {};
     }
     return {
-      functionCall: { name: tc.name, args: argsObj },
+      functionCall: { name: tc.name, args: argsObj, id: tc.id || generateToolCallId() },
     };
   });
 
@@ -283,7 +288,7 @@ function buildGeminiToolCallResponse(toolCalls: ToolCall[]): GeminiResponseChunk
       argsObj = {};
     }
     return {
-      functionCall: { name: tc.name, args: argsObj },
+      functionCall: { name: tc.name, args: argsObj, id: tc.id || generateToolCallId() },
     };
   });
 


### PR DESCRIPTION
## Summary

- Google ADK correlates function calls with function responses using the `id` field on `functionCall` objects
- LLMock's Gemini response builders omitted this field, causing ADK to fail with "FunctionCall NOT FOUND"
- Adds `id` (via `generateToolCallId()`) to both `buildGeminiToolCallStreamChunks` and `buildGeminiToolCallResponse`
- Matches the pattern already used by the OpenAI response builders
- All 396 tests pass
- Bumps version to 1.1.1