### PR TITLE
fix: preserve base URL path prefix in record proxy

### DIFF
--- a/src/__tests__/url.test.ts
+++ b/src/__tests__/url.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { resolveUpstreamUrl } from "../url.js";
+
+describe("resolveUpstreamUrl", () => {
+  it("preserves base path prefix", () => {
+    expect(resolveUpstreamUrl("https://openrouter.ai/api", "/v1/chat/completions").href).toBe(
+      "https://openrouter.ai/api/v1/chat/completions",
+    );
+  });
+
+  it("works with root-path providers", () => {
+    expect(resolveUpstreamUrl("https://api.openai.com", "/v1/chat/completions").href).toBe(
+      "https://api.openai.com/v1/chat/completions",
+    );
+  });
+
+  it("handles trailing slash on base", () => {
+    expect(resolveUpstreamUrl("https://openrouter.ai/api/", "/v1/messages").href).toBe(
+      "https://openrouter.ai/api/v1/messages",
+    );
+  });
+
+  it("handles no leading slash on pathname", () => {
+    expect(resolveUpstreamUrl("https://api.anthropic.com", "v1/messages").href).toBe(
+      "https://api.anthropic.com/v1/messages",
+    );
+  });
+
+  it("handles both trailing and no leading slash", () => {
+    expect(resolveUpstreamUrl("https://openrouter.ai/api/", "v1/embeddings").href).toBe(
+      "https://openrouter.ai/api/v1/embeddings",
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,9 @@ export type { ChaosAction } from "./types.js";
 // Recorder
 export { proxyAndRecord } from "./recorder.js";
 
+// URL
+export { resolveUpstreamUrl } from "./url.js";
+
 // Stream Collapse
 export {
   collapseOpenAISSE,

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -15,6 +15,7 @@ import { getLastMessageByRole, getTextContent } from "./router.js";
 import type { Logger } from "./logger.js";
 import { collapseStreamingResponse } from "./stream-collapse.js";
 import { writeErrorResponse } from "./sse-writer.js";
+import { resolveUpstreamUrl } from "./url.js";
 
 /**
  * Proxy an unmatched request to the real upstream provider, record the
@@ -48,7 +49,7 @@ export async function proxyAndRecord(
   const fixturePath = record.fixturePath ?? "./fixtures/recorded";
   let target: URL;
   try {
-    target = new URL(pathname, upstreamUrl);
+    target = resolveUpstreamUrl(upstreamUrl, pathname);
   } catch {
     defaults.logger.error(`Invalid upstream URL for provider "${providerKey}": ${upstreamUrl}`);
     writeErrorResponse(

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,0 +1,15 @@
+/**
+ * Resolve an upstream URL by joining a base URL with a request pathname.
+ *
+ * Uses RFC 3986 relative resolution: the base URL's path prefix is preserved
+ * by ensuring a trailing slash (marking it as a "directory") and stripping the
+ * leading slash from the pathname (making it relative, not absolute).
+ *
+ * Without this, `new URL("/v1/chat/completions", "https://openrouter.ai/api")`
+ * resolves to `https://openrouter.ai/v1/chat/completions` — losing the `/api` prefix.
+ */
+export function resolveUpstreamUrl(base: string, pathname: string): URL {
+  const normalizedBase = base.endsWith("/") ? base : base + "/";
+  const relativePath = pathname.startsWith("/") ? pathname.slice(1) : pathname;
+  return new URL(relativePath, normalizedBase);
+}


### PR DESCRIPTION
## Problem

The record proxy loses the base URL path prefix when constructing upstream URLs.

`new URL("/v1/chat/completions", "https://openrouter.ai/api")` resolves to
`https://openrouter.ai/v1/chat/completions` — the `/api` prefix is dropped.
This is standard `URL` constructor behavior (absolute pathname replaces the
base path), but breaks providers like OpenRouter whose API lives at a
non-root path (`/api/v1/...`).

Providers with root-path APIs (OpenAI, Anthropic) are unaffected.

## Fix

Extract URL joining into a `resolveUpstreamUrl()` helper that normalizes
inputs for RFC 3986 relative resolution:
- Ensure base URL has a trailing slash (marks it as a "directory")
- Strip leading slash from pathname (makes it relative, not absolute)

This preserves any path prefix while keeping existing behavior for
root-path providers unchanged. Unit tests cover all combinations.

## Examples

| Base URL | Pathname | Before | After |
|---|---|---|---|
| `https://openrouter.ai/api` | `/v1/chat/completions` | `https://openrouter.ai/v1/chat/completions` | `https://openrouter.ai/api/v1/chat/completions` |
| `https://api.openai.com` | `/v1/chat/completions` | `https://api.openai.com/v1/chat/completions` | `https://api.openai.com/v1/chat/completions` |
| `https://api.anthropic.com` | `/v1/messages` | `https://api.anthropic.com/v1/messages` | `https://api.anthropic.com/v1/messages` |