### PR TITLE
fix: set npm homepage to aimock.copilotkit.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "embeddings",
     "copilotkit"
   ],
+  "homepage": "https://aimock.copilotkit.dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/CopilotKit/aimock"


### PR DESCRIPTION
## Summary

npm shows `github.com/CopilotKit/aimock#readme` as the homepage because there's no `homepage` field in package.json. Adds `"homepage": "https://aimock.copilotkit.dev"` so npm links to the docs site.

Takes effect on next npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)