### PR TITLE
docs: add framework integration guides for 6 AI agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,13 @@ npx aimock convert mockllm ./config.yaml ./fixtures/
 docker run -d -p 4010:4010 -v ./fixtures:/fixtures ghcr.io/copilotkit/aimock -f /fixtures
 ```
 
+## Framework Guides
+
+Test your AI agents with aimock — no API keys, no network calls: [LangChain](https://aimock.copilotkit.dev/integrate-langchain) · [CrewAI](https://aimock.copilotkit.dev/integrate-crewai) · [PydanticAI](https://aimock.copilotkit.dev/integrate-pydanticai) · [LlamaIndex](https://aimock.copilotkit.dev/integrate-llamaindex) · [Mastra](https://aimock.copilotkit.dev/integrate-mastra) · [Google ADK](https://aimock.copilotkit.dev/integrate-adk)
+
 ## Switching from other tools?
 
-Step-by-step migration guides: [MSW](https://aimock.copilotkit.dev/migrate-from-msw) · [VidaiMock](https://aimock.copilotkit.dev/migrate-from-vidaimock) · [mock-llm](https://aimock.copilotkit.dev/migrate-from-mock-llm) · [Python mocks](https://aimock.copilotkit.dev/migrate-from-python-mocks) · [Mokksy](https://aimock.copilotkit.dev/migrate-from-mokksy)
+Step-by-step migration guides: [MSW](https://aimock.copilotkit.dev/migrate-from-msw) · [VidaiMock](https://aimock.copilotkit.dev/migrate-from-vidaimock) · [mock-llm](https://aimock.copilotkit.dev/migrate-from-mock-llm) · [piyook/llm-mock](https://aimock.copilotkit.dev/migrate-from-piyook) · [Python mocks](https://aimock.copilotkit.dev/migrate-from-python-mocks) · [Mokksy](https://aimock.copilotkit.dev/migrate-from-mokksy)
 
 ## Documentation
 

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -17,114 +17,6 @@
     />
     <link rel="stylesheet" href="../style.css" />
     <style>
-      /* ─── Suite Cards Grid (new component) ─────────────────────── */
-      .suite-grid {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        gap: 1.25rem;
-        margin-top: 2rem;
-        margin-bottom: 2rem;
-      }
-      .suite-card {
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-        padding: 1.5rem;
-        background: var(--bg-card);
-        border: 1px solid var(--border);
-        border-radius: 12px;
-        transition:
-          border-color 0.3s,
-          transform 0.3s,
-          box-shadow 0.3s;
-      }
-      .suite-card:hover {
-        border-color: var(--border-bright);
-        transform: translateY(-2px);
-        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
-      }
-      .suite-card.border-green {
-        border-top: 2px solid var(--accent);
-      }
-      .suite-card.border-blue {
-        border-top: 2px solid var(--blue);
-      }
-      .suite-card.border-purple {
-        border-top: 2px solid var(--purple);
-      }
-      .suite-card.border-amber {
-        border-top: 2px solid var(--warning);
-      }
-      .suite-card.border-red {
-        border-top: 2px solid var(--error);
-      }
-      .suite-card.border-gray {
-        border-top: 2px solid var(--text-dim);
-      }
-      .suite-card-header {
-        display: flex;
-        align-items: center;
-        gap: 0.6rem;
-      }
-      .suite-card-icon {
-        font-size: 1.5rem;
-        line-height: 1;
-      }
-      .suite-card-title {
-        font-size: 1.05rem;
-        font-weight: 600;
-        color: var(--text-primary);
-      }
-      .suite-card-desc {
-        font-size: 0.85rem;
-        color: var(--text-secondary);
-        line-height: 1.5;
-        margin: 0;
-      }
-      .suite-card-links {
-        list-style: none;
-        padding: 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-        margin: 0;
-      }
-      .suite-card-links li {
-        font-size: 0.8rem;
-        padding-left: 0.85rem;
-        position: relative;
-        margin: 0;
-      }
-      .suite-card-links li::before {
-        content: "\203A";
-        position: absolute;
-        left: 0;
-        color: var(--text-dim);
-      }
-      .suite-card-links a {
-        color: var(--text-secondary);
-        font-size: 0.8rem;
-        transition: color 0.15s;
-      }
-      .suite-card-links a:hover {
-        color: var(--accent);
-      }
-      .suite-card-cta {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        font-family: var(--font-mono);
-        font-size: 0.8rem;
-        font-weight: 500;
-        color: var(--accent);
-        margin-top: auto;
-        padding-top: 0.25rem;
-        transition: gap 0.2s var(--ease-out-expo);
-      }
-      .suite-card:hover .suite-card-cta {
-        gap: 0.6rem;
-      }
-
       /* ─── Quick Start Paths ────────────────────────────────────── */
       .quick-start-paths {
         display: grid;
@@ -146,12 +38,138 @@
         color: var(--text-primary);
       }
 
+      /* ─── Highlight Cards (What's New) ─────────────────────────── */
+      .highlight-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 1rem;
+        margin-top: 1.5rem;
+        margin-bottom: 2rem;
+      }
+      .highlight-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 1rem 1.15rem;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        transition:
+          border-color 0.3s,
+          transform 0.3s,
+          box-shadow 0.3s;
+      }
+      .highlight-card:hover {
+        border-color: var(--border-bright);
+        transform: translateY(-2px);
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+      }
+      .highlight-card-title {
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--text-primary);
+      }
+      .highlight-card-desc {
+        font-size: 0.8rem;
+        color: var(--text-secondary);
+        line-height: 1.45;
+        margin: 0;
+        flex: 1;
+      }
+      .highlight-card-cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        font-family: var(--font-mono);
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: var(--accent);
+        margin-top: auto;
+        transition: gap 0.2s;
+      }
+      .highlight-card:hover .highlight-card-cta {
+        gap: 0.55rem;
+      }
+
+      /* ─── Suite Table ──────────────────────────────────────────── */
+      .suite-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+        margin-bottom: 2rem;
+        font-size: 0.88rem;
+      }
+      .suite-table th {
+        text-align: left;
+        font-weight: 600;
+        color: var(--text-primary);
+        padding: 0.6rem 0.75rem;
+        border-bottom: 2px solid var(--border);
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+      .suite-table td {
+        padding: 0.6rem 0.75rem;
+        border-bottom: 1px solid var(--border);
+        color: var(--text-secondary);
+        vertical-align: top;
+      }
+      .suite-table tr:last-child td {
+        border-bottom: none;
+      }
+      .suite-table td:first-child {
+        font-weight: 600;
+        color: var(--text-primary);
+        white-space: nowrap;
+      }
+      .suite-table td:last-child {
+        white-space: nowrap;
+      }
+      .suite-table a {
+        color: var(--accent);
+        font-family: var(--font-mono);
+        font-size: 0.8rem;
+        font-weight: 500;
+      }
+      .suite-table a:hover {
+        text-decoration: underline;
+      }
+
+      /* ─── Compact link lists ───────────────────────────────────── */
+      .link-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1.25rem;
+        margin-top: 0.75rem;
+        margin-bottom: 2rem;
+      }
+      .link-row a {
+        font-size: 0.88rem;
+        color: var(--text-secondary);
+        transition: color 0.15s;
+      }
+      .link-row a:hover {
+        color: var(--accent);
+      }
+      .link-row .sep {
+        color: var(--text-dim);
+        user-select: none;
+      }
+
       /* ─── Responsive overrides ─────────────────────────────────── */
+      @media (max-width: 900px) {
+        .highlight-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
       @media (max-width: 768px) {
-        .suite-grid {
+        .quick-start-paths {
           grid-template-columns: 1fr;
         }
-        .quick-start-paths {
+      }
+      @media (max-width: 560px) {
+        .highlight-grid {
           grid-template-columns: 1fr;
         }
       }
@@ -196,130 +214,15 @@
       <main class="docs-content">
         <h1>aimock Documentation</h1>
         <p class="lead">
-          aimock is the complete mock infrastructure for AI application testing. Start with LLM API
-          mocking, add MCP tools, A2A agents, vector databases, and services as your stack grows.
-          One package. Zero dependencies.
+          Complete mock infrastructure for AI application testing. One package, zero dependencies.
         </p>
 
-        <h2>The Suite</h2>
-
-        <div class="suite-grid">
-          <!-- LLM Mocking -->
-          <div class="suite-card border-green">
-            <div class="suite-card-header">
-              <span class="suite-card-icon">&#128225;</span>
-              <span class="suite-card-title">LLM Mocking</span>
-            </div>
-            <p class="suite-card-desc">Mock 10+ LLM providers with fixture-driven responses</p>
-            <ul class="suite-card-links">
-              <li><a href="/chat-completions">Chat Completions</a></li>
-              <li><a href="/claude-messages">Claude Messages</a></li>
-              <li><a href="/gemini">Gemini</a></li>
-              <li><a href="/aws-bedrock">Bedrock</a></li>
-              <li><a href="/record-replay">Record &amp; Replay</a></li>
-            </ul>
-            <a href="/chat-completions" class="suite-card-cta">Get started <span>&rarr;</span></a>
-          </div>
-
-          <!-- MCP Protocol -->
-          <div class="suite-card border-blue">
-            <div class="suite-card-header">
-              <span class="suite-card-icon">&#128268;</span>
-              <span class="suite-card-title">MCP Protocol</span>
-            </div>
-            <p class="suite-card-desc">Mock MCP servers with tools, resources, and prompts</p>
-            <ul class="suite-card-links">
-              <li><a href="/mcp-mock">Tool handlers</a></li>
-              <li><a href="/mcp-mock">Resources</a></li>
-              <li><a href="/mcp-mock">Prompts</a></li>
-              <li><a href="/mcp-mock">Session management</a></li>
-            </ul>
-            <a href="/mcp-mock" class="suite-card-cta">Get started <span>&rarr;</span></a>
-          </div>
-
-          <!-- A2A Protocol -->
-          <div class="suite-card border-purple">
-            <div class="suite-card-header">
-              <span class="suite-card-icon">&#129309;</span>
-              <span class="suite-card-title">A2A Protocol</span>
-            </div>
-            <p class="suite-card-desc">Mock agent-to-agent interactions with streaming</p>
-            <ul class="suite-card-links">
-              <li><a href="/a2a-mock">Agent cards</a></li>
-              <li><a href="/a2a-mock">Message routing</a></li>
-              <li><a href="/a2a-mock">Task streaming</a></li>
-            </ul>
-            <a href="/a2a-mock" class="suite-card-cta">Get started <span>&rarr;</span></a>
-          </div>
-
-          <!-- AG-UI Protocol -->
-          <div class="suite-card border-purple">
-            <div class="suite-card-header">
-              <span class="suite-card-icon">&#129502;</span>
-              <span class="suite-card-title">AG-UI Protocol</span>
-            </div>
-            <p class="suite-card-desc">Mock agent-to-UI event streams for frontend testing</p>
-            <ul class="suite-card-links">
-              <li><a href="/agui-mock">Event types</a></li>
-              <li><a href="/agui-mock">Builders</a></li>
-              <li><a href="/agui-mock">Record &amp; replay</a></li>
-            </ul>
-            <a href="/agui-mock" class="suite-card-cta">Get started <span>&rarr;</span></a>
-          </div>
-
-          <!-- Vector Databases -->
-          <div class="suite-card border-amber">
-            <div class="suite-card-header">
-              <span class="suite-card-icon">&#128230;</span>
-              <span class="suite-card-title">Vector Databases</span>
-            </div>
-            <p class="suite-card-desc">Mock Pinecone, Qdrant, and ChromaDB endpoints</p>
-            <ul class="suite-card-links">
-              <li><a href="/vector-mock">Upsert &amp; query</a></li>
-              <li><a href="/vector-mock">Collections</a></li>
-              <li><a href="/vector-mock">Custom handlers</a></li>
-            </ul>
-            <a href="/vector-mock" class="suite-card-cta">Get started <span>&rarr;</span></a>
-          </div>
-
-          <!-- Services -->
-          <div class="suite-card border-red">
-            <div class="suite-card-header">
-              <span class="suite-card-icon">&#128269;</span>
-              <span class="suite-card-title">Services</span>
-            </div>
-            <p class="suite-card-desc">Search, rerank, and moderation API mocks</p>
-            <ul class="suite-card-links">
-              <li><a href="/services">Tavily search</a></li>
-              <li><a href="/services">Cohere rerank</a></li>
-              <li><a href="/services">OpenAI moderation</a></li>
-            </ul>
-            <a href="/services" class="suite-card-cta">Get started <span>&rarr;</span></a>
-          </div>
-
-          <!-- Testing & Operations -->
-          <div class="suite-card border-gray">
-            <div class="suite-card-header">
-              <span class="suite-card-icon">&#9881;</span>
-              <span class="suite-card-title">Testing &amp; Operations</span>
-            </div>
-            <p class="suite-card-desc">Chaos testing, metrics, drift detection, Docker</p>
-            <ul class="suite-card-links">
-              <li><a href="/test-plugins">Vitest &amp; Jest plugins</a></li>
-              <li><a href="/chaos-testing">Chaos testing</a></li>
-              <li><a href="/drift-detection">Drift detection</a></li>
-              <li><a href="/docker">Docker &amp; Helm</a></li>
-            </ul>
-            <a href="/chaos-testing" class="suite-card-cta">Get started <span>&rarr;</span></a>
-          </div>
-        </div>
-
+        <!-- ─── Quick Start ─────────────────────────────────────────── -->
         <h2>Quick Start</h2>
 
         <div class="quick-start-paths">
-          <!-- Path 1: LLM only -->
           <div class="quick-start-path">
-            <h3>I want to mock LLM APIs</h3>
+            <h3>Mock LLM APIs</h3>
             <div class="code-block">
               <div class="code-block-header">
                 Programmatic usage
@@ -332,12 +235,11 @@
 
 <span class="op">mock</span>.<span class="fn">onMessage</span>(<span class="str">"hello"</span>, { <span class="prop">content</span>: <span class="str">"Hi there!"</span> });</code></pre>
             </div>
-            <p><a href="/docs">Quick Start: LLM &rarr;</a></p>
+            <p><a href="/chat-completions">Quick Start: LLM &rarr;</a></p>
           </div>
 
-          <!-- Path 2: Full suite -->
           <div class="quick-start-path">
-            <h3>I want to mock my entire AI stack</h3>
+            <h3>Mock your entire stack</h3>
             <div class="code-block">
               <div class="code-block-header">
                 aimock.json config
@@ -350,10 +252,120 @@
   <span class="key">"vector"</span>: { <span class="key">"provider"</span>: <span class="str">"pinecone"</span> }
 }</code></pre>
             </div>
-            <p><a href="/aimock-cli">Quick Start: aimock suite &rarr;</a></p>
+            <p><a href="/aimock-cli">Quick Start: full suite &rarr;</a></p>
           </div>
         </div>
+
+        <!-- ─── What's New ──────────────────────────────────────────── -->
+        <h2>What's New</h2>
+
+        <div class="highlight-grid">
+          <div class="highlight-card">
+            <span class="highlight-card-title">Framework Guides</span>
+            <p class="highlight-card-desc">
+              Test your LangChain, CrewAI, PydanticAI, LlamaIndex, Mastra, or ADK agents
+            </p>
+            <a href="/integrate-langchain" class="highlight-card-cta">Guides <span>&rarr;</span></a>
+          </div>
+
+          <div class="highlight-card">
+            <span class="highlight-card-title">Multimedia APIs</span>
+            <p class="highlight-card-desc">
+              Image generation, text-to-speech, transcription, and video mocking
+            </p>
+            <a href="/images" class="highlight-card-cta">Docs <span>&rarr;</span></a>
+          </div>
+
+          <div class="highlight-card">
+            <span class="highlight-card-title">AG-UI Protocol</span>
+            <p class="highlight-card-desc">
+              Mock agent-to-UI event streams for CopilotKit frontends
+            </p>
+            <a href="/agui-mock" class="highlight-card-cta">Docs <span>&rarr;</span></a>
+          </div>
+
+          <div class="highlight-card">
+            <span class="highlight-card-title">GitHub Action</span>
+            <p class="highlight-card-desc">One-line CI setup for mock-backed test suites</p>
+            <a href="/github-action" class="highlight-card-cta">Setup <span>&rarr;</span></a>
+          </div>
+        </div>
+
+        <!-- ─── The Suite (compact table) ───────────────────────────── -->
+        <h2>The Suite</h2>
+
+        <table class="suite-table">
+          <thead>
+            <tr>
+              <th>Mock</th>
+              <th>What it does</th>
+              <th>Docs</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>LLM Providers</td>
+              <td>OpenAI, Claude, Gemini, Bedrock, Azure, Vertex AI, Ollama, Cohere</td>
+              <td><a href="/chat-completions">Docs &rarr;</a></td>
+            </tr>
+            <tr>
+              <td>Multimedia</td>
+              <td>Image generation, TTS, transcription, video</td>
+              <td><a href="/images">Docs &rarr;</a></td>
+            </tr>
+            <tr>
+              <td>MCP Protocol</td>
+              <td>Tools, resources, prompts, session management</td>
+              <td><a href="/mcp-mock">Docs &rarr;</a></td>
+            </tr>
+            <tr>
+              <td>A2A Protocol</td>
+              <td>Agent cards, message routing, SSE streaming</td>
+              <td><a href="/a2a-mock">Docs &rarr;</a></td>
+            </tr>
+            <tr>
+              <td>AG-UI Protocol</td>
+              <td>Event streams for CopilotKit frontends</td>
+              <td><a href="/agui-mock">Docs &rarr;</a></td>
+            </tr>
+            <tr>
+              <td>Vector DBs</td>
+              <td>Pinecone, Qdrant, ChromaDB</td>
+              <td><a href="/vector-mock">Docs &rarr;</a></td>
+            </tr>
+            <tr>
+              <td>Services</td>
+              <td>Search, rerank, moderation</td>
+              <td><a href="/services">Docs &rarr;</a></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <!-- ─── Framework Guides ────────────────────────────────────── -->
+        <h2>Framework Guides</h2>
+
+        <div class="link-row">
+          <a href="/integrate-langchain">LangChain</a> <span class="sep">&middot;</span>
+          <a href="/integrate-crewai">CrewAI</a> <span class="sep">&middot;</span>
+          <a href="/integrate-pydanticai">PydanticAI</a> <span class="sep">&middot;</span>
+          <a href="/integrate-llamaindex">LlamaIndex</a> <span class="sep">&middot;</span>
+          <a href="/integrate-mastra">Mastra</a> <span class="sep">&middot;</span>
+          <a href="/integrate-adk">Google ADK</a>
+        </div>
+
+        <!-- ─── Migration Guides ────────────────────────────────────── -->
+        <h2>Switching from other tools?</h2>
+
+        <div class="link-row">
+          <a href="/migrate-from-msw">MSW</a> <span class="sep">&middot;</span>
+          <a href="/migrate-from-vidaimock">VidaiMock</a> <span class="sep">&middot;</span>
+          <a href="/migrate-from-mock-llm">mock-llm</a> <span class="sep">&middot;</span>
+          <a href="/migrate-from-piyook">piyook/llm-mock</a> <span class="sep">&middot;</span>
+          <a href="/migrate-from-python-mocks">Python mocks</a> <span class="sep">&middot;</span>
+          <a href="/migrate-from-mokksy">Mokksy</a>
+        </div>
       </main>
+      <aside class="page-toc" id="page-toc"></aside>
     </div>
 
     <!-- ═══ Footer ═══════════════════════════════════════════════════ -->

--- a/docs/integrate-adk/index.html
+++ b/docs/integrate-adk/index.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Google ADK — aimock</title>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <nav class="top-nav">
+      <div class="nav-inner">
+        <div style="display: flex; align-items: center; gap: 1rem">
+          <button
+            class="sidebar-toggle"
+            onclick="document.querySelector('.sidebar').classList.toggle('open')"
+            aria-label="Toggle sidebar"
+          >
+            &#9776;
+          </button>
+          <a href="/" class="nav-brand"> <span class="prompt">$</span> aimock </a>
+        </div>
+        <ul class="nav-links">
+          <li><a href="/">Home</a></li>
+          <li><a href="/docs" style="color: var(--accent)">Docs</a></li>
+          <li>
+            <a href="https://github.com/CopilotKit/aimock" class="gh-link" target="_blank"
+              ><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+              GitHub</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="docs-layout">
+      <aside class="sidebar" id="sidebar"></aside>
+
+      <main class="docs-content">
+        <h1>Google ADK</h1>
+        <p class="lead">
+          Test your Google ADK agents without Gemini API keys. aimock speaks the Gemini API format
+          natively &mdash; <code>generateContent</code>, <code>streamGenerateContent</code>, and
+          function calling.
+        </p>
+
+        <h2>Quick Start</h2>
+        <p>
+          Point the Google Gen AI SDK at your aimock instance. ADK uses the Gen AI SDK under the
+          hood, so this is all you need:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            Configure the Gen AI client <span class="lang-tag">python</span>
+          </div>
+          <pre><code><span class="kw">from</span> google <span class="kw">import</span> genai
+
+client = genai.<span class="fn">Client</span>(
+    vertexai=<span class="kw">False</span>,
+    api_key=<span class="str">"test"</span>,
+    http_options={<span class="str">"api_version"</span>: <span class="str">"v1beta"</span>, <span class="str">"base_url"</span>: <span class="str">"http://localhost:4010"</span>},
+)</code></pre>
+        </div>
+        <p>
+          Start aimock with a Gemini-format fixture, then run your ADK agent. Requests to
+          <code>generateContent</code> and <code>streamGenerateContent</code> are handled
+          automatically.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Start aimock <span class="lang-tag">shell</span></div>
+          <pre><code>npx aimock --fixtures fixtures/examples/adk/gemini-agent.json</code></pre>
+        </div>
+
+        <h2>Gemini API Format</h2>
+        <p>
+          aimock handles the Gemini native request and response format. ADK agents hit these
+          endpoints:
+        </p>
+        <table class="endpoint-table">
+          <thead>
+            <tr>
+              <th>Method</th>
+              <th>Path</th>
+              <th>Format</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>POST</td>
+              <td><code>/v1beta/models/{model}:generateContent</code></td>
+              <td>JSON</td>
+            </tr>
+            <tr>
+              <td>POST</td>
+              <td><code>/v1beta/models/{model}:streamGenerateContent</code></td>
+              <td>JSON stream / SSE (with <code>?alt=sse</code>)</td>
+            </tr>
+            <tr>
+              <td>WS</td>
+              <td><code>/ws/google.ai.generativelanguage.*</code></td>
+              <td>Gemini Live WebSocket</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          Gemini uses <code>contents</code> with <code>parts</code> rather than OpenAI's
+          <code>messages</code> array. aimock translates Gemini requests to the unified fixture
+          format internally, so the same <code>match.userMessage</code> works regardless of which
+          provider endpoint the request arrives on.
+        </p>
+
+        <h2>Function Calling</h2>
+        <p>
+          ADK agents rely heavily on Gemini function calling. The Gemini format uses
+          <code>functionCall</code> and <code>functionResponse</code> parts instead of the
+          OpenAI-style <code>tool_calls</code> array. aimock generates the correct Gemini response
+          shape from the same fixture format:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            Function calling fixture <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"weather"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"toolCalls"</span>: [
+          {
+            <span class="prop">"name"</span>: <span class="str">"get_weather"</span>,
+            <span class="prop">"arguments"</span>: <span class="str">"{\"city\":\"San Francisco\",\"unit\":\"fahrenheit\"}"</span>
+          }
+        ]
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+        <p>
+          When a Gemini endpoint receives this fixture, aimock returns it as a
+          <code>functionCall</code> part:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            Gemini response shape <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"candidates"</span>: [{
+    <span class="prop">"content"</span>: {
+      <span class="prop">"role"</span>: <span class="str">"model"</span>,
+      <span class="prop">"parts"</span>: [{
+        <span class="prop">"functionCall"</span>: {
+          <span class="prop">"id"</span>: <span class="str">"call_abc123"</span>,
+          <span class="prop">"name"</span>: <span class="str">"get_weather"</span>,
+          <span class="prop">"args"</span>: { <span class="prop">"city"</span>: <span class="str">"San Francisco"</span>, <span class="prop">"unit"</span>: <span class="str">"fahrenheit"</span> }
+        }
+      }]
+    }
+  }]
+}</code></pre>
+        </div>
+
+        <h2>With aimock-pytest</h2>
+        <p>
+          The <code>aimock-pytest</code> plugin provides a <code>aimock</code> fixture that starts
+          and stops the server automatically:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">conftest.py <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">import</span> pytest
+
+<span class="cm"># The aimock fixture is provided by aimock-pytest</span>
+<span class="cm"># pip install aimock-pytest</span></code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">
+            test_adk_agent.py <span class="lang-tag">python</span>
+          </div>
+          <pre><code><span class="kw">from</span> google <span class="kw">import</span> genai
+
+<span class="kw">def</span> <span class="fn">test_agent_weather_tool</span>(aimock):
+    <span class="cm">"""Test that ADK agent calls get_weather tool."""</span>
+    aimock.<span class="fn">load_fixtures</span>(<span class="str">"fixtures/examples/adk/gemini-agent.json"</span>)
+
+    client = genai.<span class="fn">Client</span>(
+        vertexai=<span class="kw">False</span>,
+        api_key=<span class="str">"test"</span>,
+        http_options={<span class="str">"api_version"</span>: <span class="str">"v1beta"</span>, <span class="str">"base_url"</span>: aimock.url},
+    )
+
+    response = client.models.<span class="fn">generate_content</span>(
+        model=<span class="str">"gemini-2.0-flash"</span>,
+        contents=<span class="str">"what is the weather in San Francisco?"</span>,
+    )
+
+    <span class="cm"># Verify the tool call was returned</span>
+    part = response.candidates[<span class="num">0</span>].content.parts[<span class="num">0</span>]
+    <span class="kw">assert</span> part.function_call.name == <span class="str">"get_weather"</span></code></pre>
+        </div>
+
+        <h2>CI with GitHub Action</h2>
+        <p>
+          Use the <a href="/github-action">aimock GitHub Action</a> to run aimock as a service in
+          CI:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            .github/workflows/test.yml <span class="lang-tag">yaml</span>
+          </div>
+          <pre><code><span class="prop">steps</span>:
+  - <span class="prop">uses</span>: actions/checkout@v4
+  - <span class="prop">name</span>: <span class="str">Start aimock</span>
+    <span class="prop">uses</span>: CopilotKit/aimock@v1
+    <span class="prop">with</span>:
+      <span class="prop">fixtures</span>: fixtures/examples/adk/gemini-agent.json
+
+  - <span class="prop">name</span>: <span class="str">Run ADK tests</span>
+    <span class="prop">run</span>: pytest tests/</code></pre>
+        </div>
+        <p>
+          No real Gemini API keys needed in CI &mdash; aimock does not validate them. Note that ADK
+          / the Google Gen AI SDK does not support a <code>base_url</code> environment variable
+          override, so you must configure the base URL programmatically in your test code using
+          <code>http_options</code> (see the pytest example above).
+        </p>
+
+        <h2>Arbitrary Path Prefixes</h2>
+        <p>
+          If your ADK configuration or a proxy layer adds a non-standard base URL prefix (e.g.
+          <code>/my-app/v1beta/models/...</code>), aimock normalizes it automatically. The
+          <code>normalizeCompatPath</code> feature strips arbitrary prefixes and rewrites paths
+          ending in known suffixes to their canonical form.
+        </p>
+        <p>
+          This means your ADK agent can use any base URL structure and aimock will still route the
+          request correctly to the Gemini handler.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            Non-standard prefix example <span class="lang-tag">python</span>
+          </div>
+          <pre><code><span class="cm"># Even with a custom prefix, aimock routes correctly</span>
+client = genai.<span class="fn">Client</span>(
+    vertexai=<span class="kw">False</span>,
+    api_key=<span class="str">"test"</span>,
+    http_options={
+        <span class="str">"api_version"</span>: <span class="str">"v1beta"</span>,
+        <span class="str">"base_url"</span>: <span class="str">"http://localhost:4010/my-proxy"</span>,
+    },
+)</code></pre>
+        </div>
+      </main>
+      <aside class="page-toc" id="page-toc"></aside>
+    </div>
+    <footer class="docs-footer">
+      <div class="footer-inner">
+        <div class="footer-left"><span>$</span> aimock &middot; MIT License</div>
+        <ul class="footer-links">
+          <li><a href="https://github.com/CopilotKit/aimock" target="_blank">GitHub</a></li>
+          <li>
+            <a href="https://www.npmjs.com/package/@copilotkit/aimock" target="_blank">npm</a>
+          </li>
+        </ul>
+      </div>
+    </footer>
+    <script src="../sidebar.js"></script>
+    <script src="../cli-tabs.js"></script>
+  </body>
+</html>

--- a/docs/integrate-crewai/index.html
+++ b/docs/integrate-crewai/index.html
@@ -1,0 +1,370 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CrewAI — aimock</title>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <nav class="top-nav">
+      <div class="nav-inner">
+        <div style="display: flex; align-items: center; gap: 1rem">
+          <button
+            class="sidebar-toggle"
+            onclick="document.querySelector('.sidebar').classList.toggle('open')"
+            aria-label="Toggle sidebar"
+          >
+            &#9776;
+          </button>
+          <a href="/" class="nav-brand"> <span class="prompt">$</span> aimock </a>
+        </div>
+        <ul class="nav-links">
+          <li><a href="/">Home</a></li>
+          <li><a href="/docs" style="color: var(--accent)">Docs</a></li>
+          <li>
+            <a href="https://github.com/CopilotKit/aimock" class="gh-link" target="_blank"
+              ><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+              GitHub</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="docs-layout">
+      <aside class="sidebar" id="sidebar"></aside>
+
+      <main class="docs-content">
+        <h1>CrewAI</h1>
+        <p class="lead">
+          Test your CrewAI crews without API keys. Each agent in a crew makes its own LLM calls
+          &mdash; aimock handles them all with fixture-based responses.
+        </p>
+
+        <h2>Quick Start</h2>
+        <p>
+          CrewAI agents make OpenAI-compatible LLM calls by default. Point them at aimock and every
+          agent in your crew will send requests to the mock server instead of the real API. The
+          recommended approach is to use CrewAI's <code>LLM</code> class with an explicit
+          <code>base_url</code>, shown in the examples below.
+        </p>
+        <div class="cli-tabs" data-sync="install">
+          <div class="cli-tab-bar">
+            <button class="cli-tab active" data-tab="cli">CLI</button>
+            <button class="cli-tab" data-tab="python">Python</button>
+          </div>
+          <div class="cli-tab-content active" data-tab="cli">
+            <div class="code-block">
+              <div class="code-block-header">
+                Start aimock, then run the crew
+                <span class="lang-tag">shell</span>
+              </div>
+              <pre><code><span class="cm"># Terminal 1 &mdash; start the mock server</span>
+npx aimock --fixtures ./fixtures
+
+<span class="cm"># Terminal 2 &mdash; run your CrewAI script</span>
+<span class="kw">export</span> OPENAI_BASE_URL=http://localhost:4010/v1
+<span class="kw">export</span> OPENAI_API_KEY=test
+python crew.py</code></pre>
+            </div>
+          </div>
+          <div class="cli-tab-content" data-tab="python">
+            <div class="code-block">
+              <div class="code-block-header">crew.py <span class="lang-tag">python</span></div>
+              <pre><code><span class="kw">from</span> crewai <span class="kw">import</span> Agent, Task, Crew, LLM
+
+<span class="cm"># Recommended: use the LLM class with an explicit base_url</span>
+llm = LLM(
+    model=<span class="str">"openai/gpt-4o"</span>,
+    base_url=<span class="str">"http://localhost:4010/v1"</span>,
+    api_key=<span class="str">"test"</span>,
+)
+
+researcher = Agent(
+    role=<span class="str">"Researcher"</span>,
+    goal=<span class="str">"Research topics"</span>,
+    backstory=<span class="str">"Expert researcher"</span>,
+    llm=llm,
+)
+
+task = Task(
+    description=<span class="str">"Research the history of testing"</span>,
+    expected_output=<span class="str">"A short summary"</span>,
+    agent=researcher,
+)
+
+crew = Crew(agents=[researcher], tasks=[task])
+result = crew.kickoff()
+print(result)</code></pre>
+            </div>
+          </div>
+        </div>
+
+        <div class="callout">
+          <strong>Environment variables vs <code>LLM(base_url=...)</code></strong> &mdash; Setting
+          <code>OPENAI_BASE_URL</code> works when agents use the default OpenAI provider, but the
+          <code>LLM(base_url=...)</code> approach is more reliable across all configurations and is
+          the recommended way to point CrewAI at aimock.
+        </div>
+
+        <h2>With aimock-pytest</h2>
+        <p>
+          The <code>aimock-pytest</code> plugin starts and stops the server automatically per test,
+          so you never need to manage a background process.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Install <span class="lang-tag">shell</span></div>
+          <pre><code>pip install aimock-pytest</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">conftest.py <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">import</span> os, pytest
+
+@pytest.fixture(autouse=<span class="kw">True</span>)
+<span class="kw">def</span> <span class="fn">mock_llm</span>(aimock):
+    <span class="str">"""aimock-pytest provides the `aimock` fixture automatically.
+    It starts a fresh server for each test that requests it (function-scoped).
+    You must set OPENAI_BASE_URL yourself so CrewAI agents route to aimock."""</span>
+    os.environ[<span class="str">"OPENAI_BASE_URL"</span>] = aimock.url + <span class="str">"/v1"</span>
+    os.environ[<span class="str">"OPENAI_API_KEY"</span>] = <span class="str">"test"</span>
+    aimock.load_fixtures(<span class="str">"./fixtures/crewai-crew.json"</span>)
+    <span class="kw">yield</span> aimock</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">test_crew.py <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">from</span> crewai <span class="kw">import</span> Agent, Task, Crew
+
+<span class="kw">def</span> <span class="fn">test_researcher_crew</span>():
+    researcher = Agent(
+        role=<span class="str">"Researcher"</span>,
+        goal=<span class="str">"Research topics"</span>,
+        backstory=<span class="str">"Expert researcher"</span>,
+    )
+    task = Task(
+        description=<span class="str">"Summarize recent AI breakthroughs"</span>,
+        expected_output=<span class="str">"A short summary"</span>,
+        agent=researcher,
+    )
+    crew = Crew(agents=[researcher], tasks=[task])
+    result = crew.kickoff()
+    <span class="kw">assert</span> <span class="str">"AI"</span> <span class="kw">in</span> str(result)</code></pre>
+        </div>
+
+        <h2>Multi-Agent Crews</h2>
+        <p>
+          In a CrewAI crew, each agent makes independent LLM calls. The researcher agent sends its
+          own chat completion request, then the writer agent sends a separate one. Because aimock
+          matches on the <code>userMessage</code> field, you can write fixtures that target each
+          agent's prompt pattern independently.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            fixtures/crewai-crew.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"research"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"content"</span>: <span class="str">"Based on my research, the key findings are:\n\n1. LLM testing with fixture-based mocks eliminates flaky tests caused by non-deterministic API responses.\n2. Proxy recording captures real interactions for replay in CI without API keys.\n3. Multi-agent frameworks like CrewAI benefit most because each agent multiplies the number of LLM calls per run."</span>
+      }
+    },
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"write"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"content"</span>: <span class="str">"# Testing LLMs in CI\n\nFixture-based mocking brings determinism to AI-powered applications. By replacing real API calls with recorded responses, teams ship faster with confidence.\n\n## Why It Matters\n\nEvery agent in a CrewAI crew makes independent LLM calls. Without mocking, a two-agent crew means two sources of non-determinism per run. With aimock, every call returns the exact same response every time."</span>
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Two-agent crew <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">from</span> crewai <span class="kw">import</span> Agent, Task, Crew, Process
+
+researcher = Agent(
+    role=<span class="str">"Researcher"</span>,
+    goal=<span class="str">"Research topics thoroughly"</span>,
+    backstory=<span class="str">"Senior research analyst"</span>,
+)
+
+writer = Agent(
+    role=<span class="str">"Writer"</span>,
+    goal=<span class="str">"Write compelling articles"</span>,
+    backstory=<span class="str">"Technical content writer"</span>,
+)
+
+research_task = Task(
+    description=<span class="str">"Research LLM testing best practices"</span>,
+    expected_output=<span class="str">"Key findings as bullet points"</span>,
+    agent=researcher,
+)
+
+write_task = Task(
+    description=<span class="str">"Write a blog post from the research"</span>,
+    expected_output=<span class="str">"A short blog post in markdown"</span>,
+    agent=writer,
+)
+
+crew = Crew(
+    agents=[researcher, writer],
+    tasks=[research_task, write_task],
+    process=Process.sequential,
+)
+result = crew.kickoff()</code></pre>
+        </div>
+        <p>
+          The researcher's prompt contains "research", matching the first fixture. The writer's
+          prompt contains "write", matching the second. Each agent gets its own deterministic
+          response.
+        </p>
+
+        <h2>Tool Calls</h2>
+        <p>
+          CrewAI agents can use tools. When an agent invokes a tool, CrewAI sends a chat completion
+          with <code>tool_choice</code> and expects a tool-call response. aimock fixtures handle
+          this with the <code>toolCalls</code> response field.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            fixtures/crewai-tools.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"search"</span>, <span class="prop">"sequenceIndex"</span>: <span class="num">0</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"toolCalls"</span>: [
+          {
+            <span class="prop">"name"</span>: <span class="str">"web_search"</span>,
+            <span class="prop">"arguments"</span>: <span class="str">"{\"query\": \"LLM testing frameworks 2025\"}"</span>
+          }
+        ]
+      }
+    },
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"search"</span>, <span class="prop">"sequenceIndex"</span>: <span class="num">1</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"content"</span>: <span class="str">"Based on the search results, the top LLM testing frameworks are aimock, promptfoo, and deepeval."</span>
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Agent with tools <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">from</span> crewai <span class="kw">import</span> Agent, Task, Crew
+<span class="kw">from</span> crewai_tools <span class="kw">import</span> SerperDevTool
+
+search_tool = SerperDevTool()
+
+researcher = Agent(
+    role=<span class="str">"Researcher"</span>,
+    goal=<span class="str">"Search the web for information"</span>,
+    backstory=<span class="str">"Expert web researcher"</span>,
+    tools=[search_tool],
+)
+
+task = Task(
+    description=<span class="str">"Search for the latest LLM testing frameworks"</span>,
+    expected_output=<span class="str">"A ranked list of frameworks"</span>,
+    agent=researcher,
+)
+
+crew = Crew(agents=[researcher], tasks=[task])
+result = crew.kickoff()</code></pre>
+        </div>
+        <p>
+          The first fixture triggers the tool call. After CrewAI processes the tool result and sends
+          it back to the LLM, the second fixture matches the follow-up message and returns the final
+          answer.
+        </p>
+
+        <h2>CI with GitHub Action</h2>
+        <p>
+          Use the <code>CopilotKit/aimock</code> GitHub Action to run aimock as a background service
+          in your CI pipeline.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            .github/workflows/test.yml <span class="lang-tag">yaml</span>
+          </div>
+          <pre><code><span class="prop">name</span>: Test CrewAI Crew
+<span class="prop">on</span>: [push, pull_request]
+<span class="prop">jobs</span>:
+  <span class="prop">test</span>:
+    <span class="prop">runs-on</span>: ubuntu-latest
+    <span class="prop">steps</span>:
+      - <span class="prop">uses</span>: actions/checkout@v4
+      - <span class="prop">uses</span>: actions/setup-python@v5
+        <span class="prop">with</span>:
+          <span class="prop">python-version</span>: <span class="str">"3.11"</span>
+      - <span class="prop">uses</span>: CopilotKit/aimock@v1
+        <span class="prop">with</span>:
+          <span class="prop">fixtures</span>: ./fixtures
+      - <span class="prop">run</span>: pip install crewai pytest aimock-pytest
+      - <span class="prop">run</span>: pytest
+        <span class="prop">env</span>:
+          <span class="prop">OPENAI_BASE_URL</span>: http://127.0.0.1:4010/v1
+          <span class="prop">OPENAI_API_KEY</span>: test</code></pre>
+        </div>
+        <p>
+          The action starts aimock on port 4010, loads your fixtures, and keeps the server running
+          for the duration of the job. No real API keys needed.
+        </p>
+
+        <h2>Record &amp; Replay</h2>
+        <p>
+          Record a full crew execution against a real LLM, then replay it deterministically in tests
+          and CI. This is especially useful for capturing complex multi-agent interactions.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Record a crew run <span class="lang-tag">shell</span></div>
+          <pre><code><span class="cm"># Start aimock in record mode &mdash; unmatched requests go to OpenAI</span>
+npx aimock --fixtures ./fixtures \
+  --record \
+  --provider-openai https://api.openai.com
+
+<span class="cm"># Run your crew with the real API key (proxied through aimock)</span>
+<span class="kw">export</span> OPENAI_BASE_URL=http://localhost:4010/v1
+<span class="kw">export</span> OPENAI_API_KEY=sk-your-real-key
+python crew.py
+
+<span class="cm"># New fixtures appear in ./fixtures/recorded/</span>
+<span class="cm"># Commit them to your repo for deterministic replay</span></code></pre>
+        </div>
+        <p>
+          On subsequent runs without <code>--record</code>, aimock replays the recorded fixtures.
+          Every agent in the crew gets the exact same response it received during the original
+          recording, making your tests fully reproducible.
+        </p>
+      </main>
+      <aside class="page-toc" id="page-toc"></aside>
+    </div>
+    <footer class="docs-footer">
+      <div class="footer-inner">
+        <div class="footer-left"><span>$</span> aimock &middot; MIT License</div>
+        <ul class="footer-links">
+          <li><a href="https://github.com/CopilotKit/aimock" target="_blank">GitHub</a></li>
+          <li>
+            <a href="https://www.npmjs.com/package/@copilotkit/aimock" target="_blank">npm</a>
+          </li>
+        </ul>
+      </div>
+    </footer>
+    <script src="../sidebar.js"></script>
+    <script src="../cli-tabs.js"></script>
+  </body>
+</html>

--- a/docs/integrate-langchain/index.html
+++ b/docs/integrate-langchain/index.html
@@ -1,0 +1,240 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LangChain &amp; LangGraph — aimock</title>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <nav class="top-nav">
+      <div class="nav-inner">
+        <div style="display: flex; align-items: center; gap: 1rem">
+          <button
+            class="sidebar-toggle"
+            onclick="document.querySelector('.sidebar').classList.toggle('open')"
+            aria-label="Toggle sidebar"
+          >
+            &#9776;
+          </button>
+          <a href="/" class="nav-brand"> <span class="prompt">$</span> aimock </a>
+        </div>
+        <ul class="nav-links">
+          <li><a href="/">Home</a></li>
+          <li><a href="/docs" style="color: var(--accent)">Docs</a></li>
+          <li>
+            <a href="https://github.com/CopilotKit/aimock" class="gh-link" target="_blank"
+              ><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+              GitHub</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="docs-layout">
+      <aside class="sidebar" id="sidebar"></aside>
+
+      <main class="docs-content">
+        <h1>LangChain &amp; LangGraph</h1>
+        <p class="lead">
+          Test your LangChain and LangGraph agents without API keys or network calls. Point your LLM
+          at aimock and get deterministic, fixture-driven responses.
+        </p>
+
+        <h2>Quick Start</h2>
+        <p>
+          LangChain's <code>ChatOpenAI</code> accepts a <code>base_url</code> parameter. Point it at
+          aimock and every call goes through your fixtures instead of the real API.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Minimal setup <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">from</span> langchain_openai <span class="kw">import</span> ChatOpenAI
+
+<span class="cm"># Start aimock first: npx aimock --fixtures ./fixtures</span>
+llm = <span class="fn">ChatOpenAI</span>(
+    base_url=<span class="str">"http://localhost:4010/v1"</span>,
+    api_key=<span class="str">"test"</span>,
+)
+
+result = llm.<span class="fn">invoke</span>(<span class="str">"hello"</span>)
+<span class="fn">print</span>(result.content)  <span class="cm"># deterministic fixture response</span></code></pre>
+        </div>
+        <p>
+          This works with any LangChain component that wraps an OpenAI-compatible API:
+          <code>ChatOpenAI</code> or any provider using the <code>base_url</code> parameter. For
+          Azure OpenAI, see the <a href="/azure-openai">Azure OpenAI guide</a>.
+        </p>
+
+        <h2>With aimock-pytest</h2>
+        <p>
+          The <code>aimock-pytest</code> plugin starts and stops the server automatically per test.
+          The <code>aimock</code> fixture exposes a <code>.url</code> property you pass as the base
+          URL.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">pytest fixture <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">def</span> <span class="fn">test_my_chain</span>(aimock):
+    <span class="cm"># Load fixtures before making LLM calls</span>
+    aimock.load_fixtures(<span class="str">"./fixtures/langchain.json"</span>)
+
+    llm = <span class="fn">ChatOpenAI</span>(
+        base_url=<span class="str">f"</span>{aimock.url}<span class="str">/v1"</span>,
+        api_key=<span class="str">"test"</span>,
+    )
+    result = llm.<span class="fn">invoke</span>(<span class="str">"hello"</span>)
+    <span class="kw">assert</span> <span class="str">"Hi"</span> <span class="kw">in</span> result.content</code></pre>
+        </div>
+        <p>
+          Install with <code>pip install aimock-pytest</code>. The fixture handles server lifecycle
+          so your tests stay fast and isolated.
+        </p>
+
+        <h2>Multi-Turn Agent Loops (LangGraph)</h2>
+        <p>
+          LangGraph agents make multiple sequential LLM calls as they reason, call tools, and
+          synthesize results. A single user request like "plan a trip" might trigger three or more
+          completions in a loop. While later calls include tool results, the original user message
+          persists across the loop, so aimock's <code>sequenceIndex</code> matcher tracks how many
+          times a given message pattern has matched.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Multi-turn fixture <span class="lang-tag">json</span></div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"plan a trip"</span>, <span class="prop">"sequenceIndex"</span>: <span class="num">0</span> },
+      <span class="prop">"response"</span>: { <span class="prop">"content"</span>: <span class="str">"I'll help plan your trip. Let me look up some options."</span> }
+    },
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"plan a trip"</span>, <span class="prop">"sequenceIndex"</span>: <span class="num">1</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"toolCalls"</span>: [
+          { <span class="prop">"name"</span>: <span class="str">"search_flights"</span>, <span class="prop">"arguments"</span>: <span class="str">"{\"origin\":\"SFO\",\"dest\":\"NRT\"}"</span> }
+        ]
+      }
+    },
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"plan a trip"</span>, <span class="prop">"sequenceIndex"</span>: <span class="num">2</span> },
+      <span class="prop">"response"</span>: { <span class="prop">"content"</span>: <span class="str">"I found 3 flights from SFO to Tokyo Narita. The best option is..."</span> }
+    }
+  ]
+}</code></pre>
+        </div>
+        <p>
+          Each fixture fires once in order. The first LLM call matches index 0, the second matches
+          index 1, and so on. This lets you script the exact behavior of a multi-step agent without
+          any real API calls.
+        </p>
+        <p>
+          See <a href="/fixtures">Fixtures</a> and
+          <a href="/sequential-responses">Sequential Responses</a>
+          for the full matching reference.
+        </p>
+
+        <h2>Tool Call Fixtures</h2>
+        <p>
+          LangChain's tool-calling agents expect the LLM to return structured
+          <code>tool_calls</code> in the response. Use the <code>toolCalls</code> response field to
+          return them from aimock.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Tool call fixture <span class="lang-tag">json</span></div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"what's the weather in SF"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"toolCalls"</span>: [
+          {
+            <span class="prop">"name"</span>: <span class="str">"get_weather"</span>,
+            <span class="prop">"arguments"</span>: <span class="str">"{\"location\":\"San Francisco\",\"unit\":\"fahrenheit\"}"</span>
+          }
+        ]
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+        <p>
+          When LangChain receives this response, it will invoke the <code>get_weather</code> tool
+          with the given arguments, just as it would with a real OpenAI response. Combine tool call
+          fixtures with <code>sequenceIndex</code> to script the full loop: tool call, tool result
+          injection, then final answer.
+        </p>
+
+        <h2>Record &amp; Replay</h2>
+        <p>
+          Don't want to write fixtures by hand? Record a real LangGraph session and replay it in
+          tests. Start aimock in record mode, run your agent against a live provider, and aimock
+          saves every request/response pair as a fixture file.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Record a session <span class="lang-tag">shell</span></div>
+          <pre><code>npx aimock --record --provider-openai https://api.openai.com -f ./fixtures</code></pre>
+        </div>
+        <p>
+          Then point your LangChain code at <code>http://localhost:4010/v1</code> and run your agent
+          normally. Every LLM call is captured. On subsequent runs, aimock replays the recorded
+          responses without network calls.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Replay in tests <span class="lang-tag">shell</span></div>
+          <pre><code><span class="cm"># Replay mode (default when fixtures exist)</span>
+npx aimock -f ./fixtures
+
+<span class="cm"># Run your tests against the recorded fixtures</span>
+pytest tests/</code></pre>
+        </div>
+        <p>See <a href="/record-replay">Record &amp; Replay</a> for the full reference.</p>
+
+        <h2>CI with GitHub Action</h2>
+        <p>
+          The <code>CopilotKit/aimock</code> GitHub Action starts aimock as a background service in
+          CI. Your tests run against fixtures with zero external dependencies.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            GitHub Actions workflow <span class="lang-tag">yaml</span>
+          </div>
+          <pre><code><span class="kw">-</span> <span class="prop">uses</span>: CopilotKit/aimock@v1
+  <span class="prop">with</span>:
+    <span class="prop">fixtures</span>: ./test/fixtures
+
+<span class="kw">-</span> <span class="prop">run</span>: pytest
+  <span class="prop">env</span>:
+    <span class="prop">OPENAI_BASE_URL</span>: <span class="str">http://127.0.0.1:4010/v1</span></code></pre>
+        </div>
+        <p>
+          No API keys needed in CI. No flaky tests from rate limits or network timeouts. See
+          <a href="/github-action">GitHub Action</a> for all available options.
+        </p>
+      </main>
+      <aside class="page-toc" id="page-toc"></aside>
+    </div>
+    <footer class="docs-footer">
+      <div class="footer-inner">
+        <div class="footer-left"><span>$</span> aimock &middot; MIT License</div>
+        <ul class="footer-links">
+          <li><a href="https://github.com/CopilotKit/aimock" target="_blank">GitHub</a></li>
+          <li>
+            <a href="https://www.npmjs.com/package/@copilotkit/aimock" target="_blank">npm</a>
+          </li>
+        </ul>
+      </div>
+    </footer>
+    <script src="../sidebar.js"></script>
+    <script src="../cli-tabs.js"></script>
+  </body>
+</html>

--- a/docs/integrate-llamaindex/index.html
+++ b/docs/integrate-llamaindex/index.html
@@ -1,0 +1,322 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LlamaIndex — aimock</title>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <nav class="top-nav">
+      <div class="nav-inner">
+        <div style="display: flex; align-items: center; gap: 1rem">
+          <button
+            class="sidebar-toggle"
+            onclick="document.querySelector('.sidebar').classList.toggle('open')"
+            aria-label="Toggle sidebar"
+          >
+            &#9776;
+          </button>
+          <a href="/" class="nav-brand"> <span class="prompt">$</span> aimock </a>
+        </div>
+        <ul class="nav-links">
+          <li><a href="/">Home</a></li>
+          <li><a href="/docs" style="color: var(--accent)">Docs</a></li>
+          <li>
+            <a href="https://github.com/CopilotKit/aimock" class="gh-link" target="_blank"
+              ><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+              GitHub</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="docs-layout">
+      <aside class="sidebar" id="sidebar"></aside>
+
+      <main class="docs-content">
+        <h1>LlamaIndex</h1>
+        <p class="lead">
+          Test your LlamaIndex RAG pipelines end-to-end. aimock mocks both the LLM and the vector
+          database &mdash; retriever and generator in one server.
+        </p>
+
+        <h2>Quick Start</h2>
+        <p>
+          Point the LlamaIndex OpenAI LLM at aimock instead of the real API. No code changes to your
+          RAG pipeline &mdash; just swap the base URL.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Python <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">from</span> llama_index.llms.openai <span class="kw">import</span> OpenAI
+
+<span class="cm"># Point at aimock instead of api.openai.com</span>
+llm = OpenAI(
+    api_base=<span class="str">"http://localhost:4010/v1"</span>,
+    api_key=<span class="str">"test"</span>,
+)
+
+<span class="cm"># Configure LlamaIndex to use aimock for both LLM and embeddings</span>
+<span class="kw">from</span> llama_index.core <span class="kw">import</span> Settings, VectorStoreIndex, SimpleDirectoryReader
+<span class="kw">from</span> llama_index.embeddings.openai <span class="kw">import</span> OpenAIEmbedding
+
+Settings.llm = llm
+Settings.embed_model = OpenAIEmbedding(api_base=<span class="str">"http://localhost:4010/v1"</span>, api_key=<span class="str">"test"</span>)
+
+documents = SimpleDirectoryReader(<span class="str">"data"</span>).load_data()
+index = VectorStoreIndex.from_documents(documents)
+query_engine = index.as_query_engine()
+response = query_engine.query(<span class="str">"What is gravity?"</span>)</code></pre>
+        </div>
+        <p>Start aimock with fixtures that match the queries your pipeline will send:</p>
+        <div class="code-block">
+          <div class="code-block-header">Terminal <span class="lang-tag">shell</span></div>
+          <pre><code>npx aimock --fixtures ./fixtures/llamaindex</code></pre>
+        </div>
+
+        <h2>Mock Both LLM and Vector DB</h2>
+        <p>
+          This is where aimock shines for RAG testing. A LlamaIndex RAG pipeline has two external
+          dependencies: the <strong>retriever</strong> (vector database) and the
+          <strong>generator</strong> (LLM). aimock serves both on one port, so a single server
+          replaces Pinecone/Qdrant <em>and</em> OpenAI/Anthropic.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            fixtures/rag-pipeline.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"What is gravity?"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"content"</span>: <span class="str">"Based on the retrieved documents, gravity is a fundamental force of nature that attracts objects with mass toward one another. It is described by Newton's law of universal gravitation and Einstein's general theory of relativity."</span>
+      }
+    },
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"inputText"</span>: <span class="str">"What is gravity?"</span>, <span class="prop">"endpoint"</span>: <span class="str">"embedding"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"embedding"</span>: [<span class="num">0.9</span>, <span class="num">0.1</span>, <span class="num">0.05</span>]
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">aimock.json <span class="lang-tag">json</span></div>
+          <pre><code>{
+  <span class="prop">"llm"</span>: {
+    <span class="prop">"fixtures"</span>: <span class="str">"./fixtures/rag-pipeline.json"</span>
+  },
+  <span class="prop">"vector"</span>: {
+    <span class="prop">"collections"</span>: [
+      {
+        <span class="prop">"name"</span>: <span class="str">"knowledge-base"</span>,
+        <span class="prop">"dimension"</span>: <span class="num">3</span>,
+        <span class="prop">"vectors"</span>: [
+          {
+            <span class="prop">"id"</span>: <span class="str">"doc-gravity"</span>,
+            <span class="prop">"values"</span>: [<span class="num">0.9</span>, <span class="num">0.1</span>, <span class="num">0.05</span>],
+            <span class="prop">"metadata"</span>: { <span class="prop">"source"</span>: <span class="str">"physics.pdf"</span>, <span class="prop">"page"</span>: <span class="num">12</span> }
+          }
+        ],
+        <span class="prop">"queryResults"</span>: [
+          {
+            <span class="prop">"id"</span>: <span class="str">"doc-gravity"</span>,
+            <span class="prop">"score"</span>: <span class="num">0.97</span>,
+            <span class="prop">"metadata"</span>: { <span class="prop">"source"</span>: <span class="str">"physics.pdf"</span>, <span class="prop">"page"</span>: <span class="num">12</span> }
+          }
+        ]
+      }
+    ]
+  }
+}</code></pre>
+        </div>
+        <p>
+          Load both with <code>npx aimock --config aimock.json</code>. The config points to the
+          fixture file via <code>llm.fixtures</code>, so aimock handles both legs of the RAG
+          pipeline:
+        </p>
+        <ul>
+          <li><code>/v1/chat/completions</code> &mdash; matches LLM fixtures for the generator</li>
+          <li><code>/vector</code> &mdash; serves vector query results for the retriever</li>
+        </ul>
+        <div class="code-block">
+          <div class="code-block-header">
+            Python &mdash; dual mock <span class="lang-tag">python</span>
+          </div>
+          <pre><code><span class="kw">from</span> llama_index.llms.openai <span class="kw">import</span> OpenAI
+<span class="kw">from</span> llama_index.embeddings.openai <span class="kw">import</span> OpenAIEmbedding
+<span class="kw">from</span> llama_index.vector_stores.qdrant <span class="kw">import</span> QdrantVectorStore
+
+<span class="cm"># Generator: LLM pointed at aimock</span>
+llm = OpenAI(
+    api_base=<span class="str">"http://localhost:4010/v1"</span>,
+    api_key=<span class="str">"test"</span>,
+)
+
+<span class="cm"># Embeddings: also served by aimock</span>
+embed_model = OpenAIEmbedding(
+    api_base=<span class="str">"http://localhost:4010/v1"</span>,
+    api_key=<span class="str">"test"</span>,
+)
+
+<span class="cm"># Retriever: aimock's vector endpoint</span>
+<span class="cm"># Point your vector store client at localhost:4010/vector</span>
+<span class="cm"># aimock implements the Qdrant-compatible REST API</span>
+
+<span class="cm"># Now your entire RAG pipeline runs against one mock server</span></code></pre>
+        </div>
+
+        <h2>Embedding Fixtures</h2>
+        <p>
+          LlamaIndex indexes documents by generating embeddings. Use <code>inputText</code> matching
+          to return deterministic embedding vectors for specific inputs, ensuring your indexing and
+          retrieval paths produce consistent results in tests.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            fixtures/embeddings.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"inputText"</span>: <span class="str">"What is gravity?"</span>, <span class="prop">"endpoint"</span>: <span class="str">"embedding"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"embedding"</span>: [<span class="num">0.9</span>, <span class="num">0.1</span>, <span class="num">0.05</span>]
+      }
+    },
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"inputText"</span>: <span class="str">"Gravity is a fundamental force"</span>, <span class="prop">"endpoint"</span>: <span class="str">"embedding"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"embedding"</span>: [<span class="num">0.88</span>, <span class="num">0.12</span>, <span class="num">0.07</span>]
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+        <p>
+          The <code>inputText</code> matcher performs substring matching, so
+          <code>"gravity"</code> matches any input containing that word. Use exact strings when you
+          need precision.
+        </p>
+
+        <h2>With aimock-pytest</h2>
+        <p>
+          The <code>aimock-pytest</code> plugin starts and stops the server automatically per test.
+          Install with <code>pip install aimock-pytest</code>.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">test_rag.py <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">from</span> llama_index.llms.openai <span class="kw">import</span> OpenAI
+
+<span class="kw">def</span> <span class="fn">test_rag_query</span>(aimock):
+    <span class="cm"># Load fixtures before making LLM calls</span>
+    aimock.load_fixtures(<span class="str">"./fixtures/llamaindex/rag.json"</span>)
+
+    llm = OpenAI(
+        api_base=f<span class="str">"{aimock.url}/v1"</span>,
+        api_key=<span class="str">"test"</span>,
+    )
+    response = llm.complete(<span class="str">"What is gravity?"</span>)
+    <span class="kw">assert</span> <span class="str">"force"</span> <span class="kw">in</span> str(response).lower()</code></pre>
+        </div>
+
+        <h2>CI with GitHub Action</h2>
+        <p>
+          Run your LlamaIndex test suite in CI with the aimock GitHub Action. The action starts
+          aimock as a background service and exposes it on the default port.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            .github/workflows/test.yml <span class="lang-tag">yaml</span>
+          </div>
+          <pre><code><span class="prop">name</span>: LlamaIndex Tests
+
+<span class="prop">on</span>: [push, pull_request]
+
+<span class="prop">jobs</span>:
+  <span class="prop">test</span>:
+    <span class="prop">runs-on</span>: ubuntu-latest
+    <span class="prop">steps</span>:
+      - <span class="prop">uses</span>: actions/checkout@v4
+
+      - <span class="prop">name</span>: Start aimock
+        <span class="prop">uses</span>: CopilotKit/aimock@v1
+        <span class="prop">with</span>:
+          <span class="prop">fixtures</span>: ./fixtures/llamaindex
+
+      - <span class="prop">name</span>: Install dependencies
+        <span class="prop">run</span>: pip install -r requirements.txt
+
+      - <span class="prop">name</span>: Run tests
+        <span class="prop">run</span>: pytest tests/
+        <span class="prop">env</span>:
+          <span class="prop">OPENAI_BASE_URL</span>: http://127.0.0.1:4010/v1
+          <span class="prop">OPENAI_API_KEY</span>: test</code></pre>
+        </div>
+        <p>
+          No API keys needed in CI. Your LlamaIndex pipeline talks to aimock, which returns
+          deterministic responses from fixtures.
+        </p>
+
+        <h2>Record &amp; Replay</h2>
+        <p>
+          Record a RAG query end-to-end against real services, then replay it in tests. aimock
+          captures both the LLM completions and the embedding calls, so the full pipeline is
+          reproducible.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Record mode <span class="lang-tag">shell</span></div>
+          <pre><code><span class="cm"># Record LLM and embedding calls from a live session</span>
+npx aimock \
+  --record \
+  --provider-openai https://api.openai.com \
+  --fixtures ./fixtures/llamaindex
+
+<span class="cm"># Run your LlamaIndex pipeline against aimock</span>
+python my_rag_pipeline.py
+
+<span class="cm"># aimock saves fixtures to ./fixtures/llamaindex/</span>
+<span class="cm"># Next run replays them without hitting the real API</span></code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Replay in tests <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">def</span> <span class="fn">test_rag_query</span>(aimock):
+    <span class="cm"># Load the recorded fixtures</span>
+    aimock.load_fixtures(<span class="str">"./fixtures/llamaindex/recorded.json"</span>)
+
+    <span class="kw">from</span> llama_index.llms.openai <span class="kw">import</span> OpenAI
+    llm = OpenAI(api_base=f<span class="str">"{aimock.url}/v1"</span>, api_key=<span class="str">"test"</span>)
+    <span class="cm"># ... run your RAG pipeline, assert on results</span></code></pre>
+        </div>
+      </main>
+      <aside class="page-toc" id="page-toc"></aside>
+    </div>
+    <footer class="docs-footer">
+      <div class="footer-inner">
+        <div class="footer-left"><span>$</span> aimock &middot; MIT License</div>
+        <ul class="footer-links">
+          <li><a href="https://github.com/CopilotKit/aimock" target="_blank">GitHub</a></li>
+          <li>
+            <a href="https://www.npmjs.com/package/@copilotkit/aimock" target="_blank">npm</a>
+          </li>
+        </ul>
+      </div>
+    </footer>
+    <script src="../sidebar.js"></script>
+    <script src="../cli-tabs.js"></script>
+  </body>
+</html>

--- a/docs/integrate-mastra/index.html
+++ b/docs/integrate-mastra/index.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mastra — aimock</title>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <nav class="top-nav">
+      <div class="nav-inner">
+        <div style="display: flex; align-items: center; gap: 1rem">
+          <button
+            class="sidebar-toggle"
+            onclick="document.querySelector('.sidebar').classList.toggle('open')"
+            aria-label="Toggle sidebar"
+          >
+            &#9776;
+          </button>
+          <a href="/" class="nav-brand"> <span class="prompt">$</span> aimock </a>
+        </div>
+        <ul class="nav-links">
+          <li><a href="/">Home</a></li>
+          <li><a href="/docs" style="color: var(--accent)">Docs</a></li>
+          <li>
+            <a href="https://github.com/CopilotKit/aimock" class="gh-link" target="_blank"
+              ><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+              GitHub</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="docs-layout">
+      <aside class="sidebar" id="sidebar"></aside>
+
+      <main class="docs-content">
+        <h1>Mastra</h1>
+        <p class="lead">
+          Test your Mastra agents with deterministic LLM responses and AG-UI event streams. aimock
+          integrates natively with CopilotKit's Mastra support.
+        </p>
+
+        <h2>Quick Start</h2>
+        <p>
+          Mastra agents support multiple LLM providers through its model configuration. For
+          OpenAI-compatible models, set the base URL to point at aimock. The simplest approach is
+          setting the <code>OPENAI_BASE_URL</code> environment variable.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            Point your agent at aimock <span class="lang-tag">typescript</span>
+          </div>
+          <pre><code><span class="kw">import</span> { Agent } <span class="kw">from</span> <span class="str">"@mastra/core/agent"</span>;
+
+<span class="kw">const</span> agent = <span class="kw">new</span> <span class="fn">Agent</span>({
+  <span class="prop">name</span>: <span class="str">"my-agent"</span>,
+  <span class="prop">instructions</span>: <span class="str">"You are a helpful assistant"</span>,
+  <span class="prop">model</span>: {
+    <span class="prop">provider</span>: <span class="str">"OPEN_AI"</span>,
+    <span class="prop">name</span>: <span class="str">"gpt-4o"</span>,
+    <span class="prop">toolChoice</span>: <span class="str">"auto"</span>,
+  },
+});
+
+<span class="cm">// Set OPENAI_BASE_URL=http://localhost:4010/v1 to redirect to aimock</span>
+<span class="cm">// All completions will be served from aimock fixtures</span></code></pre>
+        </div>
+
+        <h2>With Vitest Plugin</h2>
+        <p>
+          The <code>useAimock</code> plugin starts and stops the aimock server automatically around
+          your test suite. No manual setup or teardown required.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            mastra-agent.test.ts <span class="lang-tag">typescript</span>
+          </div>
+          <pre><code><span class="kw">import</span> { describe, it, expect } <span class="kw">from</span> <span class="str">"vitest"</span>;
+<span class="kw">import</span> { useAimock } <span class="kw">from</span> <span class="str">"@copilotkit/aimock/vitest"</span>;
+<span class="kw">import</span> { Agent } <span class="kw">from</span> <span class="str">"@mastra/core/agent"</span>;
+
+<span class="kw">const</span> mock = <span class="fn">useAimock</span>({ <span class="prop">fixtures</span>: <span class="str">"./fixtures"</span> });
+
+<span class="fn">describe</span>(<span class="str">"Mastra agent"</span>, () =&gt; {
+  <span class="fn">it</span>(<span class="str">"handles a travel planning request"</span>, <span class="kw">async</span> () =&gt; {
+    process.env.<span class="prop">OPENAI_BASE_URL</span> = mock().<span class="prop">url</span> + <span class="str">"/v1"</span>;
+
+    <span class="kw">const</span> agent = <span class="kw">new</span> <span class="fn">Agent</span>({
+      <span class="prop">name</span>: <span class="str">"travel-planner"</span>,
+      <span class="prop">instructions</span>: <span class="str">"You are a travel planning assistant"</span>,
+      <span class="prop">model</span>: { <span class="prop">provider</span>: <span class="str">"OPEN_AI"</span>, <span class="prop">name</span>: <span class="str">"gpt-4o"</span> },
+    });
+    <span class="kw">const</span> result = <span class="kw">await</span> agent.<span class="fn">generate</span>(<span class="str">"plan a trip to Tokyo"</span>);
+    <span class="fn">expect</span>(result.text).<span class="fn">toContain</span>(<span class="str">"Tokyo"</span>);
+  });
+});</code></pre>
+        </div>
+
+        <h2>Tool Call Workflows</h2>
+        <p>
+          Mastra agents use tools extensively for travel planning, API calls, and multi-step
+          workflows. Define tool call fixtures to test these interactions deterministically.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            fixtures/mastra-tools.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"plan a trip"</span>, <span class="prop">"sequenceIndex"</span>: <span class="num">0</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"toolCalls"</span>: [
+          {
+            <span class="prop">"name"</span>: <span class="str">"search_flights"</span>,
+            <span class="prop">"arguments"</span>: <span class="str">"{\"origin\":\"SFO\",\"destination\":\"NRT\",\"date\":\"2025-03-15\"}"</span>
+          }
+        ]
+      }
+    },
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"plan a trip"</span>, <span class="prop">"sequenceIndex"</span>: <span class="num">1</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"toolCalls"</span>: [
+          {
+            <span class="prop">"name"</span>: <span class="str">"search_hotels"</span>,
+            <span class="prop">"arguments"</span>: <span class="str">"{\"city\":\"Tokyo\",\"checkIn\":\"2025-03-15\",\"checkOut\":\"2025-03-22\"}"</span>
+          }
+        ]
+      }
+    },
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"plan a trip"</span>, <span class="prop">"sequenceIndex"</span>: <span class="num">2</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"content"</span>: <span class="str">"I found a great itinerary for your Tokyo trip!\n\n**Flight:** SFO &rarr; NRT on March 15, departing 11:30 AM (United UA837) &mdash; $890 round trip\n\n**Hotel:** Hotel Gracery Shinjuku, March 15&ndash;22 &mdash; $185/night\n\nWould you like me to book these, or would you prefer different options?"</span>
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+        <p>
+          Each fixture fires once in sequence using <code>sequenceIndex</code>. The first call
+          triggers a flight search, the second searches for hotels, and the third returns the
+          combined itinerary. See <a href="/fixtures">Fixtures</a> for the full matching syntax.
+        </p>
+
+        <h2>AG-UI Frontend Testing</h2>
+        <p>
+          When using Mastra with CopilotKit, the frontend receives AG-UI event streams. Use
+          <code>AGUIMock</code> to test the frontend separately from the agent — no running Mastra
+          server required.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            Mock the AG-UI layer <span class="lang-tag">typescript</span>
+          </div>
+          <pre><code><span class="kw">import</span> { LLMock } <span class="kw">from</span> <span class="str">"@copilotkit/aimock"</span>;
+<span class="kw">import</span> { AGUIMock } <span class="kw">from</span> <span class="str">"@copilotkit/aimock"</span>;
+
+<span class="kw">const</span> llm = <span class="kw">new</span> <span class="fn">LLMock</span>();
+<span class="kw">const</span> agui = <span class="kw">new</span> <span class="fn">AGUIMock</span>();
+
+agui.<span class="fn">onMessage</span>(<span class="str">"hello"</span>, <span class="str">"Hi from the agent!"</span>);
+agui.<span class="fn">onToolCall</span>(<span class="op">/search/</span>, <span class="str">"web_search"</span>, <span class="str">'{"q":"test"}'</span>, { <span class="prop">result</span>: <span class="str">"[]"</span> });
+
+llm.<span class="fn">mount</span>(<span class="str">"/agui"</span>, agui);
+<span class="kw">const</span> url = <span class="kw">await</span> llm.<span class="fn">start</span>();
+
+<span class="cm">// Point your CopilotKit frontend at url + "/agui"</span>
+<span class="cm">// It receives deterministic AG-UI SSE event streams</span></code></pre>
+        </div>
+        <p>
+          This lets you develop and test CopilotKit UI components against canned agent responses
+          without running Mastra or any LLM provider. See
+          <a href="/agui-mock">AGUIMock</a> for the full API.
+        </p>
+
+        <h2>CI with GitHub Action</h2>
+        <p>
+          Run your Mastra agent tests in CI with a single step. The aimock GitHub Action starts the
+          server, waits for it to be healthy, and cleans up when the job finishes.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">workflow.yml <span class="lang-tag">yaml</span></div>
+          <pre><code><span class="prop">steps</span>:
+  - <span class="prop">uses</span>: <span class="str">actions/checkout@v4</span>
+  - <span class="prop">uses</span>: <span class="str">CopilotKit/aimock@v1</span>
+    <span class="prop">with</span>:
+      <span class="prop">fixtures</span>: <span class="str">./fixtures</span>
+  - <span class="prop">run</span>: <span class="str">pnpm test</span>
+    <span class="prop">env</span>:
+      <span class="prop">OPENAI_BASE_URL</span>: <span class="str">http://127.0.0.1:4010/v1</span></code></pre>
+        </div>
+        <p>See <a href="/github-action">GitHub Action</a> for all available inputs and outputs.</p>
+      </main>
+      <aside class="page-toc" id="page-toc"></aside>
+    </div>
+    <footer class="docs-footer">
+      <div class="footer-inner">
+        <div class="footer-left"><span>$</span> aimock &middot; MIT License</div>
+        <ul class="footer-links">
+          <li><a href="https://github.com/CopilotKit/aimock" target="_blank">GitHub</a></li>
+          <li>
+            <a href="https://www.npmjs.com/package/@copilotkit/aimock" target="_blank">npm</a>
+          </li>
+        </ul>
+      </div>
+    </footer>
+    <script src="../sidebar.js"></script>
+    <script src="../cli-tabs.js"></script>
+  </body>
+</html>

--- a/docs/integrate-pydanticai/index.html
+++ b/docs/integrate-pydanticai/index.html
@@ -1,0 +1,309 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PydanticAI — aimock</title>
+    <meta
+      name="description"
+      content="Test PydanticAI agents with aimock — deterministic structured output, tool calls, and streaming without API keys."
+    />
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <nav class="top-nav">
+      <div class="nav-inner">
+        <div style="display: flex; align-items: center; gap: 1rem">
+          <button
+            class="sidebar-toggle"
+            onclick="document.querySelector('.sidebar').classList.toggle('open')"
+            aria-label="Toggle sidebar"
+          >
+            &#9776;
+          </button>
+          <a href="/" class="nav-brand"> <span class="prompt">$</span> aimock </a>
+        </div>
+        <ul class="nav-links">
+          <li><a href="/">Home</a></li>
+          <li><a href="/docs" style="color: var(--accent)">Docs</a></li>
+          <li>
+            <a href="https://github.com/CopilotKit/aimock" class="gh-link" target="_blank"
+              ><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+              GitHub</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="docs-layout">
+      <aside class="sidebar" id="sidebar"></aside>
+
+      <main class="docs-content">
+        <h1>PydanticAI</h1>
+        <p class="lead">
+          Test your PydanticAI agents with deterministic responses. aimock handles structured output
+          validation, tool calls, and streaming &mdash; all without API keys.
+        </p>
+
+        <h2>Quick Start</h2>
+        <p>
+          PydanticAI agents accept a custom <code>base_url</code> through their model configuration.
+          Point it at aimock and use any string for the API key:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">agent.py <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">from</span> pydantic_ai <span class="kw">import</span> Agent
+<span class="kw">from</span> pydantic_ai.models.openai <span class="kw">import</span> OpenAIChatModel
+<span class="kw">from</span> pydantic_ai.providers.openai <span class="kw">import</span> OpenAIProvider
+
+model = OpenAIChatModel(
+    <span class="str">"gpt-4o"</span>,
+    provider=OpenAIProvider(
+        base_url=<span class="str">"http://localhost:4010/v1"</span>,
+        api_key=<span class="str">"test"</span>,
+    ),
+)
+agent = Agent(model)</code></pre>
+        </div>
+
+        <p>Start aimock with a fixture file, then run your agent:</p>
+        <div class="code-block">
+          <div class="code-block-header">Terminal <span class="lang-tag">shell</span></div>
+          <pre><code><span class="cm"># Terminal 1 — start aimock</span>
+npx aimock --fixtures ./fixtures
+
+<span class="cm"># Terminal 2 — run the agent</span>
+python agent.py</code></pre>
+        </div>
+
+        <h2>With aimock-pytest</h2>
+        <p>
+          The <code>aimock-pytest</code> plugin starts and stops the server automatically per test.
+          Install with <code>pip install aimock-pytest</code>. The <code>aimock</code>
+          fixture is provided automatically &mdash; just request it in your test function.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">test_agent.py <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">from</span> pydantic_ai <span class="kw">import</span> Agent
+<span class="kw">from</span> pydantic_ai.models.openai <span class="kw">import</span> OpenAIChatModel
+<span class="kw">from</span> pydantic_ai.providers.openai <span class="kw">import</span> OpenAIProvider
+
+<span class="kw">async def</span> <span class="fn">test_agent_responds</span>(aimock):
+    <span class="cm"># Load fixtures before making LLM calls</span>
+    aimock.load_fixtures(<span class="str">"./fixtures/pydanticai.json"</span>)
+
+    model = OpenAIChatModel(
+        <span class="str">"gpt-4o"</span>,
+        provider=OpenAIProvider(
+            base_url=aimock.url + <span class="str">"/v1"</span>,
+            api_key=<span class="str">"test"</span>,
+        ),
+    )
+    agent = Agent(model)
+    result = <span class="kw">await</span> agent.run(<span class="str">"What is the weather?"</span>)
+    <span class="kw">assert</span> result.output <span class="kw">is not</span> <span class="kw">None</span></code></pre>
+        </div>
+
+        <h2>Structured Output</h2>
+        <p>
+          PydanticAI validates LLM responses against Pydantic models. When your agent expects
+          structured output, PydanticAI uses <strong>tool calls</strong> by default to extract
+          structured data &mdash; not <code>response_format</code>. This means your fixture should
+          return a tool call whose arguments match your Pydantic schema. Use aimock&rsquo;s
+          <code>toolCalls</code> fixture to serve the expected structured response:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            fixtures/structured-output.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"Weather"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"toolCalls"</span>: [
+          {
+            <span class="prop">"name"</span>: <span class="str">"final_result"</span>,
+            <span class="prop">"arguments"</span>: <span class="str">"{\"city\": \"SF\", \"temp\": 72, \"unit\": \"fahrenheit\"}"</span>
+          }
+        ]
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+        <p class="note">
+          <strong>Note:</strong> PydanticAI generates a tool named <code>final_result</code> (by
+          default) whose schema matches your <code>output_type</code> model. The LLM
+          &ldquo;calls&rdquo; this tool with the structured data, and PydanticAI validates the
+          arguments against your Pydantic model. If you need to use
+          <code>response_format</code> instead, you can opt in via
+          <code>Agent(..., result_tool_name=None)</code>, in which case a
+          <code>responseFormat</code> fixture would apply:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            fixtures/structured-output-response-format.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code><span class="cm">// Only needed if you disable tool-based structured output</span>
+{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"responseFormat"</span>: <span class="str">"json_object"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"content"</span>: <span class="str">"{\"city\": \"SF\", \"temp\": 72, \"unit\": \"fahrenheit\"}"</span>
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+
+        <p>The corresponding PydanticAI agent with a typed output:</p>
+        <div class="code-block">
+          <div class="code-block-header">
+            structured_agent.py <span class="lang-tag">python</span>
+          </div>
+          <pre><code><span class="kw">from</span> pydantic <span class="kw">import</span> BaseModel
+<span class="kw">from</span> pydantic_ai <span class="kw">import</span> Agent
+<span class="kw">from</span> pydantic_ai.models.openai <span class="kw">import</span> OpenAIChatModel
+<span class="kw">from</span> pydantic_ai.providers.openai <span class="kw">import</span> OpenAIProvider
+
+<span class="kw">class</span> <span class="fn">Weather</span>(BaseModel):
+    city: str
+    temp: int
+    unit: str
+
+model = OpenAIChatModel(
+    <span class="str">"gpt-4o"</span>,
+    provider=OpenAIProvider(
+        base_url=<span class="str">"http://localhost:4010/v1"</span>,
+        api_key=<span class="str">"test"</span>,
+    ),
+)
+agent = Agent(model, output_type=Weather)
+
+result = agent.run_sync(<span class="str">"Weather in San Francisco"</span>)
+<span class="cm"># result.output is a validated Weather instance</span>
+<span class="kw">assert</span> result.output.city == <span class="str">"SF"</span>
+<span class="kw">assert</span> result.output.temp == <span class="num">72</span></code></pre>
+        </div>
+
+        <h2>Tool Calls</h2>
+        <p>
+          PydanticAI tools use typed function arguments. When an agent invokes a tool, the LLM
+          returns a tool call that PydanticAI validates and dispatches. Use aimock&rsquo;s
+          <code>toolCalls</code> fixture to return deterministic tool invocations:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            fixtures/tool-call.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"fixtures"</span>: [
+    {
+      <span class="prop">"match"</span>: { <span class="prop">"userMessage"</span>: <span class="str">"weather"</span> },
+      <span class="prop">"response"</span>: {
+        <span class="prop">"toolCalls"</span>: [
+          {
+            <span class="prop">"name"</span>: <span class="str">"get_weather"</span>,
+            <span class="prop">"arguments"</span>: <span class="str">"{\"city\": \"San Francisco\"}"</span>
+          }
+        ]
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+
+        <p>The PydanticAI agent that registers and handles the tool:</p>
+        <div class="code-block">
+          <div class="code-block-header">tool_agent.py <span class="lang-tag">python</span></div>
+          <pre><code><span class="kw">from</span> pydantic_ai <span class="kw">import</span> Agent, RunContext
+<span class="kw">from</span> pydantic_ai.models.openai <span class="kw">import</span> OpenAIChatModel
+<span class="kw">from</span> pydantic_ai.providers.openai <span class="kw">import</span> OpenAIProvider
+
+model = OpenAIChatModel(
+    <span class="str">"gpt-4o"</span>,
+    provider=OpenAIProvider(
+        base_url=<span class="str">"http://localhost:4010/v1"</span>,
+        api_key=<span class="str">"test"</span>,
+    ),
+)
+agent = Agent(model)
+
+<span class="kw">@agent.tool</span>
+<span class="kw">async def</span> <span class="fn">get_weather</span>(ctx: RunContext[<span class="kw">None</span>], city: str) -> str:
+    <span class="kw">return</span> <span class="str">f"72F and sunny in {city}"</span>
+
+result = agent.run_sync(<span class="str">"What's the weather?"</span>)
+<span class="cm"># aimock triggers the tool call, PydanticAI dispatches get_weather</span></code></pre>
+        </div>
+
+        <h2>CI with GitHub Action</h2>
+        <p>
+          Use the aimock GitHub Action to run a mock server alongside your Python test suite. No API
+          keys or network access required:
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            .github/workflows/test.yml <span class="lang-tag">yaml</span>
+          </div>
+          <pre><code><span class="prop">name</span>: <span class="str">Tests</span>
+<span class="prop">on</span>: [<span class="str">push</span>, <span class="str">pull_request</span>]
+
+<span class="prop">jobs</span>:
+  <span class="prop">test</span>:
+    <span class="prop">runs-on</span>: <span class="str">ubuntu-latest</span>
+    <span class="prop">steps</span>:
+      - <span class="prop">uses</span>: <span class="str">actions/checkout@v4</span>
+
+      - <span class="prop">uses</span>: <span class="str">actions/setup-python@v5</span>
+        <span class="prop">with</span>:
+          <span class="prop">python-version</span>: <span class="str">"3.12"</span>
+
+      - <span class="prop">uses</span>: <span class="str">CopilotKit/aimock@v1</span>
+        <span class="prop">with</span>:
+          <span class="prop">fixtures</span>: <span class="str">./fixtures</span>
+
+      - <span class="prop">run</span>: <span class="str">pip install pydantic-ai pytest</span>
+
+      - <span class="prop">run</span>: <span class="str">pytest</span>
+        <span class="prop">env</span>:
+          <span class="prop">OPENAI_BASE_URL</span>: <span class="str">http://127.0.0.1:4010/v1</span>
+          <span class="prop">OPENAI_API_KEY</span>: <span class="str">test</span></code></pre>
+        </div>
+        <p>
+          The action starts aimock as a background service on port 4010. Your tests connect via
+          <code>OPENAI_BASE_URL</code> and never hit a real API. See the
+          <a href="/github-action">GitHub Action</a> page for all available inputs.
+        </p>
+      </main>
+      <aside class="page-toc" id="page-toc"></aside>
+    </div>
+    <footer class="docs-footer">
+      <div class="footer-inner">
+        <div class="footer-left"><span>$</span> aimock &middot; MIT License</div>
+        <ul class="footer-links">
+          <li><a href="https://github.com/CopilotKit/aimock" target="_blank">GitHub</a></li>
+          <li>
+            <a href="https://www.npmjs.com/package/@copilotkit/aimock" target="_blank">npm</a>
+          </li>
+        </ul>
+      </div>
+    </footer>
+    <script src="../sidebar.js"></script>
+    <script src="../cli-tabs.js"></script>
+  </body>
+</html>

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -62,6 +62,17 @@
       ],
     },
     {
+      title: "Framework Guides",
+      links: [
+        { label: "LangChain / LangGraph", href: "/integrate-langchain" },
+        { label: "CrewAI", href: "/integrate-crewai" },
+        { label: "PydanticAI", href: "/integrate-pydanticai" },
+        { label: "LlamaIndex", href: "/integrate-llamaindex" },
+        { label: "Mastra", href: "/integrate-mastra" },
+        { label: "Google ADK", href: "/integrate-adk" },
+      ],
+    },
+    {
       title: "Orchestration",
       links: [
         { label: "aimock CLI & Config", href: "/aimock-cli" },

--- a/fixtures/examples/adk/gemini-agent.json
+++ b/fixtures/examples/adk/gemini-agent.json
@@ -1,0 +1,47 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "weather" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "get_weather",
+            "arguments": "{\"city\":\"San Francisco\",\"unit\":\"fahrenheit\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "hello" },
+      "response": {
+        "content": "Hello! I'm an ADK agent running on aimock. How can I help you today?"
+      }
+    },
+    {
+      "match": { "userMessage": "search" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "google_search",
+            "arguments": "{\"query\":\"latest AI news\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "multi-tool" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "get_weather",
+            "arguments": "{\"city\":\"New York\",\"unit\":\"celsius\"}"
+          },
+          {
+            "name": "get_time",
+            "arguments": "{\"timezone\":\"America/New_York\"}"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/fixtures/examples/crewai/multi-agent-crew.json
+++ b/fixtures/examples/crewai/multi-agent-crew.json
@@ -1,0 +1,16 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "research" },
+      "response": {
+        "content": "Based on my research, the key findings are:\n\n1. LLM testing with fixture-based mocks eliminates flaky tests caused by non-deterministic API responses.\n2. Proxy recording captures real interactions for replay in CI without API keys.\n3. Multi-agent frameworks like CrewAI benefit most because each agent multiplies the number of LLM calls per run."
+      }
+    },
+    {
+      "match": { "userMessage": "write" },
+      "response": {
+        "content": "# Testing LLMs in CI\n\nFixture-based mocking brings determinism to AI-powered applications. By replacing real API calls with recorded responses, teams ship faster with confidence.\n\n## Why It Matters\n\nEvery agent in a CrewAI crew makes independent LLM calls. Without mocking, a two-agent crew means two sources of non-determinism per run. With aimock, every call returns the exact same response every time."
+      }
+    }
+  ]
+}

--- a/fixtures/examples/langchain/agent-loop.json
+++ b/fixtures/examples/langchain/agent-loop.json
@@ -1,0 +1,27 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "plan a trip", "sequenceIndex": 0 },
+      "response": {
+        "content": "I'll help plan your trip. Let me look up some options."
+      }
+    },
+    {
+      "match": { "userMessage": "plan a trip", "sequenceIndex": 1 },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "search_flights",
+            "arguments": "{\"origin\":\"SFO\",\"dest\":\"NRT\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "plan a trip", "sequenceIndex": 2 },
+      "response": {
+        "content": "I found 3 flights from SFO to Tokyo Narita. The best option is..."
+      }
+    }
+  ]
+}

--- a/fixtures/examples/llamaindex/aimock-config.json
+++ b/fixtures/examples/llamaindex/aimock-config.json
@@ -1,0 +1,62 @@
+{
+  "llm": {
+    "fixtures": "./rag-pipeline.json"
+  },
+  "vector": {
+    "collections": [
+      {
+        "name": "knowledge-base",
+        "dimension": 3,
+        "vectors": [
+          {
+            "id": "doc-gravity",
+            "values": [0.9, 0.1, 0.05],
+            "metadata": {
+              "source": "physics.pdf",
+              "page": 12,
+              "text": "Gravity is a fundamental force of nature that attracts objects with mass toward one another."
+            }
+          },
+          {
+            "id": "doc-orbits",
+            "values": [0.75, 0.3, 0.15],
+            "metadata": {
+              "source": "physics.pdf",
+              "page": 45,
+              "text": "Orbital mechanics describes the motion of planets and satellites under gravitational influence."
+            }
+          },
+          {
+            "id": "doc-tides",
+            "values": [0.6, 0.5, 0.2],
+            "metadata": {
+              "source": "physics.pdf",
+              "page": 78,
+              "text": "Tidal forces result from the differential gravitational pull of the Moon and Sun on Earth's oceans."
+            }
+          }
+        ],
+        "queryResults": [
+          {
+            "id": "doc-gravity",
+            "score": 0.97,
+            "metadata": {
+              "source": "physics.pdf",
+              "page": 12,
+              "text": "Gravity is a fundamental force of nature that attracts objects with mass toward one another."
+            }
+          },
+          {
+            "id": "doc-orbits",
+            "score": 0.82,
+            "metadata": {
+              "source": "physics.pdf",
+              "page": 45,
+              "text": "Orbital mechanics describes the motion of planets and satellites under gravitational influence."
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/fixtures/examples/llamaindex/rag-pipeline.json
+++ b/fixtures/examples/llamaindex/rag-pipeline.json
@@ -1,0 +1,34 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "What is gravity?" },
+      "response": {
+        "content": "Based on the retrieved documents, gravity is a fundamental force of nature that attracts objects with mass toward one another. It is described by Newton's law of universal gravitation and Einstein's general theory of relativity."
+      }
+    },
+    {
+      "match": { "userMessage": "Summarize the document" },
+      "response": {
+        "content": "The document covers three main topics: gravitational force, orbital mechanics, and tidal effects. It explains how gravity governs planetary motion and influences ocean tides on Earth."
+      }
+    },
+    {
+      "match": { "inputText": "What is gravity?", "endpoint": "embedding" },
+      "response": {
+        "embedding": [0.9, 0.1, 0.05]
+      }
+    },
+    {
+      "match": { "inputText": "Gravity is a fundamental force", "endpoint": "embedding" },
+      "response": {
+        "embedding": [0.88, 0.12, 0.07]
+      }
+    },
+    {
+      "match": { "inputText": "orbital mechanics and planetary motion", "endpoint": "embedding" },
+      "response": {
+        "embedding": [0.75, 0.3, 0.15]
+      }
+    }
+  ]
+}

--- a/fixtures/examples/mastra/agent-workflow.json
+++ b/fixtures/examples/mastra/agent-workflow.json
@@ -1,0 +1,32 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "plan a trip", "sequenceIndex": 0 },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "search_flights",
+            "arguments": "{\"origin\":\"SFO\",\"destination\":\"NRT\",\"date\":\"2025-03-15\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "plan a trip", "sequenceIndex": 1 },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "search_hotels",
+            "arguments": "{\"city\":\"Tokyo\",\"checkIn\":\"2025-03-15\",\"checkOut\":\"2025-03-22\"}"
+          }
+        ]
+      }
+    },
+    {
+      "match": { "userMessage": "plan a trip", "sequenceIndex": 2 },
+      "response": {
+        "content": "I found a great itinerary for your Tokyo trip!\n\n**Flight:** SFO → NRT on March 15, departing 11:30 AM (United UA837) — $890 round trip\n\n**Hotel:** Hotel Gracery Shinjuku, March 15–22 — $185/night\n\nWould you like me to book these, or would you prefer different options?"
+      }
+    }
+  ]
+}

--- a/fixtures/examples/pydanticai/structured-output.json
+++ b/fixtures/examples/pydanticai/structured-output.json
@@ -1,0 +1,15 @@
+{
+  "fixtures": [
+    {
+      "match": { "userMessage": "Weather" },
+      "response": {
+        "toolCalls": [
+          {
+            "name": "final_result",
+            "arguments": "{\"city\": \"SF\", \"temp\": 72, \"unit\": \"fahrenheit\"}"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/__tests__/fixture-loader.test.ts
+++ b/src/__tests__/fixture-loader.test.ts
@@ -99,6 +99,35 @@ describe("loadFixtureFile", () => {
     expect(fixtures[0].match.userMessage).toBe("hello world");
   });
 
+  it("copies endpoint match field from JSON", () => {
+    const filePath = writeJson(tmpDir, "endpoint.json", {
+      fixtures: [
+        {
+          match: { inputText: "hello world", endpoint: "embedding" },
+          response: { embedding: [0.1, -0.2, 0.3] },
+        },
+      ],
+    });
+
+    const fixtures = loadFixtureFile(filePath);
+    expect(fixtures).toHaveLength(1);
+    expect(fixtures[0].match.endpoint).toBe("embedding");
+  });
+
+  it("leaves match.endpoint undefined when not present in JSON", () => {
+    const filePath = writeJson(tmpDir, "no-endpoint.json", {
+      fixtures: [
+        {
+          match: { userMessage: "hello" },
+          response: { content: "Hi!" },
+        },
+      ],
+    });
+
+    const fixtures = loadFixtureFile(filePath);
+    expect(fixtures[0].match.endpoint).toBeUndefined();
+  });
+
   it("loads inputText match field from JSON", () => {
     const filePath = writeJson(tmpDir, "embed.json", {
       fixtures: [

--- a/src/fixture-loader.ts
+++ b/src/fixture-loader.ts
@@ -18,6 +18,7 @@ export function entryToFixture(entry: FixtureFileEntry): Fixture {
       toolName: entry.match.toolName,
       model: entry.match.model,
       responseFormat: entry.match.responseFormat,
+      endpoint: entry.match.endpoint,
       ...(entry.match.sequenceIndex !== undefined && { sequenceIndex: entry.match.sequenceIndex }),
     },
     response: entry.response,
@@ -371,6 +372,7 @@ export function validateFixtures(fixtures: Fixture[]): ValidationResult[] {
     // Catch-all not in last position
     const match = f.match;
     const hasDiscriminator =
+      match.endpoint !== undefined ||
       match.userMessage !== undefined ||
       match.inputText !== undefined ||
       match.responseFormat !== undefined ||


### PR DESCRIPTION
## Summary

- Add 6 framework integration guides: LangChain, CrewAI, PydanticAI, LlamaIndex, Mastra, Google ADK
- Redesign docs overview page with Quick Start above fold, compact suite table, and correct navigation links
- Fix bug: `entryToFixture()` was silently dropping the `endpoint` match field from JSON fixture files
- Add `endpoint` as discriminator in `validateFixtures()` so endpoint-only fixtures aren't falsely flagged as catch-alls
- Add fixture examples for each framework under `fixtures/examples/`
- Add "Framework Guides" section to sidebar, README, and overview page

## Test plan

- [x] All 2335 tests pass (including 2 new endpoint tests)
- [x] Commitlint passes (all headers under 100 chars)
- [x] Prettier, ESLint, exports checks pass
- [x] 6-round CR loop converged to 0 findings
- [x] All fixture match keys validated against FixtureFileEntry schema
- [x] All inline doc fixtures verified to match shipped fixture files