### PR TITLE
Improve error visibility across WebSocket handlers

### DIFF
--- a/src/__tests__/ws-test-client.ts
+++ b/src/__tests__/ws-test-client.ts
@@ -88,20 +88,24 @@ export function connectWebSocket(url: string, path: string): Promise<WSTestClien
             },
             waitForMessages(count: number, timeoutMs = 5000): Promise<string[]> {
               return new Promise((resolve, reject) => {
+                let settled = false;
+                const timer = setTimeout(() => {
+                  if (!settled) {
+                    settled = true;
+                    reject(
+                      new Error(`Timeout waiting for ${count} messages, got ${messages.length}`),
+                    );
+                  }
+                }, timeoutMs);
                 const check = () => {
-                  if (messages.length >= count) {
+                  if (!settled && messages.length >= count) {
+                    settled = true;
+                    clearTimeout(timer);
                     resolve(messages.slice(0, count));
                   }
                 };
                 check();
                 messageResolvers.push(check);
-                setTimeout(
-                  () =>
-                    reject(
-                      new Error(`Timeout waiting for ${count} messages, got ${messages.length}`),
-                    ),
-                  timeoutMs,
-                );
               });
             },
             waitForClose(): Promise<void> {

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -234,6 +234,9 @@ function buildGeminiToolCallStreamChunks(toolCalls: ToolCall[]): GeminiResponseC
     try {
       argsObj = JSON.parse(tc.arguments || "{}") as Record<string, unknown>;
     } catch {
+      console.warn(
+        `[LLMock] Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+      );
       argsObj = {};
     }
     return {
@@ -285,6 +288,9 @@ function buildGeminiToolCallResponse(toolCalls: ToolCall[]): GeminiResponseChunk
     try {
       argsObj = JSON.parse(tc.arguments || "{}") as Record<string, unknown>;
     } catch {
+      console.warn(
+        `[LLMock] Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+      );
       argsObj = {};
     }
     return {

--- a/src/ws-framing.ts
+++ b/src/ws-framing.ts
@@ -107,8 +107,13 @@ export class WebSocketConnection extends EventEmitter {
 
     try {
       this.socket.write(Buffer.concat([header, payload]));
-    } catch {
-      // Socket destroyed between our check and write — nothing to do
+    } catch (err: unknown) {
+      // Expected when socket is destroyed between our check and write.
+      // Log unexpected errors so they don't vanish silently.
+      if (!this.socket.destroyed) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[LLMock] Unexpected writeFrame error: ${msg}`);
+      }
     }
   }
 

--- a/src/ws-gemini-live.ts
+++ b/src/ws-gemini-live.ts
@@ -186,6 +186,7 @@ export function handleWebSocketGeminiLive(
     pending = pending.then(() =>
       processMessage(raw, ws, fixtures, journal, defaults, session).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : "Internal error";
+        console.error(`[LLMock] WebSocket Gemini Live error: ${msg}`);
         try {
           ws.send(
             JSON.stringify({
@@ -193,7 +194,7 @@ export function handleWebSocketGeminiLive(
             }),
           );
         } catch {
-          // Connection already gone
+          // Connection already gone — original error already logged above
         }
       }),
     );
@@ -382,6 +383,9 @@ async function processMessage(
       try {
         argsObj = JSON.parse(tc.arguments || "{}") as Record<string, unknown>;
       } catch {
+        console.warn(
+          `[LLMock] Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+        );
         argsObj = {};
       }
       return {

--- a/src/ws-realtime.ts
+++ b/src/ws-realtime.ts
@@ -78,6 +78,9 @@ export function realtimeItemsToMessages(
         item.role === "assistant" ? "assistant" : item.role === "system" ? "system" : "user";
       messages.push({ role, content: text });
     } else if (item.type === "function_call") {
+      if (!item.name) {
+        console.warn("[LLMock] Realtime function_call item missing 'name'");
+      }
       messages.push({
         role: "assistant",
         content: null,
@@ -93,6 +96,9 @@ export function realtimeItemsToMessages(
         ],
       });
     } else if (item.type === "function_call_output") {
+      if (!item.output) {
+        console.warn("[LLMock] Realtime function_call_output item missing 'output'");
+      }
       messages.push({
         role: "tool",
         content: item.output ?? "",
@@ -152,10 +158,11 @@ export function handleWebSocketRealtime(
       processMessage(raw, ws, fixtures, journal, defaults, session, conversationItems).catch(
         (err: unknown) => {
           const msg = err instanceof Error ? err.message : "Internal error";
+          console.error(`[LLMock] WebSocket realtime error: ${msg}`);
           try {
             ws.send(buildErrorRealtimeEvent(msg, "server_error"));
           } catch {
-            // Connection already gone
+            // Connection already gone — original error already logged above
           }
         },
       ),

--- a/src/ws-responses.ts
+++ b/src/ws-responses.ts
@@ -69,10 +69,11 @@ export function handleWebSocketResponses(
     pending = pending.then(() =>
       processMessage(raw, ws, fixtures, journal, defaults).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : "Internal error";
+        console.error(`[LLMock] WebSocket responses error: ${msg}`);
         try {
           ws.send(JSON.stringify(buildErrorEvent(msg, "server_error")));
         } catch {
-          // Connection already gone
+          // Connection already gone — original error already logged above
         }
       }),
     );


### PR DESCRIPTION
## Summary

- Log `console.warn` for malformed JSON in fixture tool call arguments (gemini.ts, ws-gemini-live.ts) instead of silently falling back to `{}`
- Log `console.error` before catch blocks in WS error handlers (ws-responses.ts, ws-realtime.ts, ws-gemini-live.ts) so errors aren't swallowed when the connection is gone
- Warn on missing required fields (`name`, `output`) in Realtime conversation items
- Fix `waitForMessages` timeout/resolver leak in WS test client (clear timer on resolve, guard against double-settle)
- Log unexpected non-socket-destroyed errors in `writeFrame` (ws-framing.ts)

## Test plan

- [x] All 436 tests pass
- [x] Build clean
- [x] Lint + prettier clean
- [x] No behavioral changes — only logging additions and test client fix

Stacked on #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)