### PR TITLE
docs: sweep remaining npx invocations to llmock bin (follow-up to #123)

### DIFF
--- a/docs/agui-mock/index.html
+++ b/docs/agui-mock/index.html
@@ -241,7 +241,7 @@ agui.<span class="fn">enableRecording</span>({
         <h2>CLI Usage</h2>
         <div class="code-block">
           <div class="code-block-header">CLI flags <span class="lang-tag">shell</span></div>
-          <pre><code>npx @copilotkit/aimock --fixtures ./fixtures \
+          <pre><code>npx -p @copilotkit/aimock llmock --fixtures ./fixtures \
   --agui-record \
   --agui-upstream http://localhost:8000/agent</code></pre>
         </div>

--- a/docs/docker/index.html
+++ b/docs/docker/index.html
@@ -66,10 +66,10 @@
           <div class="tab-cli">
             <div class="code-block">
               <div class="code-block-header">Run <span class="lang-tag">shell</span></div>
-              <pre><code>$ npx @copilotkit/aimock --fixtures ./fixtures
+              <pre><code>$ npx -p @copilotkit/aimock llmock --fixtures ./fixtures
 
 <span class="cm"># Custom port</span>
-$ npx @copilotkit/aimock --fixtures ./fixtures --port 5555</code></pre>
+$ npx -p @copilotkit/aimock llmock --fixtures ./fixtures --port 5555</code></pre>
             </div>
           </div>
           <div class="tab-docker">

--- a/docs/images/index.html
+++ b/docs/images/index.html
@@ -264,7 +264,7 @@
 
         <div class="code-block">
           <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com</code></pre>
+          <pre><code>npx -p @copilotkit/aimock llmock --record --provider-openai https://api.openai.com</code></pre>
         </div>
       </main>
       <aside class="page-toc" id="page-toc"></aside>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1225,7 +1225,7 @@
                 <span class="title">terminal</span>
               </div>
               <div class="demo-body">
-                <pre><span class="t-green">$</span> npx @copilotkit/aimock --record --provider-openai https://api.openai.com
+                <pre><span class="t-green">$</span> npx -p @copilotkit/aimock llmock --record --provider-openai https://api.openai.com
 
 <span class="t-blue">&#9889;</span> Listening on http://localhost:4010
 
@@ -1876,7 +1876,11 @@
       // ── Terminal demo animation ──────────────────────────────────────
       var termSteps = [
         // Step 1: User types command
-        { type: "prompt", text: "npx @copilotkit/aimock -p 4010 -f ./fixture.json", delay: 600 },
+        {
+          type: "prompt",
+          text: "npx -p @copilotkit/aimock llmock -p 4010 -f ./fixture.json",
+          delay: 600,
+        },
         // Step 2: Server starts
         {
           type: "line",

--- a/docs/integrate-adk/index.html
+++ b/docs/integrate-adk/index.html
@@ -78,7 +78,7 @@ client = genai.<span class="fn">Client</span>(
         </p>
         <div class="code-block">
           <div class="code-block-header">Start aimock <span class="lang-tag">shell</span></div>
-          <pre><code>npx @copilotkit/aimock --fixtures fixtures/examples/adk/gemini-agent.json</code></pre>
+          <pre><code>npx -p @copilotkit/aimock llmock --fixtures fixtures/examples/adk/gemini-agent.json</code></pre>
         </div>
 
         <h2>Gemini API Format</h2>

--- a/docs/integrate-crewai/index.html
+++ b/docs/integrate-crewai/index.html
@@ -72,7 +72,7 @@
                 <span class="lang-tag">shell</span>
               </div>
               <pre><code><span class="cm"># Terminal 1 &mdash; start the mock server</span>
-npx @copilotkit/aimock --fixtures ./fixtures
+npx -p @copilotkit/aimock llmock --fixtures ./fixtures
 
 <span class="cm"># Terminal 2 &mdash; run your CrewAI script</span>
 <span class="kw">export</span> OPENAI_BASE_URL=http://localhost:4010/v1
@@ -333,7 +333,7 @@ result = crew.kickoff()</code></pre>
         <div class="code-block">
           <div class="code-block-header">Record a crew run <span class="lang-tag">shell</span></div>
           <pre><code><span class="cm"># Start aimock in record mode &mdash; unmatched requests go to OpenAI</span>
-npx @copilotkit/aimock --fixtures ./fixtures \
+npx -p @copilotkit/aimock llmock --fixtures ./fixtures \
   --record \
   --provider-openai https://api.openai.com
 

--- a/docs/integrate-langchain/index.html
+++ b/docs/integrate-langchain/index.html
@@ -62,7 +62,7 @@
           <div class="code-block-header">Minimal setup <span class="lang-tag">python</span></div>
           <pre><code><span class="kw">from</span> langchain_openai <span class="kw">import</span> ChatOpenAI
 
-<span class="cm"># Start aimock first: npx @copilotkit/aimock --fixtures ./fixtures</span>
+<span class="cm"># Start aimock first: npx -p @copilotkit/aimock llmock --fixtures ./fixtures</span>
 llm = <span class="fn">ChatOpenAI</span>(
     base_url=<span class="str">"http://localhost:4010/v1"</span>,
     api_key=<span class="str">"test"</span>,
@@ -182,7 +182,7 @@ result = llm.<span class="fn">invoke</span>(<span class="str">"hello"</span>)
         </p>
         <div class="code-block">
           <div class="code-block-header">Record a session <span class="lang-tag">shell</span></div>
-          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com -f ./fixtures</code></pre>
+          <pre><code>npx -p @copilotkit/aimock llmock --record --provider-openai https://api.openai.com -f ./fixtures</code></pre>
         </div>
         <p>
           Then point your LangChain code at <code>http://localhost:4010/v1</code> and run your agent
@@ -192,7 +192,7 @@ result = llm.<span class="fn">invoke</span>(<span class="str">"hello"</span>)
         <div class="code-block">
           <div class="code-block-header">Replay in tests <span class="lang-tag">shell</span></div>
           <pre><code><span class="cm"># Replay mode (default when fixtures exist)</span>
-npx @copilotkit/aimock -f ./fixtures
+npx -p @copilotkit/aimock llmock -f ./fixtures
 
 <span class="cm"># Run your tests against the recorded fixtures</span>
 pytest tests/</code></pre>

--- a/docs/integrate-llamaindex/index.html
+++ b/docs/integrate-llamaindex/index.html
@@ -83,7 +83,7 @@ response = query_engine.query(<span class="str">"What is gravity?"</span>)</code
         <p>Start aimock with fixtures that match the queries your pipeline will send:</p>
         <div class="code-block">
           <div class="code-block-header">Terminal <span class="lang-tag">shell</span></div>
-          <pre><code>npx @copilotkit/aimock --fixtures ./fixtures/llamaindex</code></pre>
+          <pre><code>npx -p @copilotkit/aimock llmock --fixtures ./fixtures/llamaindex</code></pre>
         </div>
 
         <h2>Mock Both LLM and Vector DB</h2>
@@ -281,7 +281,7 @@ embed_model = OpenAIEmbedding(
         <div class="code-block">
           <div class="code-block-header">Record mode <span class="lang-tag">shell</span></div>
           <pre><code><span class="cm"># Record LLM and embedding calls from a live session</span>
-npx @copilotkit/aimock \
+npx -p @copilotkit/aimock llmock \
   --record \
   --provider-openai https://api.openai.com \
   --fixtures ./fixtures/llamaindex

--- a/docs/integrate-maf/index.html
+++ b/docs/integrate-maf/index.html
@@ -69,7 +69,7 @@
 <span class="kw">from</span> agent_framework_openai <span class="kw">import</span> OpenAIChatClient
 <span class="kw">import</span> asyncio
 
-<span class="cm"># Start aimock first: npx @copilotkit/aimock --fixtures ./fixtures</span>
+<span class="cm"># Start aimock first: npx -p @copilotkit/aimock llmock --fixtures ./fixtures</span>
 client = OpenAIChatClient(
     model=<span class="str">"gpt-4o"</span>,
     base_url=<span class="str">"http://localhost:4010/v1"</span>,
@@ -99,7 +99,7 @@ asyncio.run(main())</code></pre>
               <pre><code><span class="kw">using</span> <span class="type">Microsoft.Extensions.AI</span>;
 <span class="kw">using</span> <span class="type">OpenAI</span>;
 
-<span class="cm">// Start aimock first: npx @copilotkit/aimock --fixtures ./fixtures</span>
+<span class="cm">// Start aimock first: npx -p @copilotkit/aimock llmock --fixtures ./fixtures</span>
 <span class="kw">var</span> openaiClient = <span class="kw">new</span> <span class="type">OpenAIClient</span>(
     <span class="kw">new</span> <span class="type">ApiKeyCredential</span>(<span class="str">"test"</span>),
     <span class="kw">new</span> <span class="type">OpenAIClientOptions</span>
@@ -574,7 +574,7 @@ asyncio.run(main())</code></pre>
             Record an agent session <span class="lang-tag">shell</span>
           </div>
           <pre><code><span class="cm"># Start aimock in record mode &mdash; unmatched requests go to OpenAI</span>
-npx @copilotkit/aimock --fixtures ./fixtures \
+npx -p @copilotkit/aimock llmock --fixtures ./fixtures \
   --record \
   --provider-openai https://api.openai.com
 

--- a/docs/integrate-pydanticai/index.html
+++ b/docs/integrate-pydanticai/index.html
@@ -82,7 +82,7 @@ agent = Agent(model)</code></pre>
         <div class="code-block">
           <div class="code-block-header">Terminal <span class="lang-tag">shell</span></div>
           <pre><code><span class="cm"># Terminal 1 — start aimock</span>
-npx @copilotkit/aimock --fixtures ./fixtures
+npx -p @copilotkit/aimock llmock --fixtures ./fixtures
 
 <span class="cm"># Terminal 2 — run the agent</span>
 python agent.py</code></pre>

--- a/docs/metrics/index.html
+++ b/docs/metrics/index.html
@@ -80,7 +80,7 @@
               <div class="code-block-header">
                 Enable metrics <span class="lang-tag">shell</span>
               </div>
-              <pre><code>$ npx @copilotkit/aimock --fixtures ./fixtures --metrics</code></pre>
+              <pre><code>$ npx -p @copilotkit/aimock llmock --fixtures ./fixtures --metrics</code></pre>
             </div>
           </div>
           <div class="tab-docker">

--- a/docs/speech/index.html
+++ b/docs/speech/index.html
@@ -203,7 +203,7 @@
 
         <div class="code-block">
           <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com</code></pre>
+          <pre><code>npx -p @copilotkit/aimock llmock --record --provider-openai https://api.openai.com</code></pre>
         </div>
       </main>
       <aside class="page-toc" id="page-toc"></aside>

--- a/docs/transcription/index.html
+++ b/docs/transcription/index.html
@@ -220,7 +220,7 @@
 
         <div class="code-block">
           <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com</code></pre>
+          <pre><code>npx -p @copilotkit/aimock llmock --record --provider-openai https://api.openai.com</code></pre>
         </div>
       </main>
       <aside class="page-toc" id="page-toc"></aside>

--- a/docs/video/index.html
+++ b/docs/video/index.html
@@ -199,7 +199,7 @@
 
         <div class="code-block">
           <div class="code-block-header">CLI <span class="lang-tag">sh</span></div>
-          <pre><code>npx @copilotkit/aimock --record --provider-openai https://api.openai.com</code></pre>
+          <pre><code>npx -p @copilotkit/aimock llmock --record --provider-openai https://api.openai.com</code></pre>
         </div>
       </main>
       <aside class="page-toc" id="page-toc"></aside>


### PR DESCRIPTION
## Summary

Completes the `npx @copilotkit/aimock -f …` bug-class sweep that PR #123 started. Same mechanical rewrite, applied to the 14 non-migration pages that were out-of-subject for #123 but share the same bug: `npx @copilotkit/aimock` resolves to the config-driven `aimock` bin, which rejects flag-driven args. Use `npx -p @copilotkit/aimock llmock …` instead.

Stacked on #121 (the branch #123 was merged into); base auto-retargets on merge.

## Test plan

- [x] `grep` confirms zero remaining flag-driven `npx @copilotkit/aimock` invocations in docs/
- [x] `prettier --check` clean
- [x] `pnpm test` passes (2437 pass, 26 skipped)