### PR TITLE
Tighten section spacing and fix heading consistency

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -433,7 +433,7 @@
 
       /* ─── Sections ───────────────────────────────────────────────── */
       section {
-        padding: 6rem 0;
+        padding: 3rem 0;
       }
 
       .section-label {
@@ -639,10 +639,6 @@
       }
 
       /* ─── Comparison Table ───────────────────────────────────────── */
-      .comparison {
-        border-top: 1px solid var(--border);
-      }
-
       .comparison-table {
         width: 100%;
         margin-top: 3rem;
@@ -1420,7 +1416,7 @@
     <!-- ═══ Real-World Usage ═════════════════════════════════════════ -->
     <section class="reveal">
       <div class="container">
-        <h2>Real-World Usage</h2>
+        <h2 class="section-title">Real-World Usage</h2>
         <p>
           <a href="https://github.com/CopilotKit/CopilotKit" target="_blank">CopilotKit</a> uses
           llmock across its test suite to verify AI agent behavior across multiple LLM providers


### PR DESCRIPTION
## Summary

- Section padding `6rem` → `3rem` (less dead space between sections)
- Remove `border-top` on comparison section (was the only section with a visible HR)
- Real-World Usage heading uses `section-title` class to match Claude Code Integration

Follow-up to #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)