### PR TITLE
chore: rename llmock→aimock in comments, strings, URLs, and docs

### DIFF
--- a/DRIFT.md
+++ b/DRIFT.md
@@ -1,19 +1,19 @@
 # Live API Drift Detection
 
-llmock produces responses shaped like real LLM APIs. Providers change their APIs over time. **Drift** means the mock no longer matches reality — your tests pass against llmock but break against the real API.
+aimock produces responses shaped like real LLM APIs. Providers change their APIs over time. **Drift** means the mock no longer matches reality — your tests pass against aimock but break against the real API.
 
 ## Three-Layer Approach
 
 Drift detection compares three independent sources to triangulate the cause of any mismatch:
 
-| SDK types = Real API? | Real API = llmock? | Diagnosis                                                            |
+| SDK types = Real API? | Real API = aimock? | Diagnosis                                                            |
 | --------------------- | ------------------ | -------------------------------------------------------------------- |
-| Yes                   | No                 | **llmock drift** — response builders need updating                   |
+| Yes                   | No                 | **aimock drift** — response builders need updating                   |
 | No                    | No                 | **Provider changed before SDK update** — flag, wait for SDK catch-up |
 | Yes                   | Yes                | **No drift** — all clear                                             |
 | No                    | Yes                | **SDK drift** — provider deprecated something SDK still references   |
 
-Two-way comparison (mock vs real) can't distinguish between "we need to fix llmock" and "the SDK hasn't caught up yet." Three-way comparison can.
+Two-way comparison (mock vs real) can't distinguish between "we need to fix aimock" and "the SDK hasn't caught up yet." Three-way comparison can.
 
 ## Running Drift Tests
 
@@ -40,9 +40,9 @@ Each provider's tests skip independently if its key is not set. You can run drif
 
 ### Severity levels
 
-- **critical** — Test fails. llmock produces a different shape than the real API for a field that both the SDK and real API agree on. This means llmock needs an update.
-- **warning** — Test passes (unless `STRICT_DRIFT=1`). The real API has a field that neither the SDK nor llmock knows about, or the SDK and real API disagree. Usually means a provider added something new.
-- **info** — Always passes. Known intentional differences (usage fields are always zero, optional fields llmock omits, etc.).
+- **critical** — Test fails. aimock produces a different shape than the real API for a field that both the SDK and real API agree on. This means aimock needs an update.
+- **warning** — Test passes (unless `STRICT_DRIFT=1`). The real API has a field that neither the SDK nor aimock knows about, or the SDK and real API disagree. Usually means a provider added something new.
+- **info** — Always passes. Known intentional differences (usage fields are always zero, optional fields aimock omits, etc.).
 
 ### Example report output
 
@@ -86,7 +86,7 @@ When a `critical` drift is detected:
 
 ## Model Deprecation
 
-The `models.drift.ts` test scrapes model names referenced in llmock's test files, README, and fixtures, then checks each provider's model listing API to verify they still exist.
+The `models.drift.ts` test scrapes model names referenced in aimock's test files, README, and fixtures, then checks each provider's model listing API to verify they still exist.
 
 When a model is deprecated:
 
@@ -106,7 +106,7 @@ When a model is deprecated:
 
 ## WebSocket Drift Coverage
 
-In addition to the 19 existing drift tests (16 HTTP response-shape + 3 model deprecation), WebSocket drift tests cover llmock's WS protocols (4 verified + 2 canary = 6 WS tests):
+In addition to the 19 existing drift tests (16 HTTP response-shape + 3 model deprecation), WebSocket drift tests cover aimock's WS protocols (4 verified + 2 canary = 6 WS tests):
 
 | Protocol            | Text | Tool Call | Real Endpoint                                                       | Status     |
 | ------------------- | ---- | --------- | ------------------------------------------------------------------- | ---------- |
@@ -118,13 +118,13 @@ In addition to the 19 existing drift tests (16 HTTP response-shape + 3 model dep
 
 **Auth**: Uses the same `OPENAI_API_KEY` and `GOOGLE_API_KEY` environment variables as HTTP tests. No new secrets needed.
 
-**How it works**: A TLS WebSocket client (`ws-providers.ts`) connects to real provider endpoints using `node:tls` with RFC 6455 framing. Each protocol function handles the setup sequence (e.g., Realtime session negotiation, Gemini Live setup/setupComplete) and collects messages until a terminal event. The mock side uses the existing `ws-test-client.ts` plaintext client against the local llmock server.
+**How it works**: A TLS WebSocket client (`ws-providers.ts`) connects to real provider endpoints using `node:tls` with RFC 6455 framing. Each protocol function handles the setup sequence (e.g., Realtime session negotiation, Gemini Live setup/setupComplete) and collects messages until a terminal event. The mock side uses the existing `ws-test-client.ts` plaintext client against the local aimock server.
 
 ### Gemini Live: unverified
 
-llmock's Gemini Live handler implements the text-based `BidiGenerateContent` protocol as documented in Google's [Live API reference](https://ai.google.dev/api/live) — `setup`/`setupComplete` handshake, `clientContent` with turns, `serverContent` with `modelTurn.parts[].text`, and `toolCall` responses. The protocol format is correct per the docs.
+aimock's Gemini Live handler implements the text-based `BidiGenerateContent` protocol as documented in Google's [Live API reference](https://ai.google.dev/api/live) — `setup`/`setupComplete` handshake, `clientContent` with turns, `serverContent` with `modelTurn.parts[].text`, and `toolCall` responses. The protocol format is correct per the docs.
 
-However, as of March 2026, the only models that support `bidiGenerateContent` are native-audio models (`gemini-2.5-flash-native-audio-*`), which reject text-only requests. No text-capable model exists for this endpoint yet, so we cannot triangulate llmock's output against a real API response.
+However, as of March 2026, the only models that support `bidiGenerateContent` are native-audio models (`gemini-2.5-flash-native-audio-*`), which reject text-only requests. No text-capable model exists for this endpoint yet, so we cannot triangulate aimock's output against a real API response.
 
 A canary test (`ws-gemini-live.drift.ts`) queries the Gemini model listing API on each drift run and checks for a non-audio model that supports `bidiGenerateContent`. When Google ships one, the canary will flag it and the full drift tests can be enabled.
 

--- a/packages/aimock-pytest/README.md
+++ b/packages/aimock-pytest/README.md
@@ -1,6 +1,6 @@
 # aimock-pytest
 
-pytest fixtures for [aimock](https://github.com/CopilotKit/llmock) — mock LLM APIs, MCP tools, A2A agents, vector databases, and more.
+pytest fixtures for [aimock](https://github.com/CopilotKit/aimock) — mock LLM APIs, MCP tools, A2A agents, vector databases, and more.
 
 ## Install
 

--- a/scripts/update-competitive-matrix.ts
+++ b/scripts/update-competitive-matrix.ts
@@ -172,7 +172,7 @@ const DOCS_PATH = resolve(import.meta.dirname ?? __dirname, "../docs/index.html"
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? "";
 const HEADERS: Record<string, string> = {
   Accept: "application/vnd.github.v3+json",
-  "User-Agent": "llmock-competitive-matrix-updater",
+  "User-Agent": "aimock-competitive-matrix-updater",
   ...(GITHUB_TOKEN ? { Authorization: `Bearer ${GITHUB_TOKEN}` } : {}),
 };
 
@@ -403,7 +403,7 @@ function parseCurrentMatrix(html: string): {
   while ((m = thRegex.exec(tableHtml)) !== null) {
     headers.push(m[1].trim());
   }
-  // headers[0] = "llmock", headers[1] = "MSW", headers[2..] = competitors
+  // headers[0] = "aimock", headers[1] = "MSW", headers[2..] = competitors
 
   // Extract rows
   const rows = new Map<string, Map<string, string>>();
@@ -422,7 +422,7 @@ function parseCurrentMatrix(html: string): {
 
     const rowLabel = tds[0];
     const rowMap = new Map<string, string>();
-    // tds[1] = llmock, tds[2] = MSW, tds[3..5] = competitors
+    // tds[1] = aimock, tds[2] = MSW, tds[3..5] = competitors
     for (let i = 1; i < tds.length && i - 1 < headers.length; i++) {
       rowMap.set(headers[i - 1], tds[i]);
     }
@@ -433,7 +433,7 @@ function parseCurrentMatrix(html: string): {
 }
 
 /**
- * Updates only competitor cells (not llmock or MSW) where:
+ * Updates only competitor cells (not aimock or MSW) where:
  * - The current value indicates "No" (class="no">No</td>)
  * - The feature was detected in the competitor's README
  *
@@ -495,9 +495,9 @@ function applyChanges(html: string, changes: DetectedChange[]): string {
   while ((m = thRegex.exec(theadMatch[1])) !== null) {
     headers.push(m[1].trim());
   }
-  // Column indices: "Capability" = 0 (no header link), then llmock=1, MSW=2,
+  // Column indices: "Capability" = 0 (no header link), then aimock=1, MSW=2,
   // VidaiMock=3, mock-llm=4, piyook/llm-mock=5
-  // In the <td> array: index 0 = capability, 1 = llmock, 2 = MSW, 3+ = competitors
+  // In the <td> array: index 0 = capability, 1 = aimock, 2 = MSW, 3+ = competitors
   const compColumnIndex = (name: string): number => {
     const idx = headers.indexOf(name);
     return idx === -1 ? -1 : idx + 1; // +1 because first <td> is the row label

--- a/src/__tests__/aimock-cli.test.ts
+++ b/src/__tests__/aimock-cli.test.ts
@@ -456,7 +456,7 @@ describe("runAimockCli: onReady and shutdown", () => {
     });
   });
 
-  it("shutdown calls llmock.stop()", async () => {
+  it("shutdown calls aimock.stop()", async () => {
     const mockStop = vi.fn().mockResolvedValue(undefined);
     const startFromConfigFn = vi.fn().mockResolvedValue({
       llmock: { stop: mockStop },
@@ -496,7 +496,7 @@ describe("runAimockCli: onReady and shutdown", () => {
     });
   });
 
-  it("shutdown logs error and exits 1 when llmock.stop() rejects", async () => {
+  it("shutdown logs error and exits 1 when aimock.stop() rejects", async () => {
     const mockStop = vi.fn().mockRejectedValue(new Error("close ENOTCONN"));
     const startFromConfigFn = vi.fn().mockResolvedValue({
       llmock: { stop: mockStop },

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -94,7 +94,7 @@ function writeFixture(dir: string, name: string): string {
 describe.skipIf(!CLI_AVAILABLE)("CLI: --help", () => {
   it("prints usage text and exits with code 0", async () => {
     const { stdout, code } = await runCli(["--help"]);
-    expect(stdout).toContain("Usage: llmock");
+    expect(stdout).toContain("Usage: aimock");
     expect(stdout).toContain("--port");
     expect(stdout).toContain("--fixtures");
     expect(code).toBe(0);

--- a/src/__tests__/competitive-matrix-summary.test.ts
+++ b/src/__tests__/competitive-matrix-summary.test.ts
@@ -73,7 +73,7 @@ function writeSummary(summaryPath: string, changes: DetectedChange[]): void {
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function tmpPath(suffix: string): string {
-  return join(tmpdir(), `llmock-cm-test-${suffix}-${Date.now()}.md`);
+  return join(tmpdir(), `aimock-cm-test-${suffix}-${Date.now()}.md`);
 }
 
 const tempFiles: string[] = [];

--- a/src/__tests__/config-loader.test.ts
+++ b/src/__tests__/config-loader.test.ts
@@ -772,7 +772,7 @@ describe("startFromConfig", () => {
     expect(card.name).toBe("no-events-agent");
   });
 
-  it("with record config, llmock receives record settings", async () => {
+  it("with record config, aimock receives record settings", async () => {
     const config: AimockConfig = {
       llm: {
         record: {

--- a/src/__tests__/drift/anthropic.drift.ts
+++ b/src/__tests__/drift/anthropic.drift.ts
@@ -1,7 +1,7 @@
 /**
  * Anthropic Claude Messages API drift tests.
  *
- * Three-way comparison: SDK types × real API × llmock output.
+ * Three-way comparison: SDK types × real API × aimock output.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";

--- a/src/__tests__/drift/bedrock-stream.drift.ts
+++ b/src/__tests__/drift/bedrock-stream.drift.ts
@@ -1,7 +1,7 @@
 /**
  * AWS Bedrock drift tests.
  *
- * Three-way comparison: SDK types x real API x llmock output.
+ * Three-way comparison: SDK types x real API x aimock output.
  * Covers invoke-with-response-stream and converse endpoints.
  */
 

--- a/src/__tests__/drift/cohere.drift.ts
+++ b/src/__tests__/drift/cohere.drift.ts
@@ -1,7 +1,7 @@
 /**
  * Cohere drift tests.
  *
- * Three-way comparison: expected shape x real API x llmock output.
+ * Three-way comparison: expected shape x real API x aimock output.
  * Covers /v2/chat non-streaming and streaming endpoints.
  *
  * Requires: COHERE_API_KEY

--- a/src/__tests__/drift/gemini.drift.ts
+++ b/src/__tests__/drift/gemini.drift.ts
@@ -1,7 +1,7 @@
 /**
  * Google Gemini GenerateContent API drift tests.
  *
- * Three-way comparison: SDK types × real API × llmock output.
+ * Three-way comparison: SDK types × real API × aimock output.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -1,5 +1,5 @@
 /**
- * Model deprecation checks — verify that models referenced in llmock's
+ * Model deprecation checks — verify that models referenced in aimock's
  * tests, docs, and examples still exist at each provider.
  */
 
@@ -43,7 +43,7 @@ const sourceFiles = [
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!process.env.OPENAI_API_KEY)("OpenAI model availability", () => {
-  it("models used in llmock tests are still available", async () => {
+  it("models used in aimock tests are still available", async () => {
     const models = await listOpenAIModels(process.env.OPENAI_API_KEY!);
     const referenced = scrapeModels(/\b(gpt-4o(?:-mini)?|gpt-4|gpt-3\.5-turbo)\b/g, sourceFiles);
 
@@ -62,7 +62,7 @@ describe.skipIf(!process.env.OPENAI_API_KEY)("OpenAI model availability", () => 
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!process.env.ANTHROPIC_API_KEY)("Anthropic model availability", () => {
-  it("models used in llmock tests are still available", async () => {
+  it("models used in aimock tests are still available", async () => {
     const models = await listAnthropicModels(process.env.ANTHROPIC_API_KEY!);
     const referenced = scrapeModels(
       /\b(claude-3(?:\.\d+)?-(?:opus|sonnet|haiku)(?:-\d{8})?)\b/g,
@@ -83,7 +83,7 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY)("Anthropic model availability", 
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!process.env.GOOGLE_API_KEY)("Gemini model availability", () => {
-  it("models used in llmock tests are still available", async () => {
+  it("models used in aimock tests are still available", async () => {
     const models = await listGeminiModels(process.env.GOOGLE_API_KEY!);
     const referenced = scrapeModels(/\b(gemini-(?:[\w.-]+))\b/g, sourceFiles);
 

--- a/src/__tests__/drift/ollama.drift.ts
+++ b/src/__tests__/drift/ollama.drift.ts
@@ -1,7 +1,7 @@
 /**
  * Ollama drift tests.
  *
- * Compares llmock's Ollama endpoint output shapes against a real local
+ * Compares aimock's Ollama endpoint output shapes against a real local
  * Ollama instance. Skips automatically if Ollama is not reachable.
  *
  * Requires: local Ollama running at http://localhost:11434

--- a/src/__tests__/drift/openai-chat.drift.ts
+++ b/src/__tests__/drift/openai-chat.drift.ts
@@ -1,7 +1,7 @@
 /**
  * OpenAI Chat Completions API drift tests.
  *
- * Three-way comparison: SDK types × real API × llmock output.
+ * Three-way comparison: SDK types × real API × aimock output.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";

--- a/src/__tests__/drift/openai-embeddings.drift.ts
+++ b/src/__tests__/drift/openai-embeddings.drift.ts
@@ -1,7 +1,7 @@
 /**
  * OpenAI Embeddings API drift tests.
  *
- * Three-way comparison: SDK types × real API × llmock output.
+ * Three-way comparison: SDK types × real API × aimock output.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";

--- a/src/__tests__/drift/openai-responses.drift.ts
+++ b/src/__tests__/drift/openai-responses.drift.ts
@@ -1,7 +1,7 @@
 /**
  * OpenAI Responses API drift tests.
  *
- * Three-way comparison: SDK types × real API × llmock output.
+ * Three-way comparison: SDK types × real API × aimock output.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";

--- a/src/__tests__/drift/schema.ts
+++ b/src/__tests__/drift/schema.ts
@@ -1,6 +1,6 @@
 /**
  * Shape extraction, three-way comparison, severity classification, and reporting
- * for drift detection between SDK types, real API responses, and llmock output.
+ * for drift detection between SDK types, real API responses, and aimock output.
  */
 
 // ---------------------------------------------------------------------------
@@ -23,7 +23,7 @@ export interface ShapeDiff {
   issue: string;
   expected: string; // from SDK types
   real: string; // from real API
-  mock: string; // from llmock
+  mock: string; // from aimock
 }
 
 export interface SSEEventShape {
@@ -248,7 +248,7 @@ function triangulateAt(
   // All absent — nothing to compare
   if (!sdk && !real && !mock) return diffs;
 
-  // Field in SDK + real but not mock → llmock drift (critical)
+  // Field in SDK + real but not mock → aimock drift (critical)
   if (sdk && real && !mock) {
     diffs.push({
       path: displayPath,

--- a/src/__tests__/drift/vertex-ai.drift.ts
+++ b/src/__tests__/drift/vertex-ai.drift.ts
@@ -1,7 +1,7 @@
 /**
  * Vertex AI / Gemini drift tests.
  *
- * Verifies that llmock's Vertex AI routing produces response shapes
+ * Verifies that aimock's Vertex AI routing produces response shapes
  * consistent with the Gemini generateContent endpoint.
  *
  * Requires: GOOGLE_APPLICATION_CREDENTIALS or (VERTEX_AI_PROJECT + VERTEX_AI_LOCATION)
@@ -71,7 +71,7 @@ describe.skipIf(!HAS_CREDENTIALS)("Vertex AI drift", () => {
   it("generateContent mock shape matches Gemini format", async () => {
     const sdkShape = geminiGenerateContentShape();
 
-    // Vertex AI routing in llmock follows the path pattern:
+    // Vertex AI routing in aimock follows the path pattern:
     // /v1/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent
     const mockRes = await httpPost(
       `${instance.url}/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent`,

--- a/src/__tests__/drift/ws-gemini-live.drift.ts
+++ b/src/__tests__/drift/ws-gemini-live.drift.ts
@@ -1,7 +1,7 @@
 /**
  * Gemini Live BidiGenerateContent WebSocket drift tests.
  *
- * Three-way comparison: SDK types × real API (WS) × llmock output (WS).
+ * Three-way comparison: SDK types × real API (WS) × aimock output (WS).
  *
  * Currently, the Gemini Live API only supports native-audio models
  * (those with "native-audio" in the name) which cannot return TEXT responses.

--- a/src/__tests__/drift/ws-realtime.drift.ts
+++ b/src/__tests__/drift/ws-realtime.drift.ts
@@ -1,7 +1,7 @@
 /**
  * OpenAI Realtime API WebSocket drift tests.
  *
- * Three-way comparison: SDK types x real API (WS) x llmock output (WS).
+ * Three-way comparison: SDK types x real API (WS) x aimock output (WS).
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";

--- a/src/__tests__/drift/ws-responses.drift.ts
+++ b/src/__tests__/drift/ws-responses.drift.ts
@@ -1,7 +1,7 @@
 /**
  * OpenAI Responses API WebSocket drift tests.
  *
- * Three-way comparison: SDK types × real API (WS) × llmock output (WS).
+ * Three-way comparison: SDK types × real API (WS) × aimock output (WS).
  * The Responses WS protocol uses the same event shapes as HTTP SSE.
  */
 

--- a/src/__tests__/llmock.test.ts
+++ b/src/__tests__/llmock.test.ts
@@ -46,7 +46,7 @@ function chatBody(userMessage: string, stream = true) {
 }
 
 function makeTmpDir(): string {
-  return mkdtempSync(join(tmpdir(), "llmock-test-"));
+  return mkdtempSync(join(tmpdir(), "aimock-test-"));
 }
 
 // ---- Tests ----

--- a/src/__tests__/provider-compat.test.ts
+++ b/src/__tests__/provider-compat.test.ts
@@ -31,7 +31,7 @@ async function httpGet(url: string): Promise<{ status: number; body: string }> {
 const CATCH_ALL_FIXTURES: Fixture[] = [
   {
     match: { userMessage: "hello" },
-    response: { content: "Hello from llmock!" },
+    response: { content: "Hello from aimock!" },
   },
 ];
 
@@ -66,7 +66,7 @@ describe("Mistral compatibility", () => {
     expect(status).toBe(200);
     const parsed = JSON.parse(body);
     expect(parsed.choices).toBeDefined();
-    expect(parsed.choices[0].message.content).toBe("Hello from llmock!");
+    expect(parsed.choices[0].message.content).toBe("Hello from aimock!");
     expect(parsed.object).toBe("chat.completion");
   });
 });
@@ -138,7 +138,7 @@ describe("Groq compatibility", () => {
     expect(status).toBe(200);
     const parsed = JSON.parse(body);
     expect(parsed.choices).toBeDefined();
-    expect(parsed.choices[0].message.content).toBe("Hello from llmock!");
+    expect(parsed.choices[0].message.content).toBe("Hello from aimock!");
     expect(parsed.object).toBe("chat.completion");
   });
 
@@ -182,7 +182,7 @@ describe("Ollama compatibility", () => {
     expect(status).toBe(200);
     const parsed = JSON.parse(body);
     expect(parsed.choices).toBeDefined();
-    expect(parsed.choices[0].message.content).toBe("Hello from llmock!");
+    expect(parsed.choices[0].message.content).toBe("Hello from aimock!");
     expect(parsed.object).toBe("chat.completion");
   });
 });
@@ -205,7 +205,7 @@ describe("Together AI compatibility", () => {
     expect(status).toBe(200);
     const parsed = JSON.parse(body);
     expect(parsed.choices).toBeDefined();
-    expect(parsed.choices[0].message.content).toBe("Hello from llmock!");
+    expect(parsed.choices[0].message.content).toBe("Hello from aimock!");
   });
 });
 
@@ -223,6 +223,6 @@ describe("vLLM compatibility", () => {
     expect(status).toBe(200);
     const parsed = JSON.parse(body);
     expect(parsed.choices).toBeDefined();
-    expect(parsed.choices[0].message.content).toBe("Hello from llmock!");
+    expect(parsed.choices[0].message.content).toBe("Hello from aimock!");
   });
 });

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -75,14 +75,14 @@ afterEach(async () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Spin up an upstream llmock + a recording proxy pointed at it. */
+/** Spin up an upstream aimock + a recording proxy pointed at it. */
 async function setupProxyOnly(
   upstreamFixtures: Fixture[],
   proxyOnly: boolean,
 ): Promise<{ upstreamUrl: string; recorderUrl: string; fixturePath: string }> {
   upstream = await createServer(upstreamFixtures, { port: 0 });
 
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-proxy-only-"));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-proxy-only-"));
 
   recorder = await createServer([], {
     port: 0,
@@ -194,7 +194,7 @@ describe("proxy-only mode", () => {
     // Use a counting upstream to verify both requests are proxied
     const countingUpstream = await createCountingUpstream("counted response");
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-proxy-only-cache-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-proxy-only-cache-"));
 
     recorder = await createServer([], {
       port: 0,
@@ -229,7 +229,7 @@ describe("proxy-only mode", () => {
     // Use a counting upstream to verify only the first request is proxied
     const countingUpstream = await createCountingUpstream("cached response");
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-cache-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-cache-"));
 
     recorder = await createServer([], {
       port: 0,
@@ -290,7 +290,7 @@ describe("proxy-only mode", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-proxy-only-matched-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-proxy-only-matched-"));
 
     // Recorder has its own fixture that should match BEFORE proxying
     const localFixture: Fixture = {
@@ -326,7 +326,7 @@ describe("proxy-only mode", () => {
     // Set up recorder with proxy-only mode but no anthropic provider configured
     upstream = await createServer([], { port: 0 });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-proxy-only-noprovider-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-proxy-only-noprovider-"));
 
     recorder = await createServer([], {
       port: 0,
@@ -352,7 +352,7 @@ describe("proxy-only mode", () => {
   it("returns 404 in non-strict mode when provider is not configured", async () => {
     upstream = await createServer([], { port: 0 });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-proxy-only-404-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-proxy-only-404-"));
 
     recorder = await createServer([], {
       port: 0,

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -389,7 +389,7 @@ describe("recorder streaming collapse", () => {
       },
     ]);
 
-    // Send request with stream: true — upstream llmock will return SSE
+    // Send request with stream: true — upstream aimock will return SSE
     const resp = await post(`${recorderUrl}/v1/chat/completions`, {
       model: "gpt-4",
       messages: [{ role: "user", content: "What is the capital of France?" }],
@@ -488,7 +488,7 @@ describe("recorder multi-provider routing", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
 
     recorder = await createServer([], {
       port: 0,
@@ -506,7 +506,7 @@ describe("recorder multi-provider routing", () => {
 
     expect(resp.status).toBe(200);
     // Anthropic handler translates to/from Claude format; the upstream
-    // is another llmock so it returns OpenAI format which gets proxied raw
+    // is another aimock so it returns OpenAI format which gets proxied raw
     const body = JSON.parse(resp.body);
     // The proxied response should contain content
     expect(body).toBeDefined();
@@ -573,7 +573,7 @@ describe("recorder strict mode", () => {
     // Need to create a new recorder with both record + strict
     await new Promise<void>((resolve) => recorder!.server.close(() => resolve()));
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       strict: true,
@@ -628,7 +628,7 @@ describe("LLMock enableRecording / disableRecording", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
 
     mock = new LLMock();
     const url = await mock.start();
@@ -703,7 +703,7 @@ describe("recorder multi-provider recording", () => {
       ),
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { gemini: geminiUpstream.url }, fixturePath: tmpDir },
@@ -735,7 +735,7 @@ describe("recorder multi-provider recording", () => {
       ),
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { ollama: ollamaUpstream.url }, fixturePath: tmpDir },
@@ -767,7 +767,7 @@ describe("recorder multi-provider recording", () => {
       ),
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { cohere: cohereUpstream.url }, fixturePath: tmpDir },
@@ -799,7 +799,7 @@ describe("recorder multi-provider recording", () => {
       ),
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { bedrock: bedrockUpstream.url }, fixturePath: tmpDir },
@@ -832,7 +832,7 @@ describe("recorder multi-provider recording", () => {
       ),
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { vertexai: vertexUpstream.url }, fixturePath: tmpDir },
@@ -864,7 +864,7 @@ describe("recorder multi-provider recording", () => {
       ),
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { anthropic: anthropicUpstream.url }, fixturePath: tmpDir },
@@ -897,7 +897,7 @@ describe("recorder multi-provider recording", () => {
       ),
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: {
@@ -1124,7 +1124,7 @@ describe("recorder edge cases", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstream.url }, fixturePath: tmpDir },
@@ -1275,7 +1275,7 @@ describe("recorder edge cases", () => {
     );
 
     // Use a nested path that doesn't exist
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     const nestedPath = path.join(tmpDir, "nested", "deep", "fixtures");
 
     recorder = await createServer([], {
@@ -1343,7 +1343,7 @@ describe("recorder edge cases", () => {
     await new Promise<void>((resolve) => upstreamServer.listen(0, "127.0.0.1", resolve));
     const upAddr = upstreamServer.address() as { port: number };
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: `http://127.0.0.1:${upAddr.port}` }, fixturePath: tmpDir },
@@ -1375,7 +1375,7 @@ describe("recorder edge cases", () => {
     const emptyAddr = emptyServer.address() as { port: number };
     const emptyUrl = `http://127.0.0.1:${emptyAddr.port}`;
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: emptyUrl }, fixturePath: tmpDir },
@@ -1424,7 +1424,7 @@ describe("recorder edge cases", () => {
     const ollamaAddr = ollamaRaw.address() as { port: number };
     const ollamaUrl = `http://127.0.0.1:${ollamaAddr.port}`;
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { ollama: ollamaUrl }, fixturePath: tmpDir },
@@ -1478,7 +1478,7 @@ describe("recorder strict mode thorough", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       strict: true,
@@ -1530,7 +1530,7 @@ describe("LLMock enableRecording / disableRecording lifecycle", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     mock = new LLMock();
     const url = await mock.start();
 
@@ -1570,7 +1570,7 @@ describe("LLMock enableRecording / disableRecording lifecycle", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     mock = new LLMock();
     const url = await mock.start();
 
@@ -1615,7 +1615,7 @@ describe("recorder auth header handling", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { anthropic: anthropicUpstream.url }, fixturePath: tmpDir },
@@ -1691,7 +1691,7 @@ describe("recorder auth header handling", () => {
     const echoAddr = echoServer.address() as { port: number };
     const echoUrl = `http://127.0.0.1:${echoAddr.port}`;
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: echoUrl }, fixturePath: tmpDir },
@@ -1725,7 +1725,7 @@ describe("recorder auth header handling", () => {
 
 describe("recorder upstream connection failure", () => {
   it("returns 502 when upstream is unreachable", async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: {
@@ -1757,7 +1757,7 @@ describe("recorder filesystem write failure", () => {
     );
 
     // Use a path that cannot be a directory (a regular file)
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     const blockedPath = path.join(tmpDir, "blocked");
     fs.writeFileSync(blockedPath, "i am a file not a directory");
 
@@ -1819,7 +1819,7 @@ describe("recorder buildFixtureResponse non-OpenAI formats", () => {
       stop_reason: "end_turn",
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { anthropic: upstreamUrl }, fixturePath: tmpDir },
@@ -1853,7 +1853,7 @@ describe("recorder buildFixtureResponse non-OpenAI formats", () => {
       ],
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { gemini: upstreamUrl }, fixturePath: tmpDir },
@@ -1882,7 +1882,7 @@ describe("recorder buildFixtureResponse non-OpenAI formats", () => {
       done: true,
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { ollama: upstreamUrl }, fixturePath: tmpDir },
@@ -1943,7 +1943,7 @@ describe("recorder content + toolCalls coexistence", () => {
     const rawAddr = rawServer.address() as { port: number };
     const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: rawUrl }, fixturePath: tmpDir },
@@ -2001,7 +2001,7 @@ describe("recorder non-OpenAI streaming", () => {
     const rawAddr = rawServer.address() as { port: number };
     const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { anthropic: rawUrl }, fixturePath: tmpDir },
@@ -2046,7 +2046,7 @@ describe("recorder streaming collapse: Gemini SSE", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
 
     recorder = await createServer([], {
       port: 0,
@@ -2089,7 +2089,7 @@ describe("recorder streaming collapse: Cohere SSE", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
 
     recorder = await createServer([], {
       port: 0,
@@ -2131,7 +2131,7 @@ describe("recorder streaming collapse: Ollama NDJSON", () => {
       { port: 0 },
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
 
     recorder = await createServer([], {
       port: 0,
@@ -2206,7 +2206,7 @@ describe("buildFixtureResponse format detection", () => {
       stop_reason: "tool_use",
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { anthropic: upstreamUrl }, fixturePath: tmpDir },
@@ -2262,7 +2262,7 @@ describe("buildFixtureResponse format detection", () => {
       ],
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { gemini: upstreamUrl }, fixturePath: tmpDir },
@@ -2303,7 +2303,7 @@ describe("buildFixtureResponse format detection", () => {
       status: "ok",
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstreamUrl }, fixturePath: tmpDir },
@@ -2341,7 +2341,7 @@ describe("buildFixtureResponse format detection", () => {
       embedding: [0.1, 0.2, 0.3],
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstreamUrl }, fixturePath: tmpDir },
@@ -2378,7 +2378,7 @@ describe("buildFixtureResponse format detection", () => {
       usage: { prompt_tokens: 5, total_tokens: 5 },
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstreamUrl }, fixturePath: tmpDir },
@@ -2417,7 +2417,7 @@ describe("buildFixtureResponse format detection", () => {
       usage: { prompt_tokens: 5, total_tokens: 5 },
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstreamUrl }, fixturePath: tmpDir },
@@ -2455,7 +2455,7 @@ describe("buildFixtureResponse format detection", () => {
       usage: { prompt_tokens: 5, total_tokens: 5 },
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstreamUrl }, fixturePath: tmpDir },
@@ -2494,7 +2494,7 @@ describe("buildFixtureResponse format detection", () => {
       usage: { prompt_tokens: 5, total_tokens: 5 },
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstreamUrl }, fixturePath: tmpDir },
@@ -2535,7 +2535,7 @@ describe("buildFixtureResponse format detection", () => {
       429,
     );
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstreamUrl }, fixturePath: tmpDir },
@@ -2608,7 +2608,7 @@ describe("recorder Bedrock EventStream binary", () => {
     const rawAddr = rawServer.address() as { port: number };
     const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { bedrock: rawUrl }, fixturePath: tmpDir },
@@ -2668,7 +2668,7 @@ describe("recorder streaming edge cases", () => {
     const rawAddr = rawServer.address() as { port: number };
     const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: rawUrl }, fixturePath: tmpDir },
@@ -2731,7 +2731,7 @@ describe("recorder streaming edge cases", () => {
     const rawAddr = rawServer.address() as { port: number };
     const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: rawUrl }, fixturePath: tmpDir },
@@ -2802,7 +2802,7 @@ describe("buildFixtureResponse additional format variants", () => {
       stopReason: "end_turn",
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstreamUrl }, fixturePath: tmpDir },
@@ -2843,7 +2843,7 @@ describe("buildFixtureResponse additional format variants", () => {
       stopReason: "tool_use",
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { openai: upstreamUrl }, fixturePath: tmpDir },
@@ -2885,7 +2885,7 @@ describe("buildFixtureResponse additional format variants", () => {
       role: "assistant",
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { anthropic: upstreamUrl }, fixturePath: tmpDir },
@@ -2933,7 +2933,7 @@ describe("buildFixtureResponse additional format variants", () => {
       ],
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { gemini: upstreamUrl }, fixturePath: tmpDir },
@@ -2970,7 +2970,7 @@ describe("buildFixtureResponse additional format variants", () => {
       done: true,
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { ollama: upstreamUrl }, fixturePath: tmpDir },
@@ -3012,7 +3012,7 @@ describe("buildFixtureResponse additional format variants", () => {
       done: true,
     });
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { ollama: upstreamUrl }, fixturePath: tmpDir },
@@ -3048,7 +3048,7 @@ describe("buildFixtureResponse additional format variants", () => {
 
 describe("recorder invalid upstream URL", () => {
   it("returns 502 for invalid upstream URL format", async () => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       logLevel: "silent",
@@ -3091,9 +3091,9 @@ async function setupUpstreamAndRecorder(
   upstream = await createServer(upstreamFixtures, { port: 0 });
 
   // Create temp directory for recorded fixtures
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
 
-  // Create recording llmock (no fixtures — everything proxies)
+  // Create recording aimock (no fixtures — everything proxies)
   const providers: Record<string, string> = {};
   providers[providerKey] = upstream.url;
 
@@ -3138,7 +3138,7 @@ describe("makeUpstreamRequest body timeout", () => {
 
     const setTimeoutSpy = vi.spyOn(http.IncomingMessage.prototype, "setTimeout");
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-timeout-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-timeout-"));
     const record: RecordConfig = {
       providers: { openai: `http://127.0.0.1:${port}` },
       fixturePath: tmpDir,
@@ -3226,7 +3226,7 @@ describe("recorder binary EventStream relay integrity", () => {
     const rawAddr = rawServer!.address() as { port: number };
     const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
 
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "llmock-record-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
     recorder = await createServer([], {
       port: 0,
       record: { providers: { bedrock: rawUrl }, fixturePath: tmpDir },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { AGUIMock } from "./agui-mock.js";
 import type { ChaosConfig, RecordConfig } from "./types.js";
 
 const HELP = `
-Usage: llmock [options]
+Usage: aimock [options]
 
 Options:
   -p, --port <number>       Port to listen on (default: 4010)

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -317,7 +317,7 @@ function makeUpstreamRequest(
 
 /**
  * Detect the response format from the parsed upstream JSON and convert
- * it into an llmock FixtureResponse.
+ * it into an aimock FixtureResponse.
  */
 function buildFixtureResponse(
   parsed: unknown,


### PR DESCRIPTION
## Summary

Rename remaining llmock references to aimock across the codebase:

- CLI help text (`Usage: aimock`)
- Test descriptions and temp directory prefixes
- Comments and JSDoc in runtime code (recorder.ts)
- DRIFT.md documentation
- Drift test file comments (all 13 providers)
- Competitive matrix script User-Agent header
- aimock-pytest README URLs
- SKILL.md CLI examples

**Intentionally preserved:** `LLMock` class name, `llmock` bin alias, `src/llmock.ts` filename, plugin registry name (to avoid breaking existing installations).

**Dropped from this PR:** plugin.json/marketplace.json name changes (would orphan existing plugin installations), spec file edits (file deleted by PR #103).

## Test plan
- [x] All 2305 tests pass
- [x] Build passes
- [x] Rebased on #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)