### PR TITLE
Add WebSocket row to MSW comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ MSW can't intercept any of those calls. llmock can — it's a real server on a r
 | OpenAI Responses API SSE     | **Built-in**          | Manual — MSW's `sse()` sends `data:` events, not OpenAI's `event:` format |
 | Claude Messages API SSE      | **Built-in**          | Manual — build `event:`/`data:` SSE yourself                              |
 | Gemini streaming             | **Built-in**          | Manual — build `data:` SSE yourself                                       |
+| WebSocket APIs               | **Built-in**          | **No**                                                                    |
 | Fixture file loading (JSON)  | **Yes**               | **No** — handlers are code-only                                           |
 | Request journal / inspection | **Yes**               | **No** — track requests manually                                          |
 | Non-streaming responses      | **Yes**               | **Yes**                                                                   |


### PR DESCRIPTION
## Summary

- Adds missing "WebSocket APIs" row to the README MSW comparison table
- index.html already had this row — README was out of sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)