### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/llmock",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Deterministic mock LLM server for testing (OpenAI, Anthropic, Gemini)",
   "license": "MIT",
   "packageManager": "pnpm@10.28.2",


### PR DESCRIPTION
## Summary
- Bumps package version from 1.1.1 to 1.2.0 to reflect the WebSocket API support added in PR #20 and #21

## Test plan
- [x] All 436 tests pass
- [x] Lint and prettier clean