### PR TITLE
fix: account for page-toc width in docs content centering

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -197,12 +197,15 @@ body::before {
 
 /* ─── Main Content ────────────────────────────────────────────── */
 .docs-content {
-  margin-left: var(--sidebar-width);
   flex: 1;
   padding: 3rem 4rem;
   max-width: 960px;
+  min-width: 0;
   margin-right: auto;
-  margin-left: calc(var(--sidebar-width) + max(0px, (100vw - var(--sidebar-width) - 960px) / 2));
+  margin-left: calc(
+    var(--sidebar-width) + max(0px, (100vw - var(--sidebar-width) - 220px - 960px) / 2)
+  );
+  overflow-wrap: break-word;
 }
 
 .docs-content h1 {
@@ -500,7 +503,9 @@ body::before {
 
 /* ─── Footer ─────────────────────────────────────────────────── */
 .docs-footer {
-  margin-left: calc(var(--sidebar-width) + max(0px, (100vw - var(--sidebar-width) - 960px) / 2));
+  margin-left: calc(
+    var(--sidebar-width) + max(0px, (100vw - var(--sidebar-width) - 220px - 960px) / 2)
+  );
   margin-right: auto;
   padding: 3rem 4rem;
   max-width: 960px;
@@ -599,6 +604,12 @@ body::before {
 @media (max-width: 1200px) {
   .page-toc {
     display: none;
+  }
+  .docs-content {
+    margin-left: calc(var(--sidebar-width) + max(0px, (100vw - var(--sidebar-width) - 960px) / 2));
+  }
+  .docs-footer {
+    margin-left: calc(var(--sidebar-width) + max(0px, (100vw - var(--sidebar-width) - 960px) / 2));
   }
 }
 


### PR DESCRIPTION
## Summary

- Content was centered between sidebar and viewport edge, ignoring the 220px TOC
- At larger font sizes, content overflowed rightward into the TOC
- Subtracts TOC width from centering calc for both `.docs-content` and `.docs-footer`
- Media query restores original calc when TOC is hidden below 1200px

Follow-up to #109 — this fix was in the redone commits but the PR was merged before the force-push landed.

## Test plan

- [x] Visual check at default and enlarged font sizes
- [x] Content bounded by both sidebar and TOC
- [x] Layout correct when TOC hidden (< 1200px viewport)