### PR TITLE
Patch release v1.5.1 — fix docs URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @copilotkit/llmock
 
+## 1.5.1
+
+### Patch Changes
+
+- Fix documentation URLs from `llmock.com` to `llmock.copilotkit.dev`
+
 ## 1.5.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/llmock",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Deterministic mock LLM server for testing (OpenAI, Anthropic, Gemini)",
   "license": "MIT",
   "packageManager": "pnpm@10.28.2",


### PR DESCRIPTION
Bump to 1.5.1 to republish npm package with corrected documentation URLs (llmock.copilotkit.dev instead of llmock.com). The v1.5.0 GitHub release and tag have been deleted.

Once merged, push the `v1.5.1` tag to trigger the release workflow.