### PR TITLE
fix: forward all request headers in record proxy

### DIFF
--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -1673,9 +1673,9 @@ describe("recorder auth header handling", () => {
     expect(content).not.toContain("api-key");
   });
 
-  it("custom non-auth headers from client are NOT forwarded to upstream", async () => {
-    // We'll verify by checking that the upstream doesn't receive custom headers.
-    // Create a raw upstream that echoes back received headers.
+  it("all non-hop-by-hop headers from client are forwarded to upstream", async () => {
+    // Verify that provider-specific headers (e.g. anthropic-version) are forwarded,
+    // while hop-by-hop headers (host, connection, etc.) are stripped.
     let receivedHeaders: http.IncomingHttpHeaders = {};
     const echoServer = http.createServer((req, res) => {
       receivedHeaders = req.headers;
@@ -1705,15 +1705,15 @@ describe("recorder auth header handling", () => {
       },
       {
         Authorization: "Bearer sk-test",
-        "X-Custom-Header": "should-not-forward",
-        "X-Request-Id": "req-123",
+        "X-Custom-Header": "custom-value",
+        "anthropic-version": "2023-06-01",
       },
     );
 
-    // Authorization is forwarded, custom headers are not
+    // All non-hop-by-hop headers are forwarded
     expect(receivedHeaders["authorization"]).toBe("Bearer sk-test");
-    expect(receivedHeaders["x-custom-header"]).toBeUndefined();
-    expect(receivedHeaders["x-request-id"]).toBeUndefined();
+    expect(receivedHeaders["x-custom-header"]).toBe("custom-value");
+    expect(receivedHeaders["anthropic-version"]).toBe("2023-06-01");
 
     await new Promise<void>((resolve) => echoServer.close(() => resolve()));
   });

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -16,6 +16,25 @@ import type { Logger } from "./logger.js";
 import { collapseStreamingResponse } from "./stream-collapse.js";
 import { writeErrorResponse } from "./sse-writer.js";
 
+/** Headers to strip when proxying — hop-by-hop (RFC 2616 §13.5.1) + client-set. */
+const STRIP_HEADERS = new Set([
+  // Hop-by-hop (RFC 2616 §13.5.1)
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "te",
+  "trailer",
+  "upgrade",
+  "proxy-authorization",
+  "proxy-authenticate",
+  // Set by HTTP client from the target URL / body
+  "host",
+  "content-length",
+  // Not relevant for LLM APIs; avoid leaking or mismatched encoding
+  "cookie",
+  "accept-encoding",
+]);
+
 /**
  * Proxy an unmatched request to the real upstream provider, record the
  * response as a fixture on disk and in memory, then relay the response
@@ -63,12 +82,10 @@ export async function proxyAndRecord(
 
   defaults.logger.warn(`NO FIXTURE MATCH — proxying to ${upstreamUrl}${pathname}`);
 
-  // Forward only safe headers — auth and content negotiation
+  // Forward all request headers except hop-by-hop and client-set ones.
   const forwardHeaders: Record<string, string> = {};
-  const headersToForward = ["authorization", "x-api-key", "api-key", "content-type", "accept"];
-  for (const name of headersToForward) {
-    const val = req.headers[name];
-    if (val !== undefined) {
+  for (const [name, val] of Object.entries(req.headers)) {
+    if (val !== undefined && !STRIP_HEADERS.has(name)) {
       forwardHeaders[name] = Array.isArray(val) ? val.join(", ") : val;
     }
   }


### PR DESCRIPTION
## Problem

The record proxy only forwards 5 hardcoded request headers to the upstream provider:
`authorization`, `x-api-key`, `api-key`, `content-type`, `accept`.

Provider-specific headers are silently dropped. For example, the Anthropic API
requires the `anthropic-version` header on every request — without it, the API
returns 400:

```
{'type': 'error', 'error': {'type': 'invalid_request_error',
 'message': 'anthropic-version: header is required'}}
```

This makes `--record` mode unusable with the Anthropic provider.

## Fix

Forward all request headers by default, stripping only headers that should
not be proxied. The strip list is a module-level constant:

**Hop-by-hop headers** ([RFC 2616 §13.5.1](https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1)):
`connection`, `keep-alive`, `transfer-encoding`, `te`, `trailer`, `upgrade`,
`proxy-authorization`, `proxy-authenticate`

**Set by the HTTP client** (from target URL / body):
`host`, `content-length`

**LLM proxy specific** (avoid leaking or encoding mismatch):
`cookie`, `accept-encoding`

Auth headers (`authorization`, `x-api-key`) are still forwarded — they're
no longer special-cased since all non-stripped headers pass through. They
continue to be excluded from saved fixture files (that logic is separate
and unchanged).

`Via` / `X-Forwarded-*` are **not** set or stripped — consistent with how
other LLM proxy tools (LiteLLM, Portkey, Helicone) handle upstream
forwarding, and LLM APIs (OpenAI, Anthropic) do not use them.