### PR TITLE
fix: remove preinstall only-allow hook from published package (v1.14.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @copilotkit/aimock
 
+## 1.14.9
+
+### Fixed
+
+- Removed the `preinstall: npx only-allow pnpm` script from the published package. That
+  hook was intended to guide contributors cloning the monorepo toward pnpm, but it got
+  bundled into the published tarball and fired during `npm install -g @copilotkit/aimock`,
+  aborting the install with `sh: only-allow: not found` before npm could even resolve the
+  binary. The guard belongs on the monorepo root, not inside the shipped package.
+  Unblocks CopilotKit's docs CI (and any other consumer installing aimock via npm).
+
 ## 1.14.8
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, text-to-speech, transcription, video generation, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [
@@ -149,7 +149,6 @@
     "access": "public"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "build": "tsdown",
     "test": "vitest run",
     "test:drift": "vitest run --config vitest.config.drift.ts",


### PR DESCRIPTION
## Summary
- Removes `preinstall: npx only-allow pnpm` from `package.json`. The script was meant to force pnpm for contributors cloning the monorepo, but it shipped inside the published tarball and fired during `npm install -g @copilotkit/aimock`, aborting the install with `sh: only-allow: not found`.
- Bumps version to 1.14.9 and adds a CHANGELOG entry.

Unblocks CopilotKit's docs CI (and any other consumer installing aimock via plain `npm`).

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run test` — 2488 passed, 36 skipped
- [ ] After merge, confirm `publish-release.yml` publishes 1.14.9 to npm and that `npm install -g @copilotkit/aimock@1.14.9` succeeds on a fresh machine