### PR TITLE
fix: use scoped npx @copilotkit/aimock in all docs and scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Minor Changes
 
 - Add GitHub Action for one-line CI setup — `uses: CopilotKit/aimock@v1` with fixtures, config, port, args, and health check (#102)
-- Wire fixture converters into CLI — `npx aimock convert vidaimock` and `npx aimock convert mockllm` as first-class subcommands (#102)
+- Wire fixture converters into CLI — `npx @copilotkit/aimock convert vidaimock` and `npx @copilotkit/aimock convert mockllm` as first-class subcommands (#102)
 - Add 30 npm keywords for search discoverability (#102)
 - Add fixture gallery with 11 examples covering all mock types, plus browsable docs page at /examples (#102)
 - Add vitest and jest plugins for zero-config testing — `import { useAimock } from "@copilotkit/aimock/vitest"` (#102)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ aimock mocks everything your AI app talks to:
 | **VectorMock** | Pinecone, Qdrant, ChromaDB compatible endpoints                   | [Vector](https://aimock.copilotkit.dev/vector-mock) |
 | **Services**   | Tavily search, Cohere rerank, OpenAI moderation                   | [Services](https://aimock.copilotkit.dev/services)  |
 
-Run them all on one port with `npx aimock --config aimock.json`, or use the programmatic API to compose exactly what you need.
+Run them all on one port with `npx @copilotkit/aimock --config aimock.json`, or use the programmatic API to compose exactly what you need.
 
 ## Features
 
@@ -72,17 +72,17 @@ See the [GitHub Action docs](https://aimock.copilotkit.dev/github-action) for al
 
 ```bash
 # LLM mocking only
-npx aimock -p 4010 -f ./fixtures
+npx @copilotkit/aimock -p 4010 -f ./fixtures
 
 # Full suite from config
-npx aimock --config aimock.json
+npx @copilotkit/aimock --config aimock.json
 
 # Record mode: proxy to real APIs, save fixtures
-npx aimock --record --provider-openai https://api.openai.com
+npx @copilotkit/aimock --record --provider-openai https://api.openai.com
 
 # Convert fixtures from other tools
-npx aimock convert vidaimock ./templates/ ./fixtures/
-npx aimock convert mockllm ./config.yaml ./fixtures/
+npx @copilotkit/aimock convert vidaimock ./templates/ ./fixtures/
+npx @copilotkit/aimock convert mockllm ./config.yaml ./fixtures/
 
 # Docker
 docker run -d -p 4010:4010 -v ./fixtures:/fixtures ghcr.io/copilotkit/aimock -f /fixtures

--- a/docs/agui-mock/index.html
+++ b/docs/agui-mock/index.html
@@ -241,7 +241,7 @@ agui.<span class="fn">enableRecording</span>({
         <h2>CLI Usage</h2>
         <div class="code-block">
           <div class="code-block-header">CLI flags <span class="lang-tag">shell</span></div>
-          <pre><code>npx aimock --fixtures ./fixtures \
+          <pre><code>npx @copilotkit/aimock --fixtures ./fixtures \
   --agui-record \
   --agui-upstream http://localhost:8000/agent</code></pre>
         </div>

--- a/docs/aimock-cli/index.html
+++ b/docs/aimock-cli/index.html
@@ -59,7 +59,7 @@
           <div class="tab-cli">
             <div class="code-block">
               <div class="code-block-header">Run aimock <span class="lang-tag">shell</span></div>
-              <pre><code>$ npx aimock --config aimock.json --port 4010</code></pre>
+              <pre><code>$ npx @copilotkit/aimock --config aimock.json --port 4010</code></pre>
             </div>
           </div>
           <div class="tab-docker">
@@ -69,7 +69,7 @@
   -v ./aimock.json:/config.json \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock --config /config.json --port 4010</code></pre>
+  npx @copilotkit/aimock --config /config.json --port 4010</code></pre>
             </div>
           </div>
         </div>
@@ -228,7 +228,7 @@
               <div class="code-block-header">
                 Run with config <span class="lang-tag">shell</span>
               </div>
-              <pre><code>$ npx aimock --config aimock.json --host 0.0.0.0</code></pre>
+              <pre><code>$ npx @copilotkit/aimock --config aimock.json --host 0.0.0.0</code></pre>
             </div>
           </div>
           <div class="tab-docker">
@@ -241,7 +241,7 @@ $ docker run -p 4010:4010 \
   -v ./aimock.json:/config.json \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock --config /config.json --host 0.0.0.0</code></pre>
+  npx @copilotkit/aimock --config /config.json --host 0.0.0.0</code></pre>
             </div>
           </div>
         </div>
@@ -252,7 +252,7 @@ $ docker run -p 4010:4010 \
         <h3>Usage</h3>
         <div class="code-block">
           <div class="code-block-header">Convert fixtures <span class="lang-tag">shell</span></div>
-          <pre><code>npx aimock convert &lt;format&gt; &lt;input&gt; [output]</code></pre>
+          <pre><code>npx @copilotkit/aimock convert &lt;format&gt; &lt;input&gt; [output]</code></pre>
         </div>
 
         <h3>Supported Formats</h3>
@@ -290,13 +290,13 @@ $ docker run -p 4010:4010 \
             Converter examples <span class="lang-tag">shell</span>
           </div>
           <pre><code><span class="cm"># Convert a directory of VidaiMock templates</span>
-$ npx aimock convert vidaimock ./templates/ ./fixtures/converted.json
+$ npx @copilotkit/aimock convert vidaimock ./templates/ ./fixtures/converted.json
 
 <span class="cm"># Convert a mock-llm YAML config</span>
-$ npx aimock convert mockllm ./config.yaml ./fixtures/converted.json
+$ npx @copilotkit/aimock convert mockllm ./config.yaml ./fixtures/converted.json
 
 <span class="cm"># Print to stdout (omit output path)</span>
-$ npx aimock convert vidaimock ./templates/</code></pre>
+$ npx @copilotkit/aimock convert vidaimock ./templates/</code></pre>
         </div>
 
         <h2>Docker Compose</h2>

--- a/docs/chaos-testing/index.html
+++ b/docs/chaos-testing/index.html
@@ -217,7 +217,7 @@
               <div class="code-block-header">
                 CLI chaos flags <span class="lang-tag">shell</span>
               </div>
-              <pre><code>$ npx aimock --fixtures ./fixtures \
+              <pre><code>$ npx @copilotkit/aimock --fixtures ./fixtures \
   --chaos-drop 0.1 \
   --chaos-malformed 0.05 \
   --chaos-disconnect 0.02</code></pre>
@@ -231,7 +231,7 @@
               <pre><code>$ docker run -d -p 4010:4010 \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock --fixtures /fixtures \
+  npx @copilotkit/aimock --fixtures /fixtures \
   --chaos-drop 0.1 \
   --chaos-malformed 0.05 \
   --chaos-disconnect 0.02</code></pre>

--- a/docs/docker/index.html
+++ b/docs/docker/index.html
@@ -66,10 +66,10 @@
           <div class="tab-cli">
             <div class="code-block">
               <div class="code-block-header">Run <span class="lang-tag">shell</span></div>
-              <pre><code>$ npx aimock --fixtures ./fixtures
+              <pre><code>$ npx @copilotkit/aimock --fixtures ./fixtures
 
 <span class="cm"># Custom port</span>
-$ npx aimock --fixtures ./fixtures --port 5555</code></pre>
+$ npx @copilotkit/aimock --fixtures ./fixtures --port 5555</code></pre>
             </div>
           </div>
           <div class="tab-docker">
@@ -84,7 +84,7 @@ $ docker run -p 4010:4010 \
 $ docker run -p 5555:5555 \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock --fixtures /fixtures --port 5555
+  --fixtures /fixtures --port 5555
 
 <span class="cm"># Pull from GitHub Container Registry</span>
 $ docker pull ghcr.io/copilotkit/aimock:latest

--- a/docs/images/index.html
+++ b/docs/images/index.html
@@ -264,7 +264,7 @@
 
         <div class="code-block">
           <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-          <pre><code>npx aimock --record --provider-openai https://api.openai.com</code></pre>
+          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com</code></pre>
         </div>
       </main>
       <aside class="page-toc" id="page-toc"></aside>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1225,7 +1225,7 @@
                 <span class="title">terminal</span>
               </div>
               <div class="demo-body">
-                <pre><span class="t-green">$</span> npx aimock --record --provider-openai https://api.openai.com
+                <pre><span class="t-green">$</span> npx @copilotkit/aimock --record --provider-openai https://api.openai.com
 
 <span class="t-blue">&#9889;</span> Listening on http://localhost:4010
 
@@ -1329,7 +1329,7 @@
               <span class="title">terminal</span>
             </div>
             <div class="demo-body">
-              <pre><span class="t-green">$</span> npx aimock --config aimock.json
+              <pre><span class="t-green">$</span> npx @copilotkit/aimock --config aimock.json
 
 <span class="t-blue">&#9889;</span> aimock v1.0.0
 
@@ -1875,7 +1875,7 @@
       // ── Terminal demo animation ──────────────────────────────────────
       var termSteps = [
         // Step 1: User types command
-        { type: "prompt", text: "npx aimock -p 4010 -f ./fixture.json", delay: 600 },
+        { type: "prompt", text: "npx @copilotkit/aimock -p 4010 -f ./fixture.json", delay: 600 },
         // Step 2: Server starts
         {
           type: "line",

--- a/docs/integrate-adk/index.html
+++ b/docs/integrate-adk/index.html
@@ -78,7 +78,7 @@ client = genai.<span class="fn">Client</span>(
         </p>
         <div class="code-block">
           <div class="code-block-header">Start aimock <span class="lang-tag">shell</span></div>
-          <pre><code>npx aimock --fixtures fixtures/examples/adk/gemini-agent.json</code></pre>
+          <pre><code>npx @copilotkit/aimock --fixtures fixtures/examples/adk/gemini-agent.json</code></pre>
         </div>
 
         <h2>Gemini API Format</h2>

--- a/docs/integrate-crewai/index.html
+++ b/docs/integrate-crewai/index.html
@@ -72,7 +72,7 @@
                 <span class="lang-tag">shell</span>
               </div>
               <pre><code><span class="cm"># Terminal 1 &mdash; start the mock server</span>
-npx aimock --fixtures ./fixtures
+npx @copilotkit/aimock --fixtures ./fixtures
 
 <span class="cm"># Terminal 2 &mdash; run your CrewAI script</span>
 <span class="kw">export</span> OPENAI_BASE_URL=http://localhost:4010/v1
@@ -333,7 +333,7 @@ result = crew.kickoff()</code></pre>
         <div class="code-block">
           <div class="code-block-header">Record a crew run <span class="lang-tag">shell</span></div>
           <pre><code><span class="cm"># Start aimock in record mode &mdash; unmatched requests go to OpenAI</span>
-npx aimock --fixtures ./fixtures \
+npx @copilotkit/aimock --fixtures ./fixtures \
   --record \
   --provider-openai https://api.openai.com
 

--- a/docs/integrate-langchain/index.html
+++ b/docs/integrate-langchain/index.html
@@ -62,7 +62,7 @@
           <div class="code-block-header">Minimal setup <span class="lang-tag">python</span></div>
           <pre><code><span class="kw">from</span> langchain_openai <span class="kw">import</span> ChatOpenAI
 
-<span class="cm"># Start aimock first: npx aimock --fixtures ./fixtures</span>
+<span class="cm"># Start aimock first: npx @copilotkit/aimock --fixtures ./fixtures</span>
 llm = <span class="fn">ChatOpenAI</span>(
     base_url=<span class="str">"http://localhost:4010/v1"</span>,
     api_key=<span class="str">"test"</span>,
@@ -182,7 +182,7 @@ result = llm.<span class="fn">invoke</span>(<span class="str">"hello"</span>)
         </p>
         <div class="code-block">
           <div class="code-block-header">Record a session <span class="lang-tag">shell</span></div>
-          <pre><code>npx aimock --record --provider-openai https://api.openai.com -f ./fixtures</code></pre>
+          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com -f ./fixtures</code></pre>
         </div>
         <p>
           Then point your LangChain code at <code>http://localhost:4010/v1</code> and run your agent
@@ -192,7 +192,7 @@ result = llm.<span class="fn">invoke</span>(<span class="str">"hello"</span>)
         <div class="code-block">
           <div class="code-block-header">Replay in tests <span class="lang-tag">shell</span></div>
           <pre><code><span class="cm"># Replay mode (default when fixtures exist)</span>
-npx aimock -f ./fixtures
+npx @copilotkit/aimock -f ./fixtures
 
 <span class="cm"># Run your tests against the recorded fixtures</span>
 pytest tests/</code></pre>

--- a/docs/integrate-llamaindex/index.html
+++ b/docs/integrate-llamaindex/index.html
@@ -83,7 +83,7 @@ response = query_engine.query(<span class="str">"What is gravity?"</span>)</code
         <p>Start aimock with fixtures that match the queries your pipeline will send:</p>
         <div class="code-block">
           <div class="code-block-header">Terminal <span class="lang-tag">shell</span></div>
-          <pre><code>npx aimock --fixtures ./fixtures/llamaindex</code></pre>
+          <pre><code>npx @copilotkit/aimock --fixtures ./fixtures/llamaindex</code></pre>
         </div>
 
         <h2>Mock Both LLM and Vector DB</h2>
@@ -145,8 +145,8 @@ response = query_engine.query(<span class="str">"What is gravity?"</span>)</code
 }</code></pre>
         </div>
         <p>
-          Load both with <code>npx aimock --config aimock.json</code>. The config points to the
-          fixture file via <code>llm.fixtures</code>, so aimock handles both legs of the RAG
+          Load both with <code>npx @copilotkit/aimock --config aimock.json</code>. The config points
+          to the fixture file via <code>llm.fixtures</code>, so aimock handles both legs of the RAG
           pipeline:
         </p>
         <ul>
@@ -281,7 +281,7 @@ embed_model = OpenAIEmbedding(
         <div class="code-block">
           <div class="code-block-header">Record mode <span class="lang-tag">shell</span></div>
           <pre><code><span class="cm"># Record LLM and embedding calls from a live session</span>
-npx aimock \
+npx @copilotkit/aimock \
   --record \
   --provider-openai https://api.openai.com \
   --fixtures ./fixtures/llamaindex

--- a/docs/integrate-pydanticai/index.html
+++ b/docs/integrate-pydanticai/index.html
@@ -82,7 +82,7 @@ agent = Agent(model)</code></pre>
         <div class="code-block">
           <div class="code-block-header">Terminal <span class="lang-tag">shell</span></div>
           <pre><code><span class="cm"># Terminal 1 — start aimock</span>
-npx aimock --fixtures ./fixtures
+npx @copilotkit/aimock --fixtures ./fixtures
 
 <span class="cm"># Terminal 2 — run the agent</span>
 python agent.py</code></pre>

--- a/docs/metrics/index.html
+++ b/docs/metrics/index.html
@@ -80,7 +80,7 @@
               <div class="code-block-header">
                 Enable metrics <span class="lang-tag">shell</span>
               </div>
-              <pre><code>$ npx aimock --fixtures ./fixtures --metrics</code></pre>
+              <pre><code>$ npx @copilotkit/aimock --fixtures ./fixtures --metrics</code></pre>
             </div>
           </div>
           <div class="tab-docker">
@@ -91,7 +91,7 @@
               <pre><code>$ docker run -d -p 4010:4010 \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock --fixtures /fixtures --metrics</code></pre>
+  npx @copilotkit/aimock --fixtures /fixtures --metrics</code></pre>
             </div>
           </div>
         </div>

--- a/docs/migrate-from-mock-llm/index.html
+++ b/docs/migrate-from-mock-llm/index.html
@@ -481,10 +481,10 @@
                 Install &amp; run <span class="lang-tag">sh</span>
               </div>
               <pre><code><span class="cm"># Run the mock server</span>
-npx aimock -p <span class="num">4010</span> -f ./fixtures
+npx @copilotkit/aimock -p <span class="num">4010</span> -f ./fixtures
 
 <span class="cm"># With a full config file</span>
-npx aimock --config aimock.json --port <span class="num">4010</span>
+npx @copilotkit/aimock --config aimock.json --port <span class="num">4010</span>
 
 <span class="cm"># Point your app at the mock</span>
 <span class="kw">export</span> OPENAI_BASE_URL=http://localhost:4010/v1</code></pre>

--- a/docs/migrate-from-mokksy/index.html
+++ b/docs/migrate-from-mokksy/index.html
@@ -137,8 +137,9 @@
         <!-- ─── The quick switch ─────────────────────────────────── -->
         <h2>The quick switch</h2>
         <p>
-          JVM tests can use aimock via Docker or <code>npx aimock</code> if Node.js is available.
-          Point the OpenAI Java SDK at aimock and your existing test assertions stay the same.
+          JVM tests can use aimock via Docker or <code>npx @copilotkit/aimock</code> if Node.js is
+          available. Point the OpenAI Java SDK at aimock and your existing test assertions stay the
+          same.
         </p>
 
         <div class="code-block">
@@ -402,7 +403,7 @@
           <div class="tab-cli">
             <div class="code-block">
               <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-              <pre><code>npx aimock -p <span class="num">4010</span> -f ./fixtures</code></pre>
+              <pre><code>npx @copilotkit/aimock -p <span class="num">4010</span> -f ./fixtures</code></pre>
             </div>
           </div>
           <div class="tab-docker">

--- a/docs/migrate-from-msw/index.html
+++ b/docs/migrate-from-msw/index.html
@@ -257,7 +257,7 @@
             <h3>Record &amp; Replay</h3>
             <p>
               Proxy real APIs, save as fixtures, replay forever.
-              <code>npx aimock --record --provider-openai https://api.openai.com</code>
+              <code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com</code>
             </p>
           </div>
           <div class="feature-card">
@@ -372,7 +372,7 @@
           <div class="tab-cli">
             <div class="code-block">
               <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-              <pre><code>npx aimock -p <span class="num">4010</span> -f ./fixtures</code></pre>
+              <pre><code>npx @copilotkit/aimock -p <span class="num">4010</span> -f ./fixtures</code></pre>
             </div>
           </div>
           <div class="tab-docker">

--- a/docs/migrate-from-piyook/index.html
+++ b/docs/migrate-from-piyook/index.html
@@ -395,10 +395,10 @@
                 Install &amp; run <span class="lang-tag">sh</span>
               </div>
               <pre><code><span class="cm"># Run the mock server</span>
-npx aimock -p <span class="num">4010</span> -f ./fixtures
+npx @copilotkit/aimock -p <span class="num">4010</span> -f ./fixtures
 
 <span class="cm"># With a full config file</span>
-npx aimock --config aimock.json --port <span class="num">4010</span>
+npx @copilotkit/aimock --config aimock.json --port <span class="num">4010</span>
 
 <span class="cm"># Point your app at the mock</span>
 <span class="kw">export</span> OPENAI_BASE_URL=http://localhost:4010/v1

--- a/docs/migrate-from-python-mocks/index.html
+++ b/docs/migrate-from-python-mocks/index.html
@@ -193,10 +193,11 @@
         <div class="info-box">
           <p>
             <strong>Two paths for Python teams.</strong> If you have Node.js available,
-            <code>npx aimock</code> starts a mock server in one command &mdash; no Docker needed.
-            The <code>aimock-pytest</code> pip package is in development to provide native pytest
-            fixture integration with automatic server lifecycle management. For Docker-based CI
-            environments, the <code>ghcr.io/copilotkit/aimock</code> image works with any language.
+            <code>npx @copilotkit/aimock</code> starts a mock server in one command &mdash; no
+            Docker needed. The <code>aimock-pytest</code> pip package is in development to provide
+            native pytest fixture integration with automatic server lifecycle management. For
+            Docker-based CI environments, the <code>ghcr.io/copilotkit/aimock</code> image works
+            with any language.
           </p>
         </div>
 
@@ -435,7 +436,7 @@
                 Install &amp; run <span class="lang-tag">sh</span>
               </div>
               <pre><code><span class="cm"># Run the mock server (requires Node.js)</span>
-npx aimock -p <span class="num">4010</span> -f ./fixtures
+npx @copilotkit/aimock -p <span class="num">4010</span> -f ./fixtures
 
 <span class="cm"># Point your Python app at the mock</span>
 <span class="kw">export</span> OPENAI_BASE_URL=http://localhost:4010/v1
@@ -478,7 +479,7 @@ pytest</code></pre>
         <h2>Alternative: npx fixture (no Docker)</h2>
         <p>
           If Node.js is available in your environment, you can skip Docker entirely and use
-          <code>npx aimock</code> directly from your <code>conftest.py</code>.
+          <code>npx @copilotkit/aimock</code> directly from your <code>conftest.py</code>.
         </p>
 
         <div class="code-block">

--- a/docs/migrate-from-vidaimock/index.html
+++ b/docs/migrate-from-vidaimock/index.html
@@ -78,7 +78,7 @@
                 aimock (equivalent)
                 <span class="lang-tag">shell</span>
               </div>
-              <pre><code>npx aimock -p 4010 -f ./fixtures</code></pre>
+              <pre><code>npx @copilotkit/aimock -p 4010 -f ./fixtures</code></pre>
             </div>
           </div>
           <div class="tab-docker">
@@ -90,7 +90,7 @@
               <pre><code>docker run -d -p 4010:4010 \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock -p 4010 -f /fixtures</code></pre>
+  npx @copilotkit/aimock -p 4010 -f /fixtures</code></pre>
             </div>
           </div>
         </div>
@@ -287,7 +287,7 @@
                 <span class="lang-tag">shell</span>
               </div>
               <pre><code><span class="cm"># Run the mock server</span>
-npx aimock -p 4010 -f ./fixtures
+npx @copilotkit/aimock -p 4010 -f ./fixtures
 
 <span class="cm"># Point your app at it</span>
 <span class="kw">export</span> OPENAI_BASE_URL=http://localhost:4010/v1
@@ -300,7 +300,7 @@ npx aimock -p 4010 -f ./fixtures
                 <span class="lang-tag">shell</span>
               </div>
               <pre><code><span class="cm"># Full config-driven setup (LLM + MCP + A2A + AG-UI on one port)</span>
-npx aimock --config aimock.json --port 4010</code></pre>
+npx @copilotkit/aimock --config aimock.json --port 4010</code></pre>
             </div>
           </div>
 

--- a/docs/record-replay/index.html
+++ b/docs/record-replay/index.html
@@ -89,7 +89,7 @@
               <div class="code-block-header">
                 Proxy-only mode <span class="lang-tag">shell</span>
               </div>
-              <pre><code>$ npx aimock --fixtures ./fixtures \
+              <pre><code>$ npx @copilotkit/aimock --fixtures ./fixtures \
   --proxy-only \
   --provider-openai https://api.openai.com</code></pre>
             </div>
@@ -102,7 +102,7 @@
               <pre><code>$ docker run -d -p 4010:4010 \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock -f /fixtures \
+  npx @copilotkit/aimock -f /fixtures \
   --proxy-only \
   --provider-openai https://api.openai.com</code></pre>
             </div>
@@ -140,7 +140,7 @@
           <div class="tab-cli">
             <div class="code-block">
               <div class="code-block-header">CLI usage <span class="lang-tag">shell</span></div>
-              <pre><code>$ npx aimock --fixtures ./fixtures \
+              <pre><code>$ npx @copilotkit/aimock --fixtures ./fixtures \
   --record \
   --provider-openai https://api.openai.com \
   --provider-anthropic https://api.anthropic.com</code></pre>
@@ -152,7 +152,7 @@
               <pre><code>$ docker run -d -p 4010:4010 \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock --fixtures /fixtures \
+  npx @copilotkit/aimock --fixtures /fixtures \
   --record \
   --provider-openai https://api.openai.com \
   --provider-anthropic https://api.anthropic.com</code></pre>
@@ -371,10 +371,10 @@
                 Record then replay <span class="lang-tag">shell</span>
               </div>
               <pre><code># First run: record real API responses
-$ npx aimock --record --provider-openai https://api.openai.com -f ./fixtures
+$ npx @copilotkit/aimock --record --provider-openai https://api.openai.com -f ./fixtures
 
 # Subsequent runs: replay from recorded fixtures
-$ npx aimock -f ./fixtures</code></pre>
+$ npx @copilotkit/aimock -f ./fixtures</code></pre>
             </div>
           </div>
           <div class="tab-docker">
@@ -386,13 +386,13 @@ $ npx aimock -f ./fixtures</code></pre>
 $ docker run -d -p 4010:4010 \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock --record --provider-openai https://api.openai.com -f /fixtures
+  npx @copilotkit/aimock --record --provider-openai https://api.openai.com -f /fixtures
 
 # Subsequent runs: replay from recorded fixtures
 $ docker run -d -p 4010:4010 \
   -v ./fixtures:/fixtures \
   ghcr.io/copilotkit/aimock \
-  npx aimock -f /fixtures</code></pre>
+  npx @copilotkit/aimock -f /fixtures</code></pre>
             </div>
           </div>
         </div>
@@ -413,7 +413,7 @@ $ docker run -d -p 4010:4010 \
       -v ./fixtures:/fixtures \
       -p 4010:4010 \
       ghcr.io/copilotkit/aimock \
-      npx aimock --strict -f /fixtures
+      npx @copilotkit/aimock --strict -f /fixtures
 
 - name: Run tests
   env:
@@ -494,7 +494,7 @@ await mock.start();</code></pre>
             Any language, one server <span class="lang-tag">bash</span>
           </div>
           <pre><code># Docker image serves all languages
-docker run -d -p 4010:4010 ghcr.io/copilotkit/aimock npx aimock -f /fixtures
+docker run -d -p 4010:4010 -v ./fixtures:/fixtures ghcr.io/copilotkit/aimock -f /fixtures
 
 # Python
 import openai

--- a/docs/speech/index.html
+++ b/docs/speech/index.html
@@ -203,7 +203,7 @@
 
         <div class="code-block">
           <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-          <pre><code>npx aimock --record --provider-openai https://api.openai.com</code></pre>
+          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com</code></pre>
         </div>
       </main>
       <aside class="page-toc" id="page-toc"></aside>

--- a/docs/transcription/index.html
+++ b/docs/transcription/index.html
@@ -220,7 +220,7 @@
 
         <div class="code-block">
           <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-          <pre><code>npx aimock --record --provider-openai https://api.openai.com</code></pre>
+          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com</code></pre>
         </div>
       </main>
       <aside class="page-toc" id="page-toc"></aside>

--- a/docs/video/index.html
+++ b/docs/video/index.html
@@ -199,7 +199,7 @@
 
         <div class="code-block">
           <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-          <pre><code>npx aimock --record --provider-openai https://api.openai.com</code></pre>
+          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com</code></pre>
         </div>
       </main>
       <aside class="page-toc" id="page-toc"></aside>

--- a/scripts/convert-mockllm.ts
+++ b/scripts/convert-mockllm.ts
@@ -7,7 +7,7 @@
  *   npx tsx scripts/convert-mockllm.ts <input.yaml> [output.json]
  *
  * Core logic lives in src/convert-mockllm.ts — this script is a thin CLI
- * wrapper. Prefer `npx aimock convert mockllm` instead.
+ * wrapper. Prefer `npx @copilotkit/aimock convert mockllm` instead.
  */
 
 import { readFileSync, writeFileSync } from "node:fs";

--- a/scripts/convert-vidaimock.ts
+++ b/scripts/convert-vidaimock.ts
@@ -7,7 +7,7 @@
  *   npx tsx scripts/convert-vidaimock.ts <input-path> [output-path]
  *
  * Core logic lives in src/convert-vidaimock.ts — this script is a thin CLI
- * wrapper. Prefer `npx aimock convert vidaimock` instead.
+ * wrapper. Prefer `npx @copilotkit/aimock convert vidaimock` instead.
  */
 
 import { writeFileSync, statSync } from "node:fs";


### PR DESCRIPTION
## Summary

- Replace all `npx aimock` references with `npx @copilotkit/aimock` across README, docs site, CHANGELOG, and converter scripts
- `npx aimock` resolves to a **different, unrelated package** on npm (`aimock@0.2.9` — "An OpenAI api simulator") because our package is scoped as `@copilotkit/aimock`
- 26 files, 67 replacements — all CLI examples now use the correct scoped package name

## Test plan

- [x] All 2,313 unit tests pass
- [x] No remaining unscoped `npx aimock` instances (verified with grep)
- [x] No double-scoping (`npx @copilotkit/@copilotkit/aimock`) introduced
- [ ] Verify docs site renders correctly after merge (GitHub Pages)

Closes #112