### PR TITLE
feat(cli): support https URL values for --fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @copilotkit/aimock
 
+## 1.14.7
+
+### Added
+
+- `--fixtures` now accepts `https://` and `http://` URLs to JSON fixture files in addition to filesystem paths. Fetches at boot, parses, and registers the remote fixture as if loaded from disk. On-disk cache at `~/.cache/aimock/fixtures/<sha256-of-url>/` (honoring `$XDG_CACHE_HOME`) provides resilience against transient upstream failures: with `--validate-on-load`, a fetch failure with a valid cached copy logs a warning and continues; without a cache, the process exits non-zero. HTTP fetch has a hard-coded 10s timeout and a 50 MB body size cap (enforced incrementally so a lying `Content-Length` cannot bypass it). Only `https://` and `http://` schemes are accepted — `file://`, `ftp://`, etc. are rejected with a clear error. The flag is now repeatable; multiple sources are loaded and concatenated. Tarball (`.tar.gz`) and zip URL support intentionally deferred to a future release.
+- Private-address denylist for remote `--fixtures` URLs: fetches to loopback (`127.0.0.0/8`, `::1`), link-local (`169.254.0.0/16`, `fe80::/10`), RFC1918 (`10/8`, `172.16/12`, `192.168/16`), CGNAT (`100.64/10`), cloud-metadata (`169.254.169.254`), ULA (`fc00::/7`), multicast, and other reserved ranges are rejected with a clear fail-loud error. Hostnames are resolved and every returned address is checked. Set `AIMOCK_ALLOW_PRIVATE_URLS=1` to opt out (required for local dev / tests that target `127.0.0.1`).
+- HTTP redirects are rejected (fail-loud) for remote `--fixtures` URLs to prevent scheme-bypass (a 3xx `Location:` pointing at `file://` or `javascript:` would otherwise sidestep the scheme gate and SSRF denylist). Configure the upstream to serve the final URL directly — GitHub raw content URLs already do this.
+
 ## 1.14.6
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ See the [GitHub Action docs](https://aimock.copilotkit.dev/github-action) for al
 # LLM mocking only
 npx -p @copilotkit/aimock llmock -p 4010 -f ./fixtures
 
+# Remote fixtures — load JSON from an HTTPS URL (repeatable)
+npx -p @copilotkit/aimock llmock -p 4010 \
+  -f https://raw.githubusercontent.com/acme/mocks/main/openai.json \
+  -f ./fixtures/local-overrides.json
+
 # Full suite from config
 npx @copilotkit/aimock --config aimock.json
 
@@ -98,6 +103,12 @@ docker run -d -p 4010:4010 -v "$(pwd)/fixtures:/fixtures" ghcr.io/copilotkit/aim
 ```
 
 > **Note on `llmock` vs `aimock` CLIs.** The `llmock` bin is retained as a compat alias for users of the pre-1.7.0 `@copilotkit/llmock` package. It runs a narrower flag-driven CLI without `--config` or the `convert` subcommand. New projects should use `aimock` (or `npx @copilotkit/aimock`) for full feature support.
+
+### Remote fixture URLs
+
+`--fixtures` accepts `https://` and `http://` URLs pointing at JSON fixture files in addition to filesystem paths, and the flag is repeatable so you can layer remote and local sources in argv order. Fetched fixtures are cached on disk at `~/.cache/aimock/fixtures/<sha256-of-url>/` (honors `$XDG_CACHE_HOME`); when paired with `--validate-on-load`, a fetch failure with a valid cached copy logs a warning and continues — without a cache, the process exits non-zero. HTTP fetches have a 10s timeout and a 50 MB body cap; redirects are rejected fail-loud, so configure your upstream to serve the final URL directly (GitHub raw content URLs already do).
+
+Private and link-local addresses (loopback, RFC1918, CGNAT, cloud metadata, ULA, multicast) are rejected by default to prevent SSRF. For local development or tests that need to hit `127.0.0.1`, opt out with `AIMOCK_ALLOW_PRIVATE_URLS=1`. Tarball and zip URL support is intentionally deferred.
 
 ## Framework Guides
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.14.6",
+  "version": "1.14.7",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, text-to-speech, transcription, video generation, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFile, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { createServer as createHttpServer, type Server } from "node:http";
+import { existsSync, mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { AddressInfo } from "node:net";
+import { createHash } from "node:crypto";
 
 const CLI_PATH = resolve(__dirname, "../../dist/cli.js");
 const CLI_AVAILABLE = existsSync(CLI_PATH);
@@ -378,5 +381,225 @@ describe.skipIf(!CLI_AVAILABLE)("CLI: --watch", () => {
     await new Promise<void>((resolve) => {
       child.cp.on("close", () => resolve());
     });
+  });
+});
+
+/* ================================================================== */
+/* Remote --fixtures URL support                                       */
+/* ================================================================== */
+
+interface HttpHandle {
+  server: Server;
+  url: string;
+  close: () => Promise<void>;
+}
+
+function startHttpServer(
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => void,
+): Promise<HttpHandle> {
+  return new Promise((res) => {
+    const server = createHttpServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      res({
+        server,
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () =>
+          new Promise<void>((r) => {
+            server.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+const REMOTE_FIXTURE_BODY = JSON.stringify({
+  fixtures: [
+    {
+      match: { userMessage: "hello-remote" },
+      response: { content: "Hello from remote fixture" },
+    },
+  ],
+});
+
+describe.skipIf(!CLI_AVAILABLE)("CLI: remote --fixtures URLs", () => {
+  let cacheDir: string;
+  let envBackup: string | undefined;
+  let allowPrivateBackup: string | undefined;
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), "aimock-cli-remote-cache-"));
+    envBackup = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = cacheDir;
+    // The remote-fixture SSRF denylist rejects 127.0.0.1 by default; these
+    // tests fetch from local http servers, so opt in for the subprocess.
+    allowPrivateBackup = process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+    process.env.AIMOCK_ALLOW_PRIVATE_URLS = "1";
+  });
+
+  afterEach(() => {
+    if (envBackup === undefined) delete process.env.XDG_CACHE_HOME;
+    else process.env.XDG_CACHE_HOME = envBackup;
+    if (allowPrivateBackup === undefined) delete process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+    else process.env.AIMOCK_ALLOW_PRIVATE_URLS = allowPrivateBackup;
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("loads fixtures from an https-style URL served by a local HTTP server", async () => {
+    const server = await startHttpServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(REMOTE_FIXTURE_BODY);
+      }, 50);
+    });
+    try {
+      const child = spawnCli(["--fixtures", `${server.url}/fx.json`, "--port", "0"]);
+      await child.waitForOutput(/listening on/i, 8000);
+      expect(child.stdout()).toContain("Loaded 1 fixture(s)");
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        child.cp.on("close", () => resolve());
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("exits non-zero when upstream returns 500 and no cache exists under --validate-on-load", async () => {
+    const server = await startHttpServer((_req, res) => {
+      res.writeHead(500);
+      res.end("nope");
+    });
+    try {
+      const { stderr, code } = await runCli(
+        ["--fixtures", `${server.url}/fx.json`, "--port", "0", "--validate-on-load"],
+        { timeout: 10000 },
+      );
+      expect(stderr).toMatch(/Failed to resolve --fixtures value/);
+      expect(stderr).toMatch(/HTTP 500/);
+      expect(code).toBe(1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("falls back to cached copy and warns when upstream returns 500 under --validate-on-load", async () => {
+    const server = await startHttpServer((_req, res) => {
+      res.writeHead(500);
+      res.end("nope");
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      // Pre-seed the cache using the same sha256(url) layout as the helper.
+      const digest = createHash("sha256").update(url).digest("hex");
+      const cachedDir = join(cacheDir, "aimock", "fixtures", digest);
+      mkdirSync(cachedDir, { recursive: true });
+      writeFileSync(join(cachedDir, "fixtures.json"), REMOTE_FIXTURE_BODY, "utf-8");
+
+      const child = spawnCli(["--fixtures", url, "--port", "0", "--validate-on-load"]);
+      await child.waitForOutput(/listening on/i, 8000);
+      expect(child.stdout() + child.stderr()).toMatch(/using cached copy/);
+      expect(child.stdout()).toContain("Loaded 1 fixture(s)");
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        child.cp.on("close", () => resolve());
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects non-http(s) schemes (e.g. file://) with a clear error", async () => {
+    const { stderr, code } = await runCli(
+      ["--fixtures", "file:///tmp/does-not-matter.json", "--port", "0"],
+      { timeout: 5000 },
+    );
+    expect(stderr).toMatch(/Unsupported --fixtures URL scheme "file"/);
+    expect(code).toBe(1);
+  });
+
+  it("still supports a plain filesystem path (regression guard)", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "cli-path-regression-"));
+    try {
+      const fp = join(tmp, "local.json");
+      writeFileSync(fp, REMOTE_FIXTURE_BODY, "utf-8");
+      const child = spawnCli(["--fixtures", fp, "--port", "0"]);
+      await child.waitForOutput(/listening on/i, 5000);
+      expect(child.stdout()).toContain("Loaded 1 fixture(s)");
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        child.cp.on("close", () => resolve());
+      });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("loads multiple --fixtures URLs and preserves argv load order", async () => {
+    // Fixture A responds to userMessage "alpha"; fixture B responds to "beta".
+    // Both are passed via repeatable --fixtures; both should be loaded and
+    // the count should reflect argv order (2 fixtures, A first then B).
+    const bodyA = JSON.stringify({
+      fixtures: [
+        {
+          match: { userMessage: "alpha" },
+          response: { content: "from A" },
+        },
+      ],
+    });
+    const bodyB = JSON.stringify({
+      fixtures: [
+        {
+          match: { userMessage: "beta" },
+          response: { content: "from B" },
+        },
+      ],
+    });
+    const serverA = await startHttpServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(bodyA);
+    });
+    const serverB = await startHttpServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(bodyB);
+    });
+    try {
+      const urlA = `${serverA.url}/a.json`;
+      const urlB = `${serverB.url}/b.json`;
+      const child = spawnCli([
+        "--fixtures",
+        urlA,
+        "--fixtures",
+        urlB,
+        "--port",
+        "0",
+        "--log-level",
+        "info",
+      ]);
+      await child.waitForOutput(/listening on/i, 8000);
+      // Both fixtures loaded and counted.
+      expect(child.stdout()).toContain("Loaded 2 fixture(s)");
+      // Both source URLs appear in the "Loaded N fixture(s) from ..." log line —
+      // verifying argv order: A listed before B.
+      const loadedLine = child
+        .stdout()
+        .split("\n")
+        .find((l) => l.includes("Loaded 2 fixture(s)"));
+      expect(loadedLine).toBeDefined();
+      const idxA = loadedLine!.indexOf(urlA);
+      const idxB = loadedLine!.indexOf(urlB);
+      expect(idxA).toBeGreaterThan(-1);
+      expect(idxB).toBeGreaterThan(idxA);
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        child.cp.on("close", () => resolve());
+      });
+    } finally {
+      await serverA.close();
+      await serverB.close();
+    }
   });
 });

--- a/src/__tests__/fixtures-remote.test.ts
+++ b/src/__tests__/fixtures-remote.test.ts
@@ -1,0 +1,655 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AddressInfo } from "node:net";
+import { Logger } from "../logger.js";
+import {
+  resolveFixturesValue,
+  looksLikeUrl,
+  defaultCacheRoot,
+  REMOTE_FETCH_TIMEOUT_MS,
+  REMOTE_MAX_BYTES,
+  isPrivateAddress,
+  assertAllowedHost,
+} from "../fixtures-remote.js";
+
+// All integration tests below hit 127.0.0.1 via ephemeral http servers.
+// The SSRF denylist rejects private addresses by default; opt in for the
+// whole file so fixture fetches against local test servers are allowed.
+let prevAllowPrivate: string | undefined;
+beforeAll(() => {
+  prevAllowPrivate = process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+  process.env.AIMOCK_ALLOW_PRIVATE_URLS = "1";
+});
+afterAll(() => {
+  if (prevAllowPrivate === undefined) delete process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+  else process.env.AIMOCK_ALLOW_PRIVATE_URLS = prevAllowPrivate;
+});
+
+const VALID_FIXTURE_JSON = JSON.stringify({
+  fixtures: [
+    {
+      match: { userMessage: "hello" },
+      response: { content: "Hello from remote!" },
+    },
+  ],
+});
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "aimock-remote-test-"));
+}
+
+interface FakeServerHandle {
+  server: Server;
+  url: string;
+  close: () => Promise<void>;
+}
+
+/**
+ * Build a Logger whose `warn` writes into the provided sink. Uses a subclass so
+ * the concrete `Logger` type is preserved without type casts.
+ */
+class CapturingLogger extends Logger {
+  private sink: string[];
+  constructor(sink: string[]) {
+    super("silent");
+    this.sink = sink;
+  }
+  warn(...args: unknown[]): void {
+    this.sink.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  }
+}
+
+function makeCapturingLogger(sink: string[]): Logger {
+  return new CapturingLogger(sink);
+}
+
+function startFakeServer(
+  handler: (
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse,
+  ) => void,
+): Promise<FakeServerHandle> {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      const url = `http://127.0.0.1:${addr.port}`;
+      resolve({
+        server,
+        url,
+        close: () =>
+          new Promise<void>((res) => {
+            server.close(() => res());
+          }),
+      });
+    });
+  });
+}
+
+describe("looksLikeUrl", () => {
+  it("recognizes http(s)/ftp/file schemes", () => {
+    expect(looksLikeUrl("https://example.com/x.json")).toBe(true);
+    expect(looksLikeUrl("http://example.com/x.json")).toBe(true);
+    expect(looksLikeUrl("file:///tmp/x.json")).toBe(true);
+    expect(looksLikeUrl("ftp://host/x.json")).toBe(true);
+  });
+
+  it("treats local paths as non-URL", () => {
+    expect(looksLikeUrl("./fixtures")).toBe(false);
+    expect(looksLikeUrl("/tmp/fixtures.json")).toBe(false);
+    expect(looksLikeUrl("fixtures.json")).toBe(false);
+    expect(looksLikeUrl("C:\\users\\foo\\fixtures.json")).toBe(false);
+  });
+});
+
+describe("defaultCacheRoot", () => {
+  it("honors XDG_CACHE_HOME when set", () => {
+    const prev = process.env.XDG_CACHE_HOME;
+    process.env.XDG_CACHE_HOME = "/custom/xdg";
+    try {
+      expect(defaultCacheRoot()).toBe("/custom/xdg/aimock/fixtures");
+    } finally {
+      if (prev === undefined) delete process.env.XDG_CACHE_HOME;
+      else process.env.XDG_CACHE_HOME = prev;
+    }
+  });
+});
+
+describe("resolveFixturesValue: local path", () => {
+  it("returns the resolved local path unchanged for filesystem inputs", async () => {
+    const tmp = makeTmpDir();
+    try {
+      const file = join(tmp, "fx.json");
+      writeFileSync(file, VALID_FIXTURE_JSON, "utf-8");
+      const result = await resolveFixturesValue(file, {
+        validateOnLoad: true,
+        logger: new Logger("silent"),
+      });
+      expect(result.path).toBe(file);
+      expect(result.source).toBe(file);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveFixturesValue: unsupported scheme", () => {
+  it("rejects file:// scheme with a clear error", async () => {
+    await expect(
+      resolveFixturesValue("file:///tmp/foo.json", {
+        validateOnLoad: true,
+        logger: new Logger("silent"),
+      }),
+    ).rejects.toThrow(/Unsupported --fixtures URL scheme "file"/);
+  });
+
+  it("rejects ftp:// scheme with a clear error", async () => {
+    await expect(
+      resolveFixturesValue("ftp://host/foo.json", {
+        validateOnLoad: true,
+        logger: new Logger("silent"),
+      }),
+    ).rejects.toThrow(/Unsupported --fixtures URL scheme "ftp"/);
+  });
+});
+
+describe("resolveFixturesValue: http(s) success", () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("fetches JSON, caches to disk, and returns cached path", async () => {
+    const server = await startFakeServer((_req, res) => {
+      // 50ms delay to match test plan
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(VALID_FIXTURE_JSON);
+      }, 50);
+    });
+    try {
+      const url = `${server.url}/fixtures.json`;
+      const result = await resolveFixturesValue(url, {
+        validateOnLoad: true,
+        logger: new Logger("silent"),
+        cacheRoot: cacheDir,
+      });
+      expect(result.source).toBe(url);
+      expect(result.path).toContain(cacheDir);
+      expect(readFileSync(result.path, "utf-8")).toBe(VALID_FIXTURE_JSON);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe("resolveFixturesValue: http(s) failure modes", () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("throws on HTTP 500 with no cache and validateOnLoad=true (fail loud)", async () => {
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(500);
+      res.end("boom");
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      await expect(
+        resolveFixturesValue(url, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+        }),
+      ).rejects.toThrow(/Failed to fetch.*HTTP 500/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("returns empty path and warns without validateOnLoad when fetch fails and no cache", async () => {
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(500);
+      res.end("boom");
+    });
+    const warnLines: string[] = [];
+    const logger: Logger = {
+      info: () => {},
+      warn: (msg: string) => warnLines.push(msg),
+      error: () => {},
+      debug: () => {},
+    } as unknown as Logger;
+    try {
+      const url = `${server.url}/fx.json`;
+      const result = await resolveFixturesValue(url, {
+        validateOnLoad: false,
+        logger,
+        cacheRoot: cacheDir,
+      });
+      expect(result.path).toBe("");
+      expect(warnLines.join("\n")).toMatch(/no cached copy/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("falls back to pre-seeded cache on fetch failure with validateOnLoad=true", async () => {
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(500);
+      res.end("boom");
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      // Pre-seed cache with the same hashing convention used by the helper.
+      const { createHash } = await import("node:crypto");
+      const digest = createHash("sha256").update(url).digest("hex");
+      const cachedDir = join(cacheDir, digest);
+      mkdirSync(cachedDir, { recursive: true });
+      const cachedFile = join(cachedDir, "fixtures.json");
+      writeFileSync(cachedFile, VALID_FIXTURE_JSON, "utf-8");
+
+      const warnLines: string[] = [];
+      const logger = makeCapturingLogger(warnLines);
+
+      const result = await resolveFixturesValue(url, {
+        validateOnLoad: true,
+        logger,
+        cacheRoot: cacheDir,
+      });
+      expect(result.path).toBe(cachedFile);
+      expect(existsSync(result.path)).toBe(true);
+      expect(warnLines.join("\n")).toMatch(/using cached copy/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("times out with a fail-loud error when upstream never responds", async () => {
+    // Start a server that accepts the connection but never writes a response.
+    const server = await startFakeServer(() => {
+      /* black hole */
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      await expect(
+        resolveFixturesValue(url, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+          timeoutMs: 200,
+        }),
+      ).rejects.toThrow(/timed out after 200ms/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects responses that exceed the max-size cap", async () => {
+    const big = "x".repeat(4096);
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(big);
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      await expect(
+        resolveFixturesValue(url, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+          maxBytes: 512,
+        }),
+      ).rejects.toThrow(/response too large/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects oversized responses declared via content-length", async () => {
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "content-length": "999999999",
+      });
+      res.end("{}");
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      await expect(
+        resolveFixturesValue(url, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+          maxBytes: 1024,
+        }),
+      ).rejects.toThrow(/response too large/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("throws on invalid JSON response with validateOnLoad=true", async () => {
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{ not valid json");
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      await expect(
+        resolveFixturesValue(url, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+        }),
+      ).rejects.toThrow();
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+/* ================================================================== */
+/* Gap #5 — default timeout + max-bytes constants are exported         */
+/* ================================================================== */
+
+describe("fixtures-remote: exported defaults", () => {
+  it("exposes a 10s default fetch timeout constant", () => {
+    expect(REMOTE_FETCH_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("exposes a 50 MB default max-body constant", () => {
+    expect(REMOTE_MAX_BYTES).toBe(50 * 1024 * 1024);
+  });
+});
+
+/* ================================================================== */
+/* Gap #3 — lying Content-Length + oversized stream                    */
+/* ================================================================== */
+
+describe("resolveFixturesValue: lying Content-Length", () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("enforces the byte cap incrementally when body streams past the cap via chunked encoding", async () => {
+    // Chunked transfer-encoding (no Content-Length) is the real bypass vector:
+    // the server can stream an unbounded body and there's no header-level size
+    // hint.  The incremental check must abort mid-stream once the limit is hit.
+    const maxBytes = 1024;
+    const chunk = "x".repeat(4096); // single chunk exceeds the cap by 4x
+    const server = await startFakeServer((_req, res) => {
+      // Explicitly use chunked framing — do NOT set Content-Length.
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "transfer-encoding": "chunked",
+      });
+      // Write multiple chunks to force the incremental check to run against
+      // partial totals rather than the whole body at once.
+      res.write(chunk);
+      res.write(chunk);
+      res.write(chunk);
+      res.end(chunk);
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      await expect(
+        resolveFixturesValue(url, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+          maxBytes,
+        }),
+      ).rejects.toThrow(/response too large/);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects with a fail-loud error when Content-Length under-declares body size (truncation safety)", async () => {
+    // A server that lies with a small CL header but emits a larger body
+    // causes the client reader to truncate.  The CHANGELOG guarantee is
+    // fail-loud behavior: invalid-JSON (the truncated payload) must throw
+    // rather than silently succeed with a corrupted fixture.  The cap itself
+    // is not bypassed in this scenario because Node's fetch bounds reads by
+    // the declared Content-Length — this test pins the fail-loud contract.
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "content-length": "50",
+      });
+      // Body of valid JSON padded past the declared 50 bytes — client sees
+      // only the first 50 bytes, which is truncated / invalid JSON.
+      res.end('{"fixtures":[' + " ".repeat(4096) + "]}");
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      await expect(
+        resolveFixturesValue(url, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+        }),
+      ).rejects.toThrow();
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+/* ================================================================== */
+/* Gap #1 — SSRF denylist                                              */
+/* ================================================================== */
+
+describe("isPrivateAddress: table-driven address classification", () => {
+  const blocked: Array<[string, string]> = [
+    ["127.0.0.1", "IPv4 loopback"],
+    ["127.255.255.254", "IPv4 loopback end"],
+    ["10.0.0.1", "RFC1918 10/8"],
+    ["10.255.255.255", "RFC1918 10/8 end"],
+    ["172.16.0.1", "RFC1918 172.16/12"],
+    ["172.31.255.255", "RFC1918 172.16/12 end"],
+    ["192.168.0.1", "RFC1918 192.168/16"],
+    ["169.254.169.254", "cloud metadata endpoint"],
+    ["169.254.0.1", "link-local"],
+    ["100.64.0.1", "CGNAT 100.64/10"],
+    ["198.18.0.1", "benchmarking 198.18/15"],
+    ["0.0.0.0", "unspecified 0/8"],
+    ["224.0.0.1", "multicast 224/4"],
+    ["240.0.0.1", "reserved 240/4"],
+    ["255.255.255.255", "broadcast"],
+    ["::1", "IPv6 loopback"],
+    ["::", "IPv6 unspecified"],
+    ["fe80::1", "IPv6 link-local"],
+    ["fc00::1", "IPv6 ULA"],
+    ["fd12:3456::1", "IPv6 ULA fd"],
+  ];
+
+  const allowed: Array<[string, string]> = [
+    ["8.8.8.8", "public Google DNS"],
+    ["1.1.1.1", "public Cloudflare"],
+    ["140.82.114.4", "public GitHub"],
+    ["2606:4700::1111", "public IPv6 Cloudflare"],
+  ];
+
+  for (const [addr, label] of blocked) {
+    it(`rejects ${addr} (${label}) as private`, () => {
+      expect(isPrivateAddress(addr)).toBe(true);
+    });
+  }
+
+  for (const [addr, label] of allowed) {
+    it(`accepts ${addr} (${label}) as public`, () => {
+      expect(isPrivateAddress(addr)).toBe(false);
+    });
+  }
+});
+
+describe("assertAllowedHost: env opt-out + denylist enforcement", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+    else process.env.AIMOCK_ALLOW_PRIVATE_URLS = savedEnv;
+  });
+
+  it("permits 127.0.0.1 when AIMOCK_ALLOW_PRIVATE_URLS=1", async () => {
+    process.env.AIMOCK_ALLOW_PRIVATE_URLS = "1";
+    await expect(assertAllowedHost("127.0.0.1")).resolves.toBeUndefined();
+  });
+
+  it("rejects 127.0.0.1 when AIMOCK_ALLOW_PRIVATE_URLS is unset", async () => {
+    delete process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+    await expect(assertAllowedHost("127.0.0.1")).rejects.toThrow(/private address|not allowed/i);
+  });
+
+  it("rejects literal 169.254.169.254 (cloud metadata) by default", async () => {
+    delete process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+    await expect(assertAllowedHost("169.254.169.254")).rejects.toThrow(
+      /private address|not allowed/i,
+    );
+  });
+});
+
+describe("resolveFixturesValue: SSRF integration", () => {
+  let cacheDir: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    cacheDir = makeTmpDir();
+    savedEnv = process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+    else process.env.AIMOCK_ALLOW_PRIVATE_URLS = savedEnv;
+  });
+
+  it("rejects http://169.254.169.254/ (cloud-metadata endpoint) without opt-out", async () => {
+    delete process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+    await expect(
+      resolveFixturesValue("http://169.254.169.254/latest/meta-data/", {
+        validateOnLoad: true,
+        logger: new Logger("silent"),
+        cacheRoot: cacheDir,
+      }),
+    ).rejects.toThrow(/private address|not allowed/i);
+  });
+
+  it("rejects http://127.0.0.1:<port>/ without opt-out (even with a reachable server)", async () => {
+    // Spin up a local server; even with it reachable the denylist must reject
+    // the URL because AIMOCK_ALLOW_PRIVATE_URLS is unset.
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(VALID_FIXTURE_JSON);
+    });
+    try {
+      delete process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+      await expect(
+        resolveFixturesValue(`${server.url}/fx.json`, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+        }),
+      ).rejects.toThrow(/private address|not allowed/i);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("permits http://127.0.0.1:<port>/ when AIMOCK_ALLOW_PRIVATE_URLS=1", async () => {
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(VALID_FIXTURE_JSON);
+    });
+    try {
+      process.env.AIMOCK_ALLOW_PRIVATE_URLS = "1";
+      const result = await resolveFixturesValue(`${server.url}/fx.json`, {
+        validateOnLoad: true,
+        logger: new Logger("silent"),
+        cacheRoot: cacheDir,
+      });
+      expect(result.path).toContain(cacheDir);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+/* ================================================================== */
+/* Gap #2 — redirect rejection (fail loud, no scheme bypass)           */
+/* ================================================================== */
+
+describe("resolveFixturesValue: redirect rejection", () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("rejects 302 → file:///... without following (scheme-bypass defense)", async () => {
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(302, { location: "file:///etc/passwd" });
+      res.end();
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      await expect(
+        resolveFixturesValue(url, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+        }),
+      ).rejects.toThrow(/redirect/i);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects 302 → https://other-allowed/ (redirects disabled entirely)", async () => {
+    const server = await startFakeServer((_req, res) => {
+      res.writeHead(302, { location: "https://example.invalid/other.json" });
+      res.end();
+    });
+    try {
+      const url = `${server.url}/fx.json`;
+      await expect(
+        resolveFixturesValue(url, {
+          validateOnLoad: true,
+          logger: new Logger("silent"),
+          cacheRoot: cacheDir,
+        }),
+      ).rejects.toThrow(/redirect/i);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,8 @@ import { loadFixtureFile, loadFixturesFromDir, validateFixtures } from "./fixtur
 import { Logger, type LogLevel } from "./logger.js";
 import { watchFixtures } from "./watcher.js";
 import { AGUIMock } from "./agui-mock.js";
-import type { ChaosConfig, RecordConfig } from "./types.js";
+import { resolveFixturesValue } from "./fixtures-remote.js";
+import type { Fixture, ChaosConfig, RecordConfig } from "./types.js";
 
 const HELP = `
 Usage: aimock [options]
@@ -15,7 +16,9 @@ Usage: aimock [options]
 Options:
   -p, --port <number>       Port to listen on (default: 4010)
   -h, --host <string>       Host to bind to (default: 127.0.0.1)
-  -f, --fixtures <path>     Path to fixtures directory or file (default: ./fixtures)
+  -f, --fixtures <value>    Fixture source (repeatable). Accepts:
+                              - filesystem path to a directory or .json file (default: ./fixtures)
+                              - https:// or http:// URL to a .json fixture file
   -l, --latency <ms>        Latency in ms between SSE chunks (default: 0)
   -c, --chunk-size <chars>  Chunk size in characters (default: 20)
   -w, --watch               Watch fixture path for changes and reload
@@ -48,7 +51,7 @@ const { values } = parseArgs({
   options: {
     port: { type: "string", short: "p", default: "4010" },
     host: { type: "string", short: "h", default: "127.0.0.1" },
-    fixtures: { type: "string", short: "f", default: "./fixtures" },
+    fixtures: { type: "string", short: "f", multiple: true },
     latency: { type: "string", short: "l", default: "0" },
     "chunk-size": { type: "string", short: "c", default: "20" },
     watch: { type: "boolean", short: "w", default: false },
@@ -88,7 +91,8 @@ const port = Number(values.port);
 const host = values.host!;
 const latency = Number(values.latency);
 const chunkSize = Number(values["chunk-size"]);
-const fixturePath = resolve(values.fixtures!);
+const fixtureValues: string[] =
+  values.fixtures && values.fixtures.length > 0 ? values.fixtures : ["./fixtures"];
 const watchMode = values.watch!;
 const validateOnLoad = values["validate-on-load"]!;
 const logLevelStr = values["log-level"]!;
@@ -189,9 +193,18 @@ if (values.record || values["proxy-only"]) {
     process.exit(1);
   }
 
+  // For record mode, use the first --fixtures value as the base path.
+  // Remote URL sources are not supported as record destinations — bail out with a clear error.
+  const recordBase = fixtureValues[0];
+  if (/^https?:\/\//i.test(recordBase)) {
+    console.error(
+      `Error: --record/--proxy-only requires a local --fixtures path for the recording destination; got URL ${recordBase}`,
+    );
+    process.exit(1);
+  }
   record = {
     providers,
-    fixturePath: resolve(fixturePath, "recorded"),
+    fixturePath: resolve(recordBase, "recorded"),
     proxyOnly: values["proxy-only"],
   };
 }
@@ -203,35 +216,74 @@ if (values["agui-record"] || values["agui-proxy-only"]) {
     console.error("Error: --agui-record/--agui-proxy-only requires --agui-upstream");
     process.exit(1);
   }
+  const aguiBase = fixtureValues[0];
+  if (/^https?:\/\//i.test(aguiBase)) {
+    console.error(
+      `Error: --agui-record/--agui-proxy-only requires a local --fixtures path for the recording destination; got URL ${aguiBase}`,
+    );
+    process.exit(1);
+  }
   const agui = new AGUIMock();
   agui.enableRecording({
     upstream: values["agui-upstream"],
-    fixturePath: resolve(fixturePath, "agui-recorded"),
+    fixturePath: resolve(aguiBase, "agui-recorded"),
     proxyOnly: values["agui-proxy-only"],
   });
   aguiMount = { path: "/agui", handler: agui };
 }
 
-async function main() {
-  // Load fixtures from path (detect file vs directory)
-  let isDir: boolean;
-  let fixtures;
-  try {
-    const stat = statSync(fixturePath);
-    isDir = stat.isDirectory();
-    if (isDir) {
-      fixtures = loadFixturesFromDir(fixturePath, logger);
-    } else {
-      fixtures = loadFixtureFile(fixturePath, logger);
-    }
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      console.error(`Fixtures path not found: ${fixturePath}`);
-    } else {
+interface ResolvedFixtureSource {
+  source: string;
+  path: string;
+  isDir: boolean;
+}
+
+async function resolveAllFixtureSources(): Promise<ResolvedFixtureSource[]> {
+  const resolved: ResolvedFixtureSource[] = [];
+  for (const value of fixtureValues) {
+    let local;
+    try {
+      local = await resolveFixturesValue(value, {
+        validateOnLoad,
+        logger,
+      });
+    } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`Failed to load fixtures from ${fixturePath}: ${msg}`);
+      console.error(`Failed to resolve --fixtures value "${value}": ${msg}`);
+      process.exit(1);
     }
-    process.exit(1);
+    if (!local.path) {
+      // Remote fetch failed without validate-on-load and no cache — already warned; skip.
+      continue;
+    }
+    try {
+      const stat = statSync(local.path);
+      resolved.push({ source: local.source, path: local.path, isDir: stat.isDirectory() });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        console.error(`Fixtures path not found: ${local.path}`);
+      } else {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`Failed to load fixtures from ${local.path}: ${msg}`);
+      }
+      process.exit(1);
+    }
+  }
+  return resolved;
+}
+
+function loadSource(source: ResolvedFixtureSource): Fixture[] {
+  return source.isDir
+    ? loadFixturesFromDir(source.path, logger)
+    : loadFixtureFile(source.path, logger);
+}
+
+async function main() {
+  const sources = await resolveAllFixtureSources();
+
+  const fixtures: Fixture[] = [];
+  for (const src of sources) {
+    fixtures.push(...loadSource(src));
   }
 
   if (fixtures.length === 0) {
@@ -242,7 +294,8 @@ async function main() {
     console.warn("Warning: No fixtures loaded. The server will return 404 for all requests.");
   }
 
-  logger.info(`Loaded ${fixtures.length} fixture(s) from ${fixturePath}`);
+  const sourceLabel = sources.map((s) => s.source).join(", ") || "<none>";
+  logger.info(`Loaded ${fixtures.length} fixture(s) from ${sourceLabel}`);
 
   // Validate fixtures if requested
   if (validateOnLoad) {
@@ -285,19 +338,22 @@ async function main() {
 
   logger.info(`aimock server listening on ${instance.url}`);
 
-  // Start file watcher if requested
+  // Start file watcher if requested. Only the first local source is watched —
+  // remote URL sources are fetched once at boot and are not monitored.
   let watcher: { close: () => void } | null = null;
   if (watchMode) {
-    const loadFn = isDir!
-      ? () => loadFixturesFromDir(fixturePath, logger)
-      : () => loadFixtureFile(fixturePath, logger);
-
-    watcher = watchFixtures(fixturePath, fixtures, loadFn, {
-      logger,
-      validate: validateOnLoad,
-      validateFn: validateFixtures,
-    });
-    logger.info(`Watching ${fixturePath} for changes`);
+    const primary = sources[0];
+    if (!primary) {
+      logger.warn("--watch requested but no resolvable fixture sources; skipping watcher");
+    } else {
+      const loadFn = (): Fixture[] => loadSource(primary);
+      watcher = watchFixtures(primary.path, fixtures, loadFn, {
+        logger,
+        validate: validateOnLoad,
+        validateFn: validateFixtures,
+      });
+      logger.info(`Watching ${primary.path} for changes`);
+    }
   }
 
   function shutdown() {

--- a/src/fixtures-remote.ts
+++ b/src/fixtures-remote.ts
@@ -1,11 +1,117 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync, statSync } from "node:fs";
+import { lookup as dnsLookup } from "node:dns/promises";
+import { BlockList, isIP } from "node:net";
 import { homedir } from "node:os";
 import { join, resolve as pathResolve } from "node:path";
 import type { Logger } from "./logger.js";
 
 export const REMOTE_FETCH_TIMEOUT_MS = 10_000;
 export const REMOTE_MAX_BYTES = 50 * 1024 * 1024; // 50 MB
+
+/**
+ * Private / reserved address ranges blocked by default to prevent SSRF.
+ *
+ * The list covers RFC1918 / CGNAT / loopback / link-local / cloud-metadata /
+ * ULA / multicast / unspecified — any destination that could let an attacker
+ * pivot a fetch into the local network or cloud control plane via a hostile
+ * `--fixtures` URL.  Set `AIMOCK_ALLOW_PRIVATE_URLS=1` to opt out (required
+ * for local dev / tests that target 127.0.0.1).
+ */
+const PRIVATE_V4_RANGES: Array<[string, number]> = [
+  ["0.0.0.0", 8], // "this network"
+  ["10.0.0.0", 8], // RFC1918
+  ["100.64.0.0", 10], // CGNAT
+  ["127.0.0.0", 8], // loopback
+  ["169.254.0.0", 16], // link-local / cloud metadata
+  ["172.16.0.0", 12], // RFC1918
+  ["192.0.0.0", 24], // IETF protocol assignments
+  ["192.0.2.0", 24], // TEST-NET-1
+  ["192.88.99.0", 24], // 6to4 relay anycast (deprecated)
+  ["192.168.0.0", 16], // RFC1918
+  ["198.18.0.0", 15], // benchmarking
+  ["198.51.100.0", 24], // TEST-NET-2
+  ["203.0.113.0", 24], // TEST-NET-3
+  ["224.0.0.0", 4], // multicast
+  ["240.0.0.0", 4], // reserved
+  ["255.255.255.255", 32], // broadcast
+];
+
+const PRIVATE_V6_RANGES: Array<[string, number]> = [
+  ["::", 128], // unspecified
+  ["::1", 128], // loopback
+  ["fc00::", 7], // ULA
+  ["fe80::", 10], // link-local
+];
+
+function buildBlockList(): BlockList {
+  const bl = new BlockList();
+  for (const [addr, prefix] of PRIVATE_V4_RANGES) bl.addSubnet(addr, prefix, "ipv4");
+  for (const [addr, prefix] of PRIVATE_V6_RANGES) bl.addSubnet(addr, prefix, "ipv6");
+  return bl;
+}
+
+const PRIVATE_BLOCKLIST: BlockList = buildBlockList();
+
+/**
+ * Returns true if `address` is a literal IP (v4 or v6) that falls in any
+ * blocked range (loopback, RFC1918, CGNAT, link-local, cloud-metadata,
+ * ULA, multicast, unspecified, reserved).  Returns false for public IPs
+ * and for non-literal hostnames.
+ */
+export function isPrivateAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 0) return false; // not a literal IP
+  // BlockList.check's "ipv6" bucket does not match v4-mapped ::ffff:a.b.c.d
+  // automatically — unwrap to the underlying v4 address and recurse.
+  if (family === 6) {
+    const lower = address.toLowerCase();
+    const mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped) return isPrivateAddress(mapped[1]);
+  }
+  return PRIVATE_BLOCKLIST.check(address, family === 4 ? "ipv4" : "ipv6");
+}
+
+function privateUrlsAllowed(): boolean {
+  const v = process.env.AIMOCK_ALLOW_PRIVATE_URLS;
+  return v === "1" || v === "true";
+}
+
+/**
+ * Throws if `hostname` resolves to (or literally is) a private / reserved
+ * address, unless `AIMOCK_ALLOW_PRIVATE_URLS=1` is set.  If the hostname is
+ * not a literal IP, all resolved addresses are checked — any blocked
+ * address in the set rejects the host.
+ */
+export async function assertAllowedHost(hostname: string): Promise<void> {
+  if (privateUrlsAllowed()) return;
+
+  if (isIP(hostname) !== 0) {
+    if (isPrivateAddress(hostname)) {
+      throw new Error(
+        `Refusing to fetch from private address ${hostname}: not allowed by default (set AIMOCK_ALLOW_PRIVATE_URLS=1 to override)`,
+      );
+    }
+    return;
+  }
+
+  let addresses: Array<{ address: string; family: number }>;
+  try {
+    addresses = await dnsLookup(hostname, { all: true });
+  } catch (err) {
+    // DNS failure is not an SSRF signal — let the fetch itself surface the
+    // resolution error with its own (more detailed) message.
+    void err;
+    return;
+  }
+  for (const a of addresses) {
+    if (isPrivateAddress(a.address)) {
+      throw new Error(
+        `Refusing to fetch from ${hostname}: resolves to private address ${a.address} (set AIMOCK_ALLOW_PRIVATE_URLS=1 to override)`,
+      );
+    }
+  }
+}
 
 export interface RemoteResolveOptions {
   validateOnLoad: boolean;
@@ -94,6 +200,11 @@ async function resolveHttpFixture(
   const cacheFile = join(cacheDir, "fixtures.json");
 
   try {
+    // SSRF defense: reject private / reserved destinations before any network
+    // I/O, unless explicitly opted in via AIMOCK_ALLOW_PRIVATE_URLS=1.
+    const parsed = new URL(url);
+    await assertAllowedHost(parsed.hostname);
+
     const body = await fetchWithLimits(url, fetchImpl, timeoutMs, maxBytes);
     // Parse to verify it is valid JSON before caching — fail loud if not.
     JSON.parse(body);
@@ -138,7 +249,19 @@ async function fetchWithLimits(
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error("timeout")), timeoutMs);
   try {
-    const res = await fetchImpl(url, { signal: controller.signal });
+    // Redirects are disabled: following a 3xx into a different scheme or host
+    // would bypass the scheme check and SSRF denylist.  Upstream services
+    // should serve the final URL directly (e.g. GitHub raw content URLs).
+    const res = await fetchImpl(url, {
+      signal: controller.signal,
+      redirect: "manual",
+    });
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location") ?? "<none>";
+      throw new Error(
+        `redirect not allowed: upstream returned ${res.status} → ${location} (configure the upstream to serve the final URL directly; redirects are disabled to prevent scheme-bypass)`,
+      );
+    }
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} ${res.statusText}`);
     }

--- a/src/fixtures-remote.ts
+++ b/src/fixtures-remote.ts
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve as pathResolve } from "node:path";
+import type { Logger } from "./logger.js";
+
+export const REMOTE_FETCH_TIMEOUT_MS = 10_000;
+export const REMOTE_MAX_BYTES = 50 * 1024 * 1024; // 50 MB
+
+export interface RemoteResolveOptions {
+  validateOnLoad: boolean;
+  logger: Logger;
+  /** Override fetch implementation (tests). */
+  fetchImpl?: typeof fetch;
+  /** Override cache root (tests). */
+  cacheRoot?: string;
+  /** Override timeout (tests). */
+  timeoutMs?: number;
+  /** Override max response size (tests). */
+  maxBytes?: number;
+}
+
+export interface ResolvedLocalFixture {
+  /** Original value as passed on the CLI (for logging). */
+  source: string;
+  /** Filesystem path — downstream code treats this identically to a --fixtures path. */
+  path: string;
+}
+
+/**
+ * Returns true if `value` looks like a URL (has a scheme followed by ://).
+ * Path inputs like ./fixtures or /tmp/x never start with a scheme.
+ */
+export function looksLikeUrl(value: string): boolean {
+  return /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(value);
+}
+
+/**
+ * Returns the default on-disk cache root for fetched fixtures.
+ * Honors $XDG_CACHE_HOME when set, otherwise falls back to ~/.cache.
+ */
+export function defaultCacheRoot(): string {
+  const xdg = process.env.XDG_CACHE_HOME;
+  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".cache");
+  return join(base, "aimock", "fixtures");
+}
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+/**
+ * Resolve a single --fixtures value to a local filesystem path.
+ *
+ * Behavior:
+ * - Filesystem path → return as-is.
+ * - https://, http:// URL → fetch JSON (once) to the on-disk cache; return the cached path.
+ *   On fetch failure, fall back to a pre-existing cached copy if present (warn + continue).
+ *   If --validate-on-load is set and no cache is usable, throws.
+ * - Any other scheme (file://, ftp://, ...) → throws.
+ */
+export async function resolveFixturesValue(
+  value: string,
+  opts: RemoteResolveOptions,
+): Promise<ResolvedLocalFixture> {
+  if (!looksLikeUrl(value)) {
+    return { source: value, path: pathResolve(value) };
+  }
+
+  const lower = value.toLowerCase();
+  if (!lower.startsWith("https://") && !lower.startsWith("http://")) {
+    // Extract the scheme for a clearer error
+    const match = value.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+    const scheme = match ? match[1] : "unknown";
+    throw new Error(
+      `Unsupported --fixtures URL scheme "${scheme}" in ${value} (only https:// and http:// are supported)`,
+    );
+  }
+
+  return await resolveHttpFixture(value, opts);
+}
+
+async function resolveHttpFixture(
+  url: string,
+  opts: RemoteResolveOptions,
+): Promise<ResolvedLocalFixture> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const cacheRoot = opts.cacheRoot ?? defaultCacheRoot();
+  const timeoutMs = opts.timeoutMs ?? REMOTE_FETCH_TIMEOUT_MS;
+  const maxBytes = opts.maxBytes ?? REMOTE_MAX_BYTES;
+
+  const digest = sha256Hex(url);
+  const cacheDir = join(cacheRoot, digest);
+  const cacheFile = join(cacheDir, "fixtures.json");
+
+  try {
+    const body = await fetchWithLimits(url, fetchImpl, timeoutMs, maxBytes);
+    // Parse to verify it is valid JSON before caching — fail loud if not.
+    JSON.parse(body);
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(cacheFile, body, "utf-8");
+    opts.logger.info(`Fetched ${url} (${body.length} bytes) → cached at ${cacheFile}`);
+    return { source: url, path: cacheFile };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const cacheExists = cacheFileExists(cacheFile);
+    if (cacheExists) {
+      opts.logger.warn(
+        `upstream fetch failed for ${url} (${msg}); using cached copy at ${cacheFile}`,
+      );
+      return { source: url, path: cacheFile };
+    }
+    if (opts.validateOnLoad) {
+      throw new Error(`Failed to fetch ${url} and no cached copy available: ${msg}`);
+    }
+    opts.logger.warn(
+      `upstream fetch failed for ${url} (${msg}); no cached copy available — skipping`,
+    );
+    // Signal "no path" by returning a sentinel with empty path — callers detect and skip.
+    return { source: url, path: "" };
+  }
+}
+
+function cacheFileExists(file: string): boolean {
+  try {
+    return statSync(file).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function fetchWithLimits(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+  maxBytes: number,
+): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error("timeout")), timeoutMs);
+  try {
+    const res = await fetchImpl(url, { signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    }
+    // Early reject on over-large Content-Length when the server reports it.
+    const len = res.headers.get("content-length");
+    if (len) {
+      const n = Number(len);
+      if (Number.isFinite(n) && n > maxBytes) {
+        throw new Error(`response too large: content-length ${n} exceeds limit ${maxBytes} bytes`);
+      }
+    }
+
+    // Stream and enforce the limit incrementally in case Content-Length is absent/lying.
+    if (!res.body) {
+      const text = await res.text();
+      if (Buffer.byteLength(text, "utf-8") > maxBytes) {
+        throw new Error(`response too large: body exceeds limit ${maxBytes} bytes`);
+      }
+      return text;
+    }
+
+    const reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > maxBytes) {
+          try {
+            await reader.cancel();
+          } catch {
+            // ignore cancel errors
+          }
+          throw new Error(`response too large: body exceeds limit ${maxBytes} bytes`);
+        }
+        chunks.push(value);
+      }
+    }
+    return Buffer.concat(chunks).toString("utf-8");
+  } catch (err) {
+    if (err instanceof Error && (err.name === "AbortError" || err.message === "timeout")) {
+      throw new Error(`fetch timed out after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary

- Remote `https://` / `http://` URLs for `--fixtures` with on-disk cache + fail-loud recovery
- SSRF hardening: private-address denylist (`AIMOCK_ALLOW_PRIVATE_URLS=1` opt-out for local dev)
- Redirects rejected fail-loud (configure upstream to serve the final URL directly)
- 10s hard timeout + 50MB incremental body cap (lying `Content-Length` cannot bypass)
- `--fixtures` is now repeatable; argv order preserved

## Why

Phase 1 of showcase-aimock wrapper elimination — Railway can pull fixtures from stable GitHub raw
URLs instead of rebuilding an image per fixture update.

## Test plan

- 30+ new tests across unit + integration + CLI subprocess layers; 2520/2520 suite-wide pass
- Real sockets (no mocks) for every fetch path
- Coverage: timeout, incremental cap (chunked + lying CL), cache fallback, scheme rejection,
  redirect rejection, SSRF denylist (table-driven across 20 reserved ranges + 4 public IPs),
  env opt-out, invalid JSON fail-loud, non-zero exit, repeatable `--fixtures` load order
