### PR TITLE
feat: apply pre-flight chaos to proxy mode (phase 1)

### DIFF
--- a/src/__tests__/chaos-fixture-mode.test.ts
+++ b/src/__tests__/chaos-fixture-mode.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import { createServer, type ServerInstance } from "../server.js";
+
+// minimal helpers duplicated to keep this test isolated
+import * as http from "node:http";
+
+function post(url: string, body: unknown): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+let server: ServerInstance | undefined;
+let tmpDir: string | undefined;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((resolve) => server!.server.close(() => resolve()));
+    server = undefined;
+  }
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+});
+
+const CHAT_REQUEST = {
+  model: "gpt-4",
+  messages: [{ role: "user", content: "What is the capital of France?" }],
+};
+
+describe("chaos (fixture mode)", () => {
+  it("pre-flight chaos short-circuits even when fixture would match", async () => {
+    const fixture = {
+      match: { userMessage: "capital of France" },
+      response: { content: "Paris" },
+    };
+
+    server = await createServer([fixture], {
+      port: 0,
+      chaos: { dropRate: 1.0 },
+    });
+
+    const resp = await post(`${server.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    expect(resp.status).toBe(500);
+    const body = JSON.parse(resp.body);
+    expect(body).toMatchObject({ error: { code: "chaos_drop" } });
+  });
+});

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -225,6 +225,25 @@ describe("proxy-only mode", () => {
     await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
   });
 
+  it("applies chaos BEFORE proxying (drop)", async () => {
+    const countingUpstream = await createCountingUpstream("should not be hit");
+
+    recorder = await createServer([], {
+      port: 0,
+      chaos: { dropRate: 1.0 },
+      record: {
+        providers: { openai: countingUpstream.url },
+        fixturePath: fs.mkdtempSync(path.join(os.tmpdir(), "aimock-chaos-proxy-")),
+        proxyOnly: true,
+      },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    expect(resp.status).toBe(500);
+    expect(countingUpstream.getCount()).toBe(0);
+  });
+
   it("regular record mode DOES cache in memory — second request served from cache", async () => {
     // Use a counting upstream to verify only the first request is proxied
     const countingUpstream = await createCountingUpstream("cached response");

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -268,6 +268,24 @@ describe("proxy-only mode", () => {
     await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
   });
 
+  it("pre-flight chaos short-circuits even when fixture would match", async () => {
+    // fixture that WOULD match
+    const fixture = {
+      match: { userMessage: "capital of France" },
+      response: { content: "Paris" },
+    };
+
+    recorder = await createServer([fixture], {
+      port: 0,
+      chaos: { dropRate: 1.0 },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    // should be dropped before fixture is used
+    expect(resp.status).toBe(500);
+  });
+
   it("regular record mode DOES cache in memory — second request served from cache", async () => {
     // Use a counting upstream to verify only the first request is proxied
     const countingUpstream = await createCountingUpstream("cached response");

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -233,7 +233,7 @@ describe("proxy-only mode", () => {
       chaos: { dropRate: 1.0 },
       record: {
         providers: { openai: countingUpstream.url },
-        fixturePath: fs.mkdtempSync(path.join(os.tmpdir(), "aimock-chaos-proxy-")),
+        fixturePath: (tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-chaos-proxy-"))),
         proxyOnly: true,
       },
     });
@@ -242,6 +242,30 @@ describe("proxy-only mode", () => {
 
     expect(resp.status).toBe(500);
     expect(countingUpstream.getCount()).toBe(0);
+
+    await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
+  });
+
+  it("applies chaos BEFORE proxying (disconnect)", async () => {
+    const countingUpstream = await createCountingUpstream("should not be hit");
+
+    recorder = await createServer([], {
+      port: 0,
+      chaos: { disconnectRate: 1.0 },
+      record: {
+        providers: { openai: countingUpstream.url },
+        fixturePath: (tmpDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "aimock-chaos-proxy-disconnect-"),
+        )),
+        proxyOnly: true,
+      },
+    });
+
+    await expect(post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST)).rejects.toThrow();
+
+    expect(countingUpstream.getCount()).toBe(0);
+
+    await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
   });
 
   it("regular record mode DOES cache in memory — second request served from cache", async () => {

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -267,31 +267,6 @@ describe("proxy-only mode", () => {
 
     await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
   });
-});
-
-describe("chaos (fixture mode)", () => {
-  it("pre-flight chaos short-circuits even when fixture would match", async () => {
-    // fixture that WOULD match
-    const fixture = {
-      match: { userMessage: "capital of France" },
-      response: { content: "Paris" },
-    };
-
-    recorder = await createServer([fixture], {
-      port: 0,
-      chaos: { dropRate: 1.0 },
-    });
-
-    const resp = await post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST);
-
-    // should be dropped before fixture is used
-    expect(resp.status).toBe(500);
-    const body = JSON.parse(resp.body);
-    expect(body).toMatchObject({
-      error: { code: "chaos_drop" },
-    });
-  });
-
   it("regular record mode DOES cache in memory — second request served from cache", async () => {
     // Use a counting upstream to verify only the first request is proxied
     const countingUpstream = await createCountingUpstream("cached response");

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -267,7 +267,9 @@ describe("proxy-only mode", () => {
 
     await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
   });
+});
 
+describe("chaos (fixture mode)", () => {
   it("pre-flight chaos short-circuits even when fixture would match", async () => {
     // fixture that WOULD match
     const fixture = {
@@ -284,6 +286,10 @@ describe("proxy-only mode", () => {
 
     // should be dropped before fixture is used
     expect(resp.status).toBe(500);
+    const body = JSON.parse(resp.body);
+    expect(body).toMatchObject({
+      error: { code: "chaos_drop" },
+    });
   });
 
   it("regular record mode DOES cache in memory — second request served from cache", async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -400,7 +400,8 @@ async function handleCompletions(
   const method = req.method ?? "POST";
   const path = req.url ?? COMPLETIONS_PATH;
   const flatHeaders = flattenHeaders(req.headers);
-  // Ensure endpoint type is present for pre-flight journal entries
+
+  // Set endpoint type once early so router/recorder and journal see it
   body._endpointType = "chat";
 
   // Pre-flight chaos: run before fixture matching or proxying

--- a/src/server.ts
+++ b/src/server.ts
@@ -397,6 +397,30 @@ async function handleCompletions(
     return;
   }
 
+  const method = req.method ?? "POST";
+  const path = req.url ?? COMPLETIONS_PATH;
+  const flatHeaders = flattenHeaders(req.headers);
+
+  // Pre-flight chaos: run before fixture matching or proxying
+  if (
+    applyChaos(
+      res,
+      null,
+      defaults.chaos,
+      req.headers,
+      journal,
+      {
+        method,
+        path,
+        headers: flatHeaders,
+        body,
+      },
+      defaults.registry,
+      defaults.logger,
+    )
+  )
+    return;
+
   // Match fixture
   body._endpointType = "chat";
   const testId = getTestId(req);
@@ -411,11 +435,7 @@ async function handleCompletions(
     journal.incrementFixtureMatchCount(fixture, fixtures, testId);
   }
 
-  const method = req.method ?? "POST";
-  const path = req.url ?? COMPLETIONS_PATH;
-  const flatHeaders = flattenHeaders(req.headers);
-
-  // Apply chaos before normal response handling
+  // Post-match chaos (preserves existing fixture-level behavior like malformed)
   if (
     applyChaos(
       res,

--- a/src/server.ts
+++ b/src/server.ts
@@ -425,7 +425,6 @@ async function handleCompletions(
     return;
 
   // Match fixture
-  body._endpointType = "chat";
   const testId = getTestId(req);
   const fixture = matchFixture(
     fixtures,

--- a/src/server.ts
+++ b/src/server.ts
@@ -400,6 +400,8 @@ async function handleCompletions(
   const method = req.method ?? "POST";
   const path = req.url ?? COMPLETIONS_PATH;
   const flatHeaders = flattenHeaders(req.headers);
+  // Ensure endpoint type is present for pre-flight journal entries
+  body._endpointType = "chat";
 
   // Pre-flight chaos: run before fixture matching or proxying
   if (
@@ -435,7 +437,10 @@ async function handleCompletions(
     journal.incrementFixtureMatchCount(fixture, fixtures, testId);
   }
 
-  // Post-match chaos (preserves existing fixture-level behavior like malformed)
+  // NOTE: Chaos may be evaluated twice (pre-flight + post-match), which
+  // increases effective trigger probability for non-boundary rates.
+  // This is an intentional tradeoff to enable pre-flight chaos without
+  // refactoring the existing applyChaos flow.
   if (
     applyChaos(
       res,


### PR DESCRIPTION
## Summary

Applies chaos before routing so it affects proxy mode. This introduces pre-flight chaos (drop, disconnect) that runs before fixture matching and proxying.

## Changes

- Run `applyChaos` pre-flight with `fixture = null`
- Preserve existing post-match chaos to maintain fixture-level behavior
- Set `_endpointType` once early (removed duplicate assignment later in flow)
- Add test ensuring drop prevents proxy call
- Add disconnect test
- Add fixture-mode pre-flight chaos test
- Fix test resource cleanup (no leaked servers or temp dirs)

## Scope

- drop
- disconnect

## Why

Previously, chaos was skipped for proxy paths, making proxied responses unrealistically reliable.

This change ensures chaos applies consistently across fixture and proxy flows.

## Behavior Note

Chaos is evaluated both pre-flight and post-match, which can increase effective trigger probability for non-boundary rates (p → p(2 - p)). This is an intentional tradeoff to enable pre-flight chaos without refactoring the existing flow.

## Tests

- New: drop in proxy mode prevents upstream call
- New: disconnect in proxy mode prevents upstream call
- New: fixture-mode pre-flight chaos short-circuits matching
- Fixed: test cleanup (no leaked servers or temp dirs)
- All existing tests pass

## Notes

- Minimal change: no modifications to proxy or writer layers
- Future work will split pre/post phases to remove double evaluation (and add latency handling)