### PR TITLE
Fix CopilotKit test suite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,9 +648,9 @@ Areas where llmock could grow, and explicit non-goals for the current scope.
 
 ## Real-World Usage
 
-[CopilotKit](https://github.com/CopilotKit/CopilotKit) uses llmock in its E2E test suite to verify AI agent behavior across multiple LLM providers without hitting real APIs. The tests exercise the full stack — Playwright driving a Next.js app whose CopilotKit runtime talks to llmock — providing reproducible, fast, and deterministic coverage of streaming text, tool calls, and multi-turn conversations.
+[CopilotKit](https://github.com/CopilotKit/CopilotKit) uses llmock across its test suite to verify AI agent behavior across multiple LLM providers without hitting real APIs. The tests cover streaming text, tool calls, and multi-turn conversations across both v1 and v2 runtimes.
 
-See the [CopilotKit E2E test fixtures](https://github.com/CopilotKit/CopilotKit/tree/main/tests/e2e) for real-world examples of llmock in action.
+See the [CopilotKit test suite](https://github.com/CopilotKit/CopilotKit/search?q=llmock&type=code) for real-world examples of llmock in action.
 
 ## License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1357,15 +1357,16 @@
         <h2>Real-World Usage</h2>
         <p>
           <a href="https://github.com/CopilotKit/CopilotKit" target="_blank">CopilotKit</a> uses
-          llmock in its E2E test suite to verify AI agent behavior across multiple LLM providers
-          without hitting real APIs. The tests exercise the full stack &mdash; Playwright driving a
-          Next.js app whose CopilotKit runtime talks to llmock &mdash; providing reproducible, fast,
-          and deterministic coverage of streaming text, tool calls, and multi-turn conversations.
+          llmock across its test suite to verify AI agent behavior across multiple LLM providers
+          without hitting real APIs. The tests cover streaming text, tool calls, and multi-turn
+          conversations across both v1 and v2 runtimes.
         </p>
         <p>
           See the
-          <a href="https://github.com/CopilotKit/CopilotKit/tree/main/tests/e2e" target="_blank"
-            >CopilotKit E2E test fixtures</a
+          <a
+            href="https://github.com/CopilotKit/CopilotKit/search?q=llmock&amp;type=code"
+            target="_blank"
+            >CopilotKit test suite</a
           >
           for real-world examples of llmock in action.
         </p>


### PR DESCRIPTION
## Summary

- Fix broken link to `tests/e2e` (path doesn't exist) → link to GitHub code search for `llmock` instead
- Update description: CopilotKit uses llmock across its test suite (not just E2E), covering v1 and v2 runtimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)