### PR TITLE
Fix watcher cleanup, empty-reload guard, and stale README

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ Areas where llmock could grow, and explicit non-goals for the current scope.
 
 - **Request metadata in predicates**: Predicate functions receive only the `ChatCompletionRequest`, not HTTP headers, method, or URL.
 - **Multi-turn conversation state**: Fixtures are stateless — there is no built-in way to sequence responses across multiple requests in a conversation.
-- **Validation on load**: Fixture files are not schema-validated at load time; malformed fixtures surface as runtime errors.
+- **Validation on load**: Schema validation is available via `--validate-on-load` (CLI) and `validateFixtures()` (programmatic API), but it is opt-in and not enabled by default.
 - **Inheritance and aliasing**: No `$ref` or `extends` mechanism for fixture reuse across files.
 
 ### Testing

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -30,6 +30,13 @@ export function watchFixtures(
       return;
     }
 
+    if (newFixtures.length === 0 && fixtures.length > 0) {
+      logger.warn(
+        "Reload produced 0 fixtures — keeping previous fixtures. Check fixture file for errors.",
+      );
+      return;
+    }
+
     if (validate && validateFn) {
       const results = validateFn(newFixtures);
       const errors = results.filter((r) => r.severity === "error");
@@ -60,6 +67,13 @@ export function watchFixtures(
   });
 
   watcher.on("error", (err: Error) => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = null;
+    try {
+      watcher.close();
+    } catch {
+      /* already dead */
+    }
     logger.error(`File watcher error on ${fixturePath}: ${err.message}`);
     logger.error("Fixture auto-reload is no longer active. Restart the server to resume watching.");
   });


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #40. Addresses 3 findings from code review:

- Watcher error handler now clears debounce timer and closes FSWatcher to avoid indeterminate state after fs.watch errors
- Reload guards against replacing fixtures with empty array on parse failure, preserving previous working fixtures
- Update README Future Direction to reflect that `--validate-on-load` and `validateFixtures()` now exist

## Test plan

- [x] All 565 existing tests pass
- [ ] Manually verify watcher error recovery (kill the watched file's filesystem)
- [ ] Verify reload with invalid JSON preserves previous fixtures