### PR TITLE
Add Reliability section to docs site, switch drift CI to daily

### DIFF
--- a/.github/workflows/test-drift.yml
+++ b/.github/workflows/test-drift.yml
@@ -1,7 +1,7 @@
 name: Drift Tests
 on:
   schedule:
-    - cron: "0 6 * * 1" # Weekly Monday 6am UTC
+    - cron: "0 6 * * *" # Daily 6am UTC
   workflow_dispatch: # Manual trigger
 jobs:
   drift:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.tsbuildinfo
 .worktrees/
+.superpowers/

--- a/DRIFT.md
+++ b/DRIFT.md
@@ -132,7 +132,7 @@ A canary test (`ws-gemini-live.drift.ts`) queries the Gemini model listing API o
 
 Drift tests run on a schedule:
 
-- **Weekly**: Monday 6:00 AM UTC
+- **Daily**: 6:00 AM UTC
 - **Manual**: Trigger via GitHub Actions UI (`workflow_dispatch`)
 - **NOT** on PR or push — these tests hit real APIs and cost money
 
@@ -140,4 +140,4 @@ See `.github/workflows/test-drift.yml`.
 
 ## Cost
 
-~25 API calls per run (16 HTTP response-shape + 3 model listing + 4 WS + 2 canaries) using the cheapest available models (`gpt-4o-mini`, `gpt-4o-mini-realtime-preview`, `claude-haiku-4-5-20251001`, `gemini-2.5-flash`) with 10-100 max tokens each. Under $0.02/week. When Gemini Live text-capable models become available, this will increase to 6 WS calls.
+~25 API calls per run (16 HTTP response-shape + 3 model listing + 4 WS + 2 canaries) using the cheapest available models (`gpt-4o-mini`, `gpt-4o-mini-realtime-preview`, `claude-haiku-4-5-20251001`, `gemini-2.5-flash`) with 10-100 max tokens each. Under $0.15/week at daily cadence. When Gemini Live text-capable models become available, this will increase to 6 WS calls.

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ Areas where llmock could grow, and explicit non-goals for the current scope.
 
 ### Testing
 
-- **Live API drift detection**: The `drift` test suite runs against real OpenAI, Anthropic, and Gemini APIs to catch response format drift. See [DRIFT.md](DRIFT.md) for details on the three-layer triangulation approach, how to run tests, and how to fix detected drift. Runs weekly in CI; requires API keys.
+- **Live API drift detection**: The `drift` test suite runs against real OpenAI, Anthropic, and Gemini APIs to catch response format drift. See [DRIFT.md](DRIFT.md) for details on the three-layer triangulation approach, how to run tests, and how to fix detected drift. Runs daily in CI; requires API keys.
 - **Token counts**: Usage fields are always zero across all providers.
 - **Vision/image content**: Image content parts are not handled by any provider.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -638,6 +638,182 @@
         color: var(--warning);
       }
 
+      /* ─── Reliability / Drift Detection ─────────────────────────── */
+      .triangle-wrapper {
+        position: relative;
+        width: 100%;
+        max-width: 600px;
+        margin: 3.5rem auto 1rem;
+        aspect-ratio: 1.3 / 1;
+      }
+      .triangle-wrapper svg {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 0;
+      }
+      .tri-node {
+        position: absolute;
+        background: var(--bg-card);
+        border: 2px solid;
+        border-radius: 12px;
+        padding: 1rem 1.25rem;
+        text-align: center;
+        width: 170px;
+        z-index: 1;
+      }
+      .tri-node h3 {
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin-bottom: 0.3rem;
+      }
+      .tri-node p {
+        font-size: 0.75rem;
+        color: var(--text-secondary);
+        line-height: 1.4;
+      }
+      .tri-node .node-icon {
+        font-size: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+      .tri-node.sdk {
+        border-color: var(--blue);
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+      }
+      .tri-node.sdk .node-icon {
+        color: var(--blue);
+      }
+      .tri-node.real {
+        border-color: var(--accent);
+        bottom: 0;
+        left: 0;
+      }
+      .tri-node.real .node-icon {
+        color: var(--accent);
+      }
+      .tri-node.mock {
+        border-color: var(--purple);
+        bottom: 0;
+        right: 0;
+      }
+      .tri-node.mock .node-icon {
+        color: var(--purple);
+      }
+      .diagnosis-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 1rem;
+        margin-top: 2.5rem;
+      }
+      .diagnosis-card {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+      }
+      .diagnosis-card .diag-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 0.4rem;
+      }
+      .diagnosis-card .diag-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+      .diagnosis-card h4 {
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--text-primary);
+      }
+      .diagnosis-card p {
+        font-size: 0.78rem;
+        color: var(--text-secondary);
+        line-height: 1.5;
+      }
+      .drift-report {
+        background: var(--bg-deep);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1.25rem 1.5rem;
+        margin-top: 2.5rem;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        line-height: 1.8;
+        color: var(--text-secondary);
+        overflow-x: auto;
+      }
+      .drift-report .report-header {
+        color: var(--text-primary);
+        font-weight: 600;
+        margin-bottom: 0.75rem;
+        font-size: 0.8rem;
+      }
+      .drift-report .severity-critical {
+        color: var(--error);
+      }
+      .drift-report .severity-warning {
+        color: var(--warning);
+      }
+      .drift-report .severity-ok {
+        color: var(--accent);
+      }
+      .drift-report .field-path {
+        color: var(--blue);
+      }
+      .drift-report .drift-label {
+        color: var(--text-primary);
+      }
+      .drift-report .report-summary {
+        color: var(--text-dim);
+      }
+      .drift-report .field-label {
+        color: var(--text-dim);
+      }
+      .drift-report .divider {
+        border-top: 1px solid var(--border);
+        margin: 0.6rem 0;
+      }
+      .ci-footer {
+        display: flex;
+        align-items: center;
+        gap: 1.5rem;
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--border);
+      }
+      .ci-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 0.4rem 0.75rem;
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+        font-family: var(--font-mono);
+        flex-shrink: 0;
+      }
+      .ci-badge .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--accent);
+      }
+      .ci-text {
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+        line-height: 1.6;
+      }
+
       /* ─── Comparison Table ───────────────────────────────────────── */
       .comparison-table {
         width: 100%;
@@ -804,6 +980,9 @@
         .code-section {
           grid-template-columns: 1fr;
         }
+        .diagnosis-grid {
+          grid-template-columns: 1fr;
+        }
         .comparison-table {
           font-size: 0.8rem;
         }
@@ -825,6 +1004,10 @@
         .nav-links a:not(.gh-link) {
           display: none;
         }
+        .ci-footer {
+          flex-direction: column;
+          align-items: flex-start;
+        }
         footer .container {
           flex-direction: column;
           gap: 1.5rem;
@@ -845,6 +1028,7 @@
         <ul class="nav-links">
           <li><a href="#features">Features</a></li>
           <li><a href="#examples">Examples</a></li>
+          <li><a href="#reliability">Reliability</a></li>
           <li><a href="#comparison">vs MSW</a></li>
           <li><a href="#claude-code">Claude Code</a></li>
           <li>
@@ -1233,6 +1417,185 @@
 <span class="cm">// {"type":"response.text.done", ...}</span>
 <span class="cm">// {"type":"response.done", ...}</span></code></pre>
           </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══ Reliability / Drift Detection ═══════════════════════════ -->
+    <section id="reliability" class="reveal">
+      <div class="container">
+        <span class="section-label">Reliability</span>
+        <h2 class="section-title">Verified against real APIs. Every day.</h2>
+        <p class="section-desc">
+          A mock that doesn't match reality is worse than no mock &mdash; your tests pass, but
+          production breaks. llmock runs three-way drift detection that compares SDK types, real API
+          responses, and mock output to catch shape mismatches before you do.
+        </p>
+
+        <!-- Triangle diagram -->
+        <div class="triangle-wrapper">
+          <svg viewBox="0 0 600 420" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <!-- SDK → Real (left edge) -->
+            <line
+              x1="245"
+              y1="105"
+              x2="130"
+              y2="280"
+              stroke="var(--border)"
+              stroke-width="1.5"
+              stroke-dasharray="6 4"
+            />
+            <polygon points="127,274 137,278 133,286" fill="var(--border)" />
+            <!-- SDK → Mock (right edge) -->
+            <line
+              x1="355"
+              y1="105"
+              x2="470"
+              y2="280"
+              stroke="var(--border)"
+              stroke-width="1.5"
+              stroke-dasharray="6 4"
+            />
+            <polygon points="473,274 463,278 467,286" fill="var(--border)" />
+            <!-- Real ↔ Mock (bottom edge) -->
+            <line
+              x1="195"
+              y1="355"
+              x2="405"
+              y2="355"
+              stroke="var(--border)"
+              stroke-width="1.5"
+              stroke-dasharray="6 4"
+            />
+            <polygon points="200,349 190,355 200,361" fill="var(--border)" />
+            <polygon points="400,349 410,355 400,361" fill="var(--border)" />
+            <!-- Edge labels (horizontal, centered on each line) -->
+            <rect x="131" y="182" width="85" height="20" rx="4" fill="var(--bg-deep)" />
+            <text
+              x="173"
+              y="196"
+              text-anchor="middle"
+              fill="var(--text-dim)"
+              font-family="JetBrains Mono, SF Mono, Fira Code, monospace"
+              font-size="11"
+            >
+              SDK = Real?
+            </text>
+            <rect x="360" y="182" width="90" height="20" rx="4" fill="var(--bg-deep)" />
+            <text
+              x="405"
+              y="196"
+              text-anchor="middle"
+              fill="var(--text-dim)"
+              font-family="JetBrains Mono, SF Mono, Fira Code, monospace"
+              font-size="11"
+            >
+              SDK = Mock?
+            </text>
+            <rect x="255" y="338" width="90" height="20" rx="4" fill="var(--bg-deep)" />
+            <text
+              x="300"
+              y="352"
+              text-anchor="middle"
+              fill="var(--text-dim)"
+              font-family="JetBrains Mono, SF Mono, Fira Code, monospace"
+              font-size="11"
+            >
+              Real = Mock?
+            </text>
+          </svg>
+          <div class="tri-node sdk">
+            <div class="node-icon">{ }</div>
+            <h3>SDK Types</h3>
+            <p>What TypeScript types say the shape should be</p>
+          </div>
+          <div class="tri-node real">
+            <div class="node-icon">&#8644;</div>
+            <h3>Real API</h3>
+            <p>What OpenAI, Claude, Gemini actually return</p>
+          </div>
+          <div class="tri-node mock">
+            <div class="node-icon">&#9881;</div>
+            <h3>llmock</h3>
+            <p>What the mock produces for the same request</p>
+          </div>
+        </div>
+
+        <!-- Diagnosis cards -->
+        <div class="diagnosis-grid">
+          <div class="diagnosis-card">
+            <div class="diag-header">
+              <div class="diag-dot" style="background: var(--error)"></div>
+              <h4>Mock doesn't match real</h4>
+            </div>
+            <p>
+              llmock needs updating &mdash; test fails immediately. The SDK comparison tells us why
+              it drifted.
+            </p>
+          </div>
+          <div class="diagnosis-card">
+            <div class="diag-header">
+              <div class="diag-dot" style="background: var(--warning)"></div>
+              <h4>Provider changed, SDK is behind</h4>
+            </div>
+            <p>
+              Early warning &mdash; the real API has new fields that neither the SDK nor llmock know
+              about yet.
+            </p>
+          </div>
+          <div class="diagnosis-card">
+            <div class="diag-header">
+              <div class="diag-dot" style="background: var(--accent)"></div>
+              <h4>All three agree</h4>
+            </div>
+            <p>No drift &mdash; the mock matches reality and the SDK types are current.</p>
+          </div>
+        </div>
+
+        <!-- Drift report snippet -->
+        <div class="drift-report">
+          <div class="report-header">$ pnpm test:drift</div>
+          <span class="severity-critical">[critical]</span>
+          <span class="drift-label">LLMOCK DRIFT</span> &mdash; field in SDK + real API but missing
+          from mock<br />
+          <span class="field-label">Path:</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="field-path"
+            >choices[].message.refusal</span
+          ><br />
+          <span class="field-label">SDK:</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;null &nbsp;&nbsp;
+          <span class="field-label">Real:</span> null &nbsp;&nbsp;
+          <span class="field-label">Mock:</span> &lt;absent&gt;<br />
+          <div class="divider"></div>
+          <span class="severity-critical">[critical]</span>
+          <span class="drift-label">TYPE MISMATCH</span> &mdash; real API and mock disagree on
+          type<br />
+          <span class="field-label">Path:</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="field-path"
+            >content[].input</span
+          ><br />
+          <span class="field-label">SDK:</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;object &nbsp;&nbsp;
+          <span class="field-label">Real:</span> object &nbsp;&nbsp;
+          <span class="field-label">Mock:</span> string<br />
+          <div class="divider"></div>
+          <span class="severity-warning">[warning]</span>
+          <span class="drift-label">PROVIDER ADDED FIELD</span> &mdash; in real API but not in SDK
+          or mock<br />
+          <span class="field-label">Path:</span>&nbsp;&nbsp;&nbsp;&nbsp;<span class="field-path"
+            >choices[].message.annotations</span
+          ><br />
+          <span class="field-label">SDK:</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;absent&gt;
+          &nbsp;&nbsp; <span class="field-label">Real:</span> array &nbsp;&nbsp;
+          <span class="field-label">Mock:</span> &lt;absent&gt;<br />
+          <div class="divider"></div>
+          <span class="severity-ok" style="font-size: 0.85rem">&#10003;</span>
+          <span class="report-summary"
+            >2 critical (test fails) &middot; 1 warning (logged) &middot; detected before any user
+            reported it</span
+          >
+        </div>
+
+        <!-- CI footer -->
+        <div class="ci-footer">
+          <div class="ci-badge"><span class="dot"></span> Daily CI</div>
+          <span class="ci-text">Drift tests across 4 providers run automatically every day.</span>
         </div>
       </div>
     </section>

--- a/docs/superpowers/specs/2026-03-15-trust-section-design.md
+++ b/docs/superpowers/specs/2026-03-15-trust-section-design.md
@@ -1,0 +1,93 @@
+# Design: "Reliability" Trust Section for llmock Docs Site
+
+## Summary
+
+Add a new section to the llmock docs site (`docs/index.html`) between "Fixture-driven. Zero boilerplate." (code examples) and "llmock vs MSW" (comparison table). The section explains why users can trust that llmock's response shapes match real provider APIs, and how three-way drift detection keeps it that way.
+
+## Placement
+
+```
+Features ("Stop paying for flaky tests")
+Code Examples ("Fixture-driven. Zero boilerplate.")
+→ NEW: Reliability ("Verified against real APIs. Every day.")
+Comparison ("llmock vs MSW")
+Claude Code Integration
+Real-World Usage
+Footer
+```
+
+## Section Structure
+
+### Header
+
+- **Section label**: `RELIABILITY`
+- **Headline**: "Verified against real APIs. Every day."
+- **Description paragraph**: "A mock that doesn't match reality is worse than no mock — your tests pass, but production breaks. llmock runs three-way drift detection that compares SDK types, real API responses, and mock output to catch shape mismatches before you do."
+
+### Triangle Diagram
+
+SVG-based diagram showing three nodes arranged in a triangle:
+
+- **Top center**: "SDK Types" (blue border, `{ }` icon) — "What TypeScript types say the shape should be"
+- **Bottom left**: "Real API" (green border, `↔` icon) — "What OpenAI, Claude, Gemini actually return"
+- **Bottom right**: "llmock" (purple border, `⚙` icon) — "What the mock produces for the same request"
+
+Dashed connector lines between all three nodes with horizontal labels at each midpoint:
+
+- Left edge: "SDK = Real?"
+- Right edge: "SDK = Mock?"
+- Bottom edge: "Real = Mock?"
+
+### Diagnosis Cards (3-column grid)
+
+Three cards explaining the possible outcomes:
+
+1. **Red dot — "Mock doesn't match real"**: llmock needs updating — test fails immediately. The SDK comparison tells us why it drifted.
+2. **Amber dot — "Provider changed, SDK is behind"**: Early warning — the real API has new fields that neither the SDK nor llmock know about yet.
+3. **Green dot — "All three agree"**: No drift — the mock matches reality and the SDK types are current.
+
+Key principle: any mismatch between real API and mock is a failure, regardless of SDK state. The SDK layer diagnoses _why_ drift happened, it doesn't gate severity.
+
+### Drift Report Snippet
+
+Monospace terminal-style block showing `$ pnpm test:drift` output with three distinct examples:
+
+1. `[critical] LLMOCK DRIFT` — missing field (`choices[].message.refusal`: SDK has it, real has it, mock doesn't)
+2. `[critical] TYPE MISMATCH` — wrong type (`content[].input`: SDK says object, real says object, mock says string)
+3. `[warning] PROVIDER ADDED FIELD` — new field (`choices[].message.annotations`: only real API has it)
+
+Footer line: "2 critical (test fails) · 1 warning (logged) · detected before any user reported it"
+
+### CI Footer
+
+Badge showing "Daily CI" with green dot, text: "Drift tests across 4 providers run automatically every day."
+
+## Styling
+
+All styles must use the site's CSS custom properties (not hardcoded hex):
+
+- Background: `var(--bg-deep)` (page) / `var(--bg-card)` (cards)
+- Borders: `var(--border)`
+- Text: `var(--text-primary)` (headings) / `var(--text-secondary)` (body) / `var(--text-dim)` (labels)
+- Accent: `var(--accent)` (green)
+- Uses existing `.section-label`, `.section-title`, `.section-desc` CSS classes
+- Section uses `class="reveal"` for scroll-triggered animation
+- Triangle diagram uses inline SVG for connector lines
+
+## CI Cadence Change
+
+The drift CI workflow (`.github/workflows/test-drift.yml`) will be updated from weekly (Monday 6am UTC) to daily (6am UTC every day). The cron changes from `0 6 * * 1` to `0 6 * * *`.
+
+DRIFT.md and the site footer text will be updated to say "every day" instead of "every week."
+
+## Files to Modify
+
+| File                               | Change                                                                                                                |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `docs/index.html`                  | Insert new section between code examples and comparison. New CSS for triangle diagram, diagnosis cards, drift report. |
+| `.github/workflows/test-drift.yml` | Change cron from `0 6 * * 1` to `0 6 * * *`                                                                           |
+| `DRIFT.md`                         | Update schedule references from weekly to daily; update cost estimate in Cost section for daily cadence               |
+
+## Validated Mockup
+
+The approved design is in `.superpowers/brainstorm/84286-1773621431/trust-section-v4.html`.


### PR DESCRIPTION
## Summary

- New "Reliability" section on the docs site between code examples and MSW comparison
- SVG triangle diagram showing three-way drift detection (SDK types × Real API × llmock)
- Three diagnosis cards: mock drift (red), provider ahead of SDK (amber), all clear (green)
- Real drift report output showing mixed severity results
- Daily CI badge footer
- Drift cron changed from weekly to daily
- Nav link added for new section
- DRIFT.md cost updated for daily cadence
- README "weekly" → "daily"

## Test plan

- [x] `pnpm test` — 540/540 pass
- [x] All CSS uses site custom properties (no hardcoded hex)
- [x] Mobile breakpoints for diagnosis grid and CI footer
- [x] 2 rounds of CR — all 6 toolkit agents, clean on final round

🤖 Generated with [Claude Code](https://claude.com/claude-code)