### PR TITLE
ci: bump CI node-version 22 to 24 to match engines.node

### DIFF
--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 24, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: npx pkg-pr-new publish

--- a/.github/workflows/static-quality.yml
+++ b/.github/workflows/static-quality.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 24, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: pnpm format:check
 
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 24, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 24, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test:exports
@@ -44,6 +44,6 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
+        with: { node-version: 24, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: pnpm commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-drift.yml
+++ b/.github/workflows/test-drift.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
@@ -35,7 +35,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/update-competitive-matrix.yml
+++ b/.github/workflows/update-competitive-matrix.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Fixes the failing [drift CI run](https://github.com/CopilotKit/aimock/actions/runs/24820874668/job/72645103329).

`package.json` pins `engines.node` to `>=24.0.0`, but several workflows pinned node to `22`. pnpm emits an `Unsupported engine` WARN to stdout on setup, which corrupted the JSON that `scripts/drift-report-collector.ts` parses, breaking the drift workflow.

Bumped `node-version` `22 -> 24` in every single-version workflow pin:
- `test-drift.yml` (both jobs)
- `fix-drift.yml`
- `static-quality.yml` (all 4 jobs: prettier, eslint, exports, commitlint)
- `publish-commit.yml`
- `update-competitive-matrix.yml`

Matrix workflows (`test-unit.yml`, `test-pytest.yml`) left alone — their `[20, 22, 24]` matrices intentionally exercise compat across node versions.

## Test plan

- [ ] Trigger `test-drift.yml` manually on this branch via `gh workflow run test-drift.yml --ref fix/drift-workflows-node24`
- [ ] Confirm the `agui-schema-drift` job runs green (no engines WARN poisoning stdout)
- [ ] Confirm `static-quality`, `publish-commit` run green on this PR