### PR TITLE
Enable Git LFS for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.pdf filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.webm filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary

- Adds `.gitattributes` tracking gif, jpg, jpeg, png, pdf, mp4, webm, and svg via Git LFS
- Matches CopilotKit/CopilotKit convention (PR #3418)
- Needed before any binary assets (screenshots, demo videos) are added to the repo

## Test plan

- [ ] `git lfs env` confirms LFS is active
- [ ] Adding a binary file shows it tracked via `git lfs status`