### PR TITLE
feat: add matchKeyTransform option for recording match key normalization

### DIFF
--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -2797,3 +2797,178 @@ describe("recorder binary EventStream relay integrity", () => {
     expect(fixtureContent.fixtures[0].response.content).toBe("Binary integrity test");
   });
 });
+
+// ---------------------------------------------------------------------------
+// matchKeyTransform
+// ---------------------------------------------------------------------------
+
+describe("recorder matchKeyTransform", () => {
+  it("saves the transformed match key in the fixture file", async () => {
+    // Upstream responds to any user message containing "capital"
+    upstream = await createServer(
+      [{ match: { userMessage: "capital" }, response: { content: "Paris" } }],
+      { port: 0 },
+    );
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-transform-"));
+
+    // The transform strips the dynamic timestamp from the user message
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: upstream.url },
+        fixturePath: tmpDir,
+        matchKeyTransform: (req) => ({
+          ...req,
+          messages: req.messages.map((m) => ({
+            ...m,
+            content:
+              typeof m.content === "string"
+                ? m.content.replace(/\d{4}-\d{2}-\d{2}T[\d:.+Z-]+/g, "")
+                : m.content,
+          })),
+        }),
+      },
+    });
+
+    // Send a request with a dynamic timestamp in the user message
+    const resp = await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        {
+          role: "user",
+          content: "What is the capital of France?\nTimestamp: 2026-03-30T13:19:38.000Z",
+        },
+      ],
+    });
+
+    expect(resp.status).toBe(200);
+    const body = JSON.parse(resp.body);
+    expect(body.choices[0].message.content).toBe("Paris");
+
+    // The saved fixture should use the transformed (timestamp-stripped) match key
+    const files = fs.readdirSync(tmpDir);
+    const fixtureFiles = files.filter((f) => f.endsWith(".json"));
+    expect(fixtureFiles).toHaveLength(1);
+
+    const fixtureContent = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, fixtureFiles[0]), "utf-8"),
+    ) as FixtureFile;
+    expect(fixtureContent.fixtures[0].match.userMessage).toBe(
+      "What is the capital of France?\nTimestamp: ",
+    );
+  });
+
+  it("preserves the original response from upstream", async () => {
+    upstream = await createServer(
+      [{ match: { userMessage: "capital" }, response: { content: "Paris is the capital." } }],
+      { port: 0 },
+    );
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-transform-"));
+
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: upstream.url },
+        fixturePath: tmpDir,
+        matchKeyTransform: (req) => ({
+          ...req,
+          messages: req.messages.map((m) => ({
+            ...m,
+            content:
+              typeof m.content === "string" ? m.content.replace(/uuid=[a-f0-9-]+/g, "") : m.content,
+          })),
+        }),
+      },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "What is the capital? uuid=550e8400-e29b-41d4-a716-446655440000" },
+      ],
+    });
+
+    expect(resp.status).toBe(200);
+    const body = JSON.parse(resp.body);
+    // The upstream response is preserved as-is
+    expect(body.choices[0].message.content).toBe("Paris is the capital.");
+
+    // The saved fixture response is also the original upstream response
+    const files = fs.readdirSync(tmpDir);
+    const fixtureFiles = files.filter((f) => f.endsWith(".json"));
+    const fixtureContent = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, fixtureFiles[0]), "utf-8"),
+    ) as FixtureFile;
+    expect((fixtureContent.fixtures[0].response as { content: string }).content).toBe(
+      "Paris is the capital.",
+    );
+  });
+
+  it("does not alter match key when no transform is configured", async () => {
+    upstream = await createServer(
+      [{ match: { userMessage: "capital" }, response: { content: "Paris" } }],
+      { port: 0 },
+    );
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-notransform-"));
+
+    // No matchKeyTransform
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: upstream.url },
+        fixturePath: tmpDir,
+      },
+    });
+
+    const message = "What is the capital? ts=2026-03-30T13:19:38.000Z";
+    await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: message }],
+    });
+
+    const files = fs.readdirSync(tmpDir);
+    const fixtureFiles = files.filter((f) => f.endsWith(".json"));
+    const fixtureContent = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, fixtureFiles[0]), "utf-8"),
+    ) as FixtureFile;
+    // Without a transform, the full original message is the match key
+    expect(fixtureContent.fixtures[0].match.userMessage).toBe(message);
+  });
+
+  it("applies transform to embedding requests", async () => {
+    upstream = await createServer(
+      [{ match: { inputText: "hello" }, response: { embedding: [0.1, 0.2, 0.3] } }],
+      { port: 0 },
+    );
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-transform-embed-"));
+
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: upstream.url },
+        fixturePath: tmpDir,
+        matchKeyTransform: (req) => ({
+          ...req,
+          embeddingInput: req.embeddingInput?.replace(/ \| session=[a-f0-9]+/, ""),
+        }),
+      },
+    });
+
+    const resp = await post(`${recorder.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: "hello world | session=abc123def",
+    });
+
+    expect(resp.status).toBe(200);
+    const body = JSON.parse(resp.body);
+    expect(body.data[0].embedding).toEqual([0.1, 0.2, 0.3]);
+
+    const files = fs.readdirSync(tmpDir);
+    const fixtureFiles = files.filter((f) => f.endsWith(".json"));
+    const fixtureContent = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, fixtureFiles[0]), "utf-8"),
+    ) as FixtureFile;
+    // The transform stripped the session suffix from the embedding input
+    expect(fixtureContent.fixtures[0].match.inputText).toBe("hello world");
+  });
+});

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -146,8 +146,10 @@ export async function proxyAndRecord(
     fixtureResponse = buildFixtureResponse(parsedResponse, upstreamStatus);
   }
 
-  // Build the match criteria from the original request
-  const fixtureMatch = buildFixtureMatch(request);
+  // Build the match criteria — apply optional transform before key extraction
+  const transform = record.matchKeyTransform ?? ((req: ChatCompletionRequest) => req);
+  const normalizedReq = transform(request);
+  const fixtureMatch = buildFixtureMatch(normalizedReq);
 
   // Build and save the fixture
   const fixture: Fixture = { match: fixtureMatch, response: fixtureResponse };

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,6 +230,11 @@ export type RecordProviderKey =
 export interface RecordConfig {
   providers: Partial<Record<RecordProviderKey, string>>;
   fixturePath?: string;
+  /** Transform request before extracting match key during recording.
+   * Use to strip dynamic fields (timestamps, UUIDs) that change between runs.
+   * The transform is applied before the match key is derived from the request.
+   * Only affects recording — replay matching uses the stored (transformed) key. */
+  matchKeyTransform?: (req: ChatCompletionRequest) => ChatCompletionRequest;
 }
 
 export interface MockServerOptions {


### PR DESCRIPTION
## Problem

When recording fixtures, the match key is derived from the full request
content (last user message, embedding input text). If the request contains
dynamic data (timestamps, UUIDs, session metadata), the recorded match key
won't match on replay because these values differ between runs.

This is a common issue when recording through services that inject timestamps
into LLM prompts:

```
"Extract facts...\nEvent Date: 2026-03-30T13:19:38...\nText:\nThe user's color is blue"
```

On replay, the timestamp differs, so `text.includes(recordedKey)` fails.

## Solution

Add an optional `matchKeyTransform` function to `RecordConfig`. When
provided, the request is transformed before the match key is extracted
and saved to the fixture file. The transform runs only during recording —
replay matching uses the stored (already-transformed) key.

```typescript
const mock = new LLMock({
  record: {
    providers: { openai: "https://api.openai.com" },
    matchKeyTransform: (req) => ({
      ...req,
      messages: req.messages.map(m => ({
        ...m,
        content: typeof m.content === "string"
          ? m.content.replace(/\d{4}-\d{2}-\d{2}T[\d:.+Z]+/g, "")
          : m.content,
      })),
      embeddingInput: req.embeddingInput?.split(" | ")[0],
    }),
  },
});
```

This follows the Polly.js pattern of composable request normalizers for
deterministic match key generation.

## Changes

- `types.ts`: Add `matchKeyTransform` to `RecordConfig`
- `recorder.ts`: Apply transform before match key extraction
- Tests: Verify transformed keys are saved, original response preserved