### PR TITLE
fix: explicitly mark semver releases as Latest

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.check.outputs.published == 'false'
         run: |
           TAG="v${{ steps.check.outputs.version }}"
-          gh release create "${TAG}" --generate-notes --title "${TAG}" --verify-tag
+          gh release create "${TAG}" --generate-notes --title "${TAG}" --verify-tag --latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

`gh release create` is invoked without `--latest`, leaving GitHub's default selector to decide which Release wears the "Latest" badge. When other Release objects exist (notably the floating `v1` Release that has tracked the major version), GitHub can race and flip the badge to a non-semver release unpredictably.

## Fix

Add `--latest` to the `gh release create` invocation in `publish-release.yml` so every future semver release unambiguously claims Latest.

```diff
-          gh release create "${TAG}" --generate-notes --title "${TAG}" --verify-tag
+          gh release create "${TAG}" --generate-notes --title "${TAG}" --verify-tag --latest
```

## Notes

- Orthogonal to #116 (Docker publish chain). Independently useful.
- The floating `v1` Release object is being deleted separately as a one-shot ops action; this PR is **defense in depth** so the badge can never race again, regardless of what other Release objects exist now or in the future.
- Single-line YAML change. Format/lint/build/test all pass locally.

**Do not merge. Do not enable auto-merge.**