### PR TITLE
feat: chaos for proxy mode (drop, disconnect, malformed)

### DIFF
--- a/docs/chaos-testing/index.html
+++ b/docs/chaos-testing/index.html
@@ -69,7 +69,10 @@
               <td>HTTP 500</td>
               <td>
                 Returns a 500 error with
-                <code>{"error":{"message":"Chaos: request dropped","code":"chaos_drop"}}</code>
+                <code
+                  >{"error":{"message":"Chaos: request
+                  dropped","type":"server_error","code":"chaos_drop"}}</code
+                >
               </td>
             </tr>
             <tr>
@@ -204,7 +207,7 @@
     <span class="str">"Content-Type"</span>: <span class="str">"application/json"</span>,
     <span class="str">"x-aimock-chaos-disconnect"</span>: <span class="str">"1.0"</span>,
   },
-  <span class="prop">body</span>: <span class="fn">JSON.stringify</span>({ <span class="prop">model</span>: <span class="str">"gpt-4"</span>, <span class="prop">messages</span>: [...] }),
+  <span class="prop">body</span>: <span class="fn">JSON.stringify</span>({ <span class="prop">model</span>: <span class="str">"gpt-4"</span>, <span class="prop">messages</span>: [{ <span class="prop">role</span>: <span class="str">"user"</span>, <span class="prop">content</span>: <span class="str">"hello"</span> }] }),
 });</code></pre>
         </div>
 
@@ -217,7 +220,7 @@
               <div class="code-block-header">
                 CLI chaos flags <span class="lang-tag">shell</span>
               </div>
-              <pre><code>$ npx -p @copilotkit/aimock llmock --fixtures ./fixtures \
+              <pre><code>$ npx -p @copilotkit/aimock aimock --fixtures ./fixtures \
   --chaos-drop 0.1 \
   --chaos-malformed 0.05 \
   --chaos-disconnect 0.02</code></pre>
@@ -239,6 +242,55 @@
           </div>
         </div>
 
+        <h2>Proxy Mode</h2>
+        <p>
+          When aimock is configured as a record/replay proxy (<code>--record</code>), chaos applies
+          to proxied requests too &mdash; so a staging environment pointed at real upstream APIs
+          still sees the failure modes your tests expect. Chaos is rolled <em>once per request</em>,
+          after fixture matching, with the same headers&nbsp;&gt;&nbsp;fixture&nbsp;&gt;&nbsp;server
+          precedence.
+        </p>
+        <table class="endpoint-table">
+          <thead>
+            <tr>
+              <th>Mode</th>
+              <th>When upstream is contacted</th>
+              <th>What the client sees</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>drop</code></td>
+              <td>Never &mdash; upstream not contacted</td>
+              <td>HTTP 500 chaos body; upstream is not called</td>
+            </tr>
+            <tr>
+              <td><code>disconnect</code></td>
+              <td>Never &mdash; upstream not contacted</td>
+              <td>Connection destroyed; upstream is not called</td>
+            </tr>
+            <tr>
+              <td><code>malformed</code></td>
+              <td>Called &mdash; post-response</td>
+              <td>
+                Request proxies normally; the upstream response is captured, then the body is
+                replaced with invalid JSON before relay. The recorded fixture (if recording) keeps
+                the real upstream response &mdash; chaos is a live-traffic decoration, not a fixture
+                mutation.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          <strong>SSE bypass.</strong> If upstream returns
+          <code>Content-Type: text/event-stream</code>, aimock streams chunks to the client
+          progressively. By the time <code>malformed</code> would fire, the bytes are already on the
+          wire &mdash; the chaos action cannot be applied. This bypass is observable via the
+          <code>aimock_chaos_bypassed_total</code> counter (see Prometheus Metrics below) and a
+          warning in the server log, so a configured chaos rate doesn't silently drop to 0% on SSE
+          traffic. Streaming mutation is planned for a future phase.
+        </p>
+
         <h2>Journal Tracking</h2>
         <p>
           When chaos triggers, the journal entry includes a <code>chaosAction</code> field recording
@@ -254,6 +306,7 @@
   "path": "/v1/chat/completions",
   "response": {
     "status": 500,
+    "source": "fixture",
     "fixture": { "...": "elided for brevity" },
     "chaosAction": "drop"
   }
@@ -268,15 +321,31 @@
         <h2>Prometheus Metrics</h2>
         <p>
           When metrics are enabled (<code>--metrics</code>), each chaos trigger increments the
-          <code>aimock_chaos_triggered_total</code> counter with an <code>action</code> label:
+          <code>aimock_chaos_triggered_total</code> counter, tagged with <code>action</code> and
+          <code>source</code>. <code>source="fixture"</code> means a fixture matched (or would have,
+          before chaos intervened); <code>source="proxy"</code> means the request was on the proxy
+          dispatch path.
         </p>
 
         <div class="code-block">
           <div class="code-block-header">Metrics output <span class="lang-tag">text</span></div>
           <pre><code># TYPE aimock_chaos_triggered_total counter
-aimock_chaos_triggered_total{action="drop"} 3
-aimock_chaos_triggered_total{action="malformed"} 1
-aimock_chaos_triggered_total{action="disconnect"} 2</code></pre>
+aimock_chaos_triggered_total{action="drop",source="fixture"} 3
+aimock_chaos_triggered_total{action="malformed",source="fixture"} 1
+aimock_chaos_triggered_total{action="disconnect",source="proxy"} 2</code></pre>
+        </div>
+
+        <p>
+          When a chaos action is rolled but can't be applied &mdash; today, only
+          <code>malformed</code> on an SSE proxy response &mdash; the bypass is recorded in a
+          separate counter so operators can distinguish "chaos didn't roll" from "chaos rolled but
+          was bypassed":
+        </p>
+
+        <div class="code-block">
+          <div class="code-block-header">Bypass counter <span class="lang-tag">text</span></div>
+          <pre><code># TYPE aimock_chaos_bypassed_total counter
+aimock_chaos_bypassed_total{action="malformed",source="proxy",reason="sse_streamed"} 4</code></pre>
         </div>
       </main>
       <aside class="page-toc" id="page-toc"></aside>

--- a/src/__tests__/chaos-fixture-mode.test.ts
+++ b/src/__tests__/chaos-fixture-mode.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { createServer, type ServerInstance } from "../server.js";
+
+// minimal helpers duplicated to keep this test isolated
+import * as http from "node:http";
+
+function post(url: string, body: unknown): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+let server: ServerInstance | undefined;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((resolve) => server!.server.close(() => resolve()));
+    server = undefined;
+  }
+});
+
+const CHAT_REQUEST = {
+  model: "gpt-4",
+  messages: [{ role: "user", content: "What is the capital of France?" }],
+};
+
+describe("chaos (fixture mode)", () => {
+  it("pre-flight chaos short-circuits even when fixture would match", async () => {
+    const fixture = {
+      match: { userMessage: "capital of France" },
+      response: { content: "Paris" },
+    };
+
+    server = await createServer([fixture], {
+      port: 0,
+      chaos: { dropRate: 1.0 },
+    });
+
+    const resp = await post(`${server.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    expect(resp.status).toBe(500);
+    const body = JSON.parse(resp.body);
+    expect(body).toMatchObject({ error: { code: "chaos_drop" } });
+  });
+});

--- a/src/__tests__/chaos-fixture-mode.test.ts
+++ b/src/__tests__/chaos-fixture-mode.test.ts
@@ -48,7 +48,7 @@ const CHAT_REQUEST = {
 };
 
 describe("chaos (fixture mode)", () => {
-  it("pre-flight chaos short-circuits even when fixture would match", async () => {
+  it("chaos short-circuits even when fixture would match", async () => {
     const fixture = {
       match: { userMessage: "capital of France" },
       response: { content: "Paris" },
@@ -64,5 +64,30 @@ describe("chaos (fixture mode)", () => {
     expect(resp.status).toBe(500);
     const body = JSON.parse(resp.body);
     expect(body).toMatchObject({ error: { code: "chaos_drop" } });
+  });
+
+  it("rolls chaos once per request: drop journals the matched fixture, not null", async () => {
+    // Pins the single-roll behavior: chaos evaluation happens AFTER fixture
+    // matching, so when drop fires on a request that matches a fixture, the
+    // journal entry reflects the match (not null, as the old double-roll
+    // pre-flight path would have recorded).
+    const fixture = {
+      match: { userMessage: "capital of France" },
+      response: { content: "Paris" },
+    };
+
+    server = await createServer([fixture], {
+      port: 0,
+      chaos: { dropRate: 1.0 },
+    });
+
+    const resp = await post(`${server.url}/v1/chat/completions`, CHAT_REQUEST);
+    expect(resp.status).toBe(500);
+
+    const last = server.journal.getLast();
+    expect(last?.response.chaosAction).toBe("drop");
+    expect(last?.response.fixture).toBe(fixture);
+    // Match count reflects that the fixture did participate in the decision
+    expect(server.journal.getFixtureMatchCount(fixture)).toBe(1);
   });
 });

--- a/src/__tests__/chaos-fixture-mode.test.ts
+++ b/src/__tests__/chaos-fixture-mode.test.ts
@@ -90,4 +90,28 @@ describe("chaos (fixture mode)", () => {
     // Match count reflects that the fixture did participate in the decision
     expect(server.journal.getFixtureMatchCount(fixture)).toBe(1);
   });
+
+  it("disconnect journals the matched fixture with status 0", async () => {
+    // Symmetric to the drop test above. Disconnect's status is 0 (no response
+    // ever written before res.destroy()) which is a slightly unusual shape;
+    // pin it so future refactors don't silently change it to e.g. 500.
+    const fixture = {
+      match: { userMessage: "capital of France" },
+      response: { content: "Paris" },
+    };
+
+    server = await createServer([fixture], {
+      port: 0,
+      chaos: { disconnectRate: 1.0 },
+    });
+
+    // Client sees a socket destroy mid-request → post() rejects
+    await expect(post(`${server.url}/v1/chat/completions`, CHAT_REQUEST)).rejects.toThrow();
+
+    const last = server.journal.getLast();
+    expect(last?.response.chaosAction).toBe("disconnect");
+    expect(last?.response.status).toBe(0);
+    expect(last?.response.fixture).toBe(fixture);
+    expect(server.journal.getFixtureMatchCount(fixture)).toBe(1);
+  });
 });

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -549,7 +549,7 @@ describe("integration: /metrics endpoint", () => {
     expect(infMatch![1]).toBe(countMatch![1]);
   });
 
-  it("increments chaos counter when chaos triggers", async () => {
+  it("increments chaos counter when chaos triggers (fixture source)", async () => {
     const fixtures: Fixture[] = [
       {
         match: { userMessage: "hello" },
@@ -565,7 +565,43 @@ describe("integration: /metrics endpoint", () => {
 
     const res = await httpGet(`${instance.url}/metrics`);
     expect(res.body).toContain("aimock_chaos_triggered_total");
-    expect(res.body).toMatch(/aimock_chaos_triggered_total\{[^}]*action="drop"[^}]*\} 1/);
+    // Require both labels: action AND source. The source label is part of the
+    // public metric contract (added when chaos was extended to proxy mode) and
+    // an unasserted label is a regression hazard — future callers that forget
+    // to pass source would serialize `source=""` and pass a bare action match.
+    expect(res.body).toMatch(
+      /aimock_chaos_triggered_total\{[^}]*action="drop"[^}]*source="fixture"[^}]*\} 1/,
+    );
+  });
+
+  it('chaos counter carries source="proxy" on proxy path', async () => {
+    // Counterpart to the fixture-source test: proves the source label flips
+    // correctly when the chaos roll belongs to the proxy dispatch branch.
+    // Together these two tests pin both label values of the source dimension.
+    const upstream = await createServer(
+      [{ match: { userMessage: "hi" }, response: { content: "upstream" } }],
+      { port: 0 },
+    );
+    try {
+      instance = await createServer([], {
+        metrics: true,
+        chaos: { dropRate: 1.0 },
+        record: {
+          providers: { openai: upstream.url },
+          fixturePath: "/tmp/aimock-metrics-proxy-source",
+          proxyOnly: true,
+        },
+      });
+
+      await httpPost(`${instance.url}/v1/chat/completions`, chatRequest("hi"));
+
+      const res = await httpGet(`${instance.url}/metrics`);
+      expect(res.body).toMatch(
+        /aimock_chaos_triggered_total\{[^}]*action="drop"[^}]*source="proxy"[^}]*\} 1/,
+      );
+    } finally {
+      await new Promise<void>((resolve) => upstream.server.close(() => resolve()));
+    }
   });
 
   it("increments chaos counter on Anthropic /v1/messages endpoint", async () => {
@@ -588,7 +624,9 @@ describe("integration: /metrics endpoint", () => {
 
     const res = await httpGet(`${instance.url}/metrics`);
     expect(res.body).toContain("aimock_chaos_triggered_total");
-    expect(res.body).toMatch(/aimock_chaos_triggered_total\{[^}]*action="drop"[^}]*\} 1/);
+    expect(res.body).toMatch(
+      /aimock_chaos_triggered_total\{[^}]*action="drop"[^}]*source="fixture"[^}]*\} 1/,
+    );
   });
 
   it("tracks fixtures loaded gauge", async () => {

--- a/src/__tests__/multimedia-record.test.ts
+++ b/src/__tests__/multimedia-record.test.ts
@@ -105,7 +105,7 @@ describe("multimedia record: image response detection", () => {
       };
 
       const { req, res } = createMockReqRes("/v1/images/generations");
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         request,
@@ -115,7 +115,7 @@ describe("multimedia record: image response detection", () => {
         { record, logger },
       );
 
-      expect(proxied).toBe(true);
+      expect(outcome).toBe("relayed");
       expect(fixtures).toHaveLength(1);
       const fixture = fixtures[0];
       expect(fixture.match.endpoint).toBe("image");

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -267,7 +267,6 @@ describe("proxy-only mode", () => {
 
     await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
   });
-
   it("regular record mode DOES cache in memory — second request served from cache", async () => {
     // Use a counting upstream to verify only the first request is proxied
     const countingUpstream = await createCountingUpstream("cached response");

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -267,6 +267,62 @@ describe("proxy-only mode", () => {
 
     await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
   });
+
+  it("applies malformed chaos AFTER proxying (upstream called, body corrupted, journaled)", async () => {
+    const countingUpstream = await createCountingUpstream("valid content");
+
+    recorder = await createServer([], {
+      port: 0,
+      chaos: { malformedRate: 1.0 },
+      record: {
+        providers: { openai: countingUpstream.url },
+        fixturePath: (tmpDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "aimock-chaos-postresponse-"),
+        )),
+        proxyOnly: true,
+      },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    // Upstream IS called: malformed is a post-response mutation, not a pre-flight drop
+    expect(countingUpstream.getCount()).toBe(1);
+    // Client sees 200 with a body that does NOT parse as JSON
+    expect(resp.status).toBe(200);
+    expect(() => JSON.parse(resp.body)).toThrow();
+    // Journal records the chaos action exactly once (no double-entry from the
+    // chaos path + the default proxy-relay path)
+    expect(recorder.journal.size).toBe(1);
+    const last = recorder.journal.getLast();
+    expect(last?.response.chaosAction).toBe("malformed");
+    expect(last?.response.fixture).toBeNull();
+
+    await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
+  });
+
+  it("preserves upstream content-type on replay when no chaos fires", async () => {
+    const countingUpstream = await createCountingUpstream("valid content");
+
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: countingUpstream.url },
+        fixturePath: (tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-proxy-ct-"))),
+        proxyOnly: true,
+      },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    expect(resp.status).toBe(200);
+    const ct = resp.headers["content-type"];
+    expect(typeof ct === "string" ? ct : "").toContain("application/json");
+    // Body is valid JSON and round-trips
+    expect(JSON.parse(resp.body).choices[0].message.content).toBe("valid content");
+
+    await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
+  });
+
   it("regular record mode DOES cache in memory — second request served from cache", async () => {
     // Use a counting upstream to verify only the first request is proxied
     const countingUpstream = await createCountingUpstream("cached response");

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -225,6 +225,49 @@ describe("proxy-only mode", () => {
     await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
   });
 
+  it("applies chaos BEFORE proxying (drop)", async () => {
+    const countingUpstream = await createCountingUpstream("should not be hit");
+
+    recorder = await createServer([], {
+      port: 0,
+      chaos: { dropRate: 1.0 },
+      record: {
+        providers: { openai: countingUpstream.url },
+        fixturePath: (tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-chaos-proxy-"))),
+        proxyOnly: true,
+      },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    expect(resp.status).toBe(500);
+    expect(countingUpstream.getCount()).toBe(0);
+
+    await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
+  });
+
+  it("applies chaos BEFORE proxying (disconnect)", async () => {
+    const countingUpstream = await createCountingUpstream("should not be hit");
+
+    recorder = await createServer([], {
+      port: 0,
+      chaos: { disconnectRate: 1.0 },
+      record: {
+        providers: { openai: countingUpstream.url },
+        fixturePath: (tmpDir = fs.mkdtempSync(
+          path.join(os.tmpdir(), "aimock-chaos-proxy-disconnect-"),
+        )),
+        proxyOnly: true,
+      },
+    });
+
+    await expect(post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST)).rejects.toThrow();
+
+    expect(countingUpstream.getCount()).toBe(0);
+
+    await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
+  });
+
   it("regular record mode DOES cache in memory — second request served from cache", async () => {
     // Use a counting upstream to verify only the first request is proxied
     const countingUpstream = await createCountingUpstream("cached response");

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -376,6 +376,76 @@ describe("proxy-only mode", () => {
     expect(entry?.response.chaosAction).toBeUndefined();
   });
 
+  it("SSE upstream bypasses malformed chaos: body intact, bypass counted, journal clean", async () => {
+    // Pins the one place chaos silently no-ops: when upstream streams SSE,
+    // the bytes are already on the wire before the chaos hook could fire.
+    // Without an explicit bypass signal, malformedRate: 1.0 on SSE traffic
+    // would silently mean 0% corruption with no log, metric, or journal
+    // trace. Lifting the gate out of recorder.ts in a future refactor
+    // (phase 3: streaming mutation) should trip this test.
+    const sseUpstream = await new Promise<{ server: http.Server; url: string }>((resolve) => {
+      const server = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "text/event-stream" });
+        res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: "hi" } }] })}\n\n`);
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address() as { port: number };
+        resolve({ server, url: `http://127.0.0.1:${port}` });
+      });
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      metrics: true,
+      chaos: { malformedRate: 1.0 },
+      record: {
+        providers: { openai: sseUpstream.url },
+        fixturePath: (tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-chaos-sse-"))),
+        proxyOnly: true,
+      },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    // Client receives a real SSE stream — content-type and frames intact, not
+    // the malformed-JSON sentinel.
+    expect(resp.status).toBe(200);
+    const ct = resp.headers["content-type"];
+    expect(typeof ct === "string" ? ct : "").toContain("text/event-stream");
+    expect(resp.body).toContain("data: ");
+    expect(resp.body).not.toContain("{malformed json");
+
+    // Journal records the relayed proxy call, NOT a chaos action — the
+    // chaos roll happened but couldn't be applied, so claiming it fired
+    // would be a lie to the observer.
+    expect(recorder.journal.size).toBe(1);
+    const last = recorder.journal.getLast();
+    expect(last?.response.chaosAction).toBeUndefined();
+    expect(last?.response.source).toBe("proxy");
+
+    // Bypass must be visible in metrics so operators can see that a
+    // configured chaos action didn't fire.
+    const metricsRes = await new Promise<{ body: string }>((resolve, reject) => {
+      const mReq = http.request(`${recorder!.url}/metrics`, { method: "GET" }, (mRes) => {
+        const chunks: Buffer[] = [];
+        mRes.on("data", (c: Buffer) => chunks.push(c));
+        mRes.on("end", () => resolve({ body: Buffer.concat(chunks).toString() }));
+      });
+      mReq.on("error", reject);
+      mReq.end();
+    });
+    expect(metricsRes.body).toMatch(
+      /aimock_chaos_bypassed_total\{[^}]*action="malformed"[^}]*source="proxy"[^}]*\} 1/,
+    );
+    // Paired negative: the normal chaos_triggered counter must NOT increment
+    // for a bypass — the action didn't actually fire.
+    expect(metricsRes.body).not.toMatch(/aimock_chaos_triggered_total\{[^}]*action="malformed"/);
+
+    await new Promise<void>((resolve) => sseUpstream.server.close(() => resolve()));
+  });
+
   it("regular record mode DOES cache in memory — second request served from cache", async () => {
     // Use a counting upstream to verify only the first request is proxied
     const countingUpstream = await createCountingUpstream("cached response");

--- a/src/__tests__/proxy-only.test.ts
+++ b/src/__tests__/proxy-only.test.ts
@@ -323,6 +323,59 @@ describe("proxy-only mode", () => {
     await new Promise<void>((resolve) => countingUpstream.server.close(() => resolve()));
   });
 
+  it("proxy failure produces 502 end-to-end and journals the failure", async () => {
+    // Integration test: unit tests prove recorder.ts writes 502 on upstream
+    // failure; this pins that handleCompletions handles the "relayed" outcome
+    // correctly (journals, doesn't hang).
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: "http://127.0.0.1:1" }, // port 1 — unreachable
+        fixturePath: (tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-proxy-fail-"))),
+        proxyOnly: true,
+      },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    expect(resp.status).toBe(502);
+    expect(recorder.journal.size).toBe(1);
+    const entry = recorder.journal.getLast();
+    expect(entry?.response.status).toBe(502);
+    expect(entry?.response.fixture).toBeNull();
+    expect(entry?.response.source).toBe("proxy");
+    expect(entry?.response.chaosAction).toBeUndefined();
+  });
+
+  it("chaos + proxy failure: malformed was rolled but upstream failed → 502, no chaosAction", async () => {
+    // Integration test: when chaos rolls malformed but the upstream request
+    // fails, proxyAndRecord synthesizes a 502 before the hook is invoked. The
+    // journal should reflect what actually happened (502, no chaos) rather
+    // than what was intended.
+    recorder = await createServer([], {
+      port: 0,
+      chaos: { malformedRate: 1.0 },
+      record: {
+        providers: { openai: "http://127.0.0.1:1" }, // unreachable
+        fixturePath: (tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-chaos-proxy-fail-"))),
+        proxyOnly: true,
+      },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, CHAT_REQUEST);
+
+    // Client sees the proxy failure, NOT a malformed-JSON body
+    expect(resp.status).toBe(502);
+    expect(() => JSON.parse(resp.body)).not.toThrow();
+
+    expect(recorder.journal.size).toBe(1);
+    const entry = recorder.journal.getLast();
+    expect(entry?.response.status).toBe(502);
+    expect(entry?.response.source).toBe("proxy");
+    // Chaos was rolled but never applied — journal must not claim it fired
+    expect(entry?.response.chaosAction).toBeUndefined();
+  });
+
   it("regular record mode DOES cache in memory — second request served from cache", async () => {
     // Use a counting upstream to verify only the first request is proxied
     const countingUpstream = await createCountingUpstream("cached response");

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Fixture, FixtureFile } from "../types.js";
 import { createServer, type ServerInstance } from "../server.js";
-import { proxyAndRecord } from "../recorder.js";
+import { proxyAndRecord, type ProxyCapturedResponse } from "../recorder.js";
 import type { RecordConfig } from "../types.js";
 import { Logger } from "../logger.js";
 import { LLMock } from "../llmock.js";
@@ -149,6 +149,70 @@ describe("proxyAndRecord", () => {
     );
 
     expect(result).toBe("not_configured");
+  });
+
+  it("beforeWriteResponse hook receives raw upstream bytes (binary-safe)", async () => {
+    // Pins the refactor's claim that the hook sees raw upstream bytes, not a
+    // UTF-8-decoded-then-re-encoded view. Uses a deliberately non-UTF8 byte
+    // sequence so any round-trip through String() would corrupt it.
+    const bytes = Buffer.from([0xff, 0xfe, 0xfd, 0x00, 0x01, 0x02, 0x7f, 0x80]);
+
+    const binaryUpstream = http.createServer((_upReq, upRes) => {
+      upRes.writeHead(200, { "Content-Type": "application/octet-stream" });
+      upRes.end(bytes);
+    });
+    await new Promise<void>((resolve) => binaryUpstream.listen(0, "127.0.0.1", () => resolve()));
+    const upstreamPort = (binaryUpstream.address() as { port: number }).port;
+
+    let captured: ProxyCapturedResponse | undefined;
+
+    // Minimal HTTP server that invokes proxyAndRecord with our capture hook,
+    // so req/res are real and the full recorder pipeline exercises the hook.
+    const recorderServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", async () => {
+        const rawBody = Buffer.concat(chunks).toString();
+        await proxyAndRecord(
+          req,
+          res,
+          JSON.parse(rawBody),
+          "openai",
+          "/v1/chat/completions",
+          [],
+          {
+            record: {
+              providers: { openai: `http://127.0.0.1:${upstreamPort}` },
+              proxyOnly: true,
+            },
+            logger: new Logger("silent"),
+          },
+          rawBody,
+          {
+            beforeWriteResponse: (response) => {
+              captured = response;
+              return false; // let the default relay proceed; we only wanted to observe
+            },
+          },
+        );
+      });
+    });
+    await new Promise<void>((resolve) => recorderServer.listen(0, "127.0.0.1", () => resolve()));
+    const recorderPort = (recorderServer.address() as { port: number }).port;
+
+    try {
+      await post(`http://127.0.0.1:${recorderPort}/v1/chat/completions`, {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      expect(captured).toBeDefined();
+      expect(captured!.body).toBeInstanceOf(Buffer);
+      expect(Buffer.compare(captured!.body, bytes)).toBe(0);
+    } finally {
+      await new Promise<void>((resolve) => binaryUpstream.close(() => resolve()));
+      await new Promise<void>((resolve) => recorderServer.close(() => resolve()));
+    }
   });
 });
 

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -110,13 +110,13 @@ afterEach(async () => {
 // ---------------------------------------------------------------------------
 
 describe("proxyAndRecord", () => {
-  it("returns false when provider is not configured", async () => {
+  it('returns "not_configured" when provider is not configured', async () => {
     const fixtures: Fixture[] = [];
     const logger = new Logger("silent");
     const record: RecordConfig = { providers: {} };
 
     // Create a mock req/res pair — we just need them to exist,
-    // proxyAndRecord should return false before using them
+    // proxyAndRecord should short-circuit before using them
     const { req, res } = createMockReqRes();
 
     const result = await proxyAndRecord(
@@ -129,10 +129,10 @@ describe("proxyAndRecord", () => {
       { record, logger },
     );
 
-    expect(result).toBe(false);
+    expect(result).toBe("not_configured");
   });
 
-  it("returns false when record config is undefined", async () => {
+  it('returns "not_configured" when record config is undefined', async () => {
     const fixtures: Fixture[] = [];
     const logger = new Logger("silent");
 
@@ -148,7 +148,7 @@ describe("proxyAndRecord", () => {
       { record: undefined, logger },
     );
 
-    expect(result).toBe(false);
+    expect(result).toBe("not_configured");
   });
 });
 

--- a/src/bedrock-converse.ts
+++ b/src/bedrock-converse.ts
@@ -298,6 +298,7 @@ export async function handleConverse(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )
@@ -508,6 +509,7 @@ export async function handleConverseStream(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/bedrock-converse.ts
+++ b/src/bedrock-converse.ts
@@ -306,7 +306,7 @@ export async function handleConverse(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -316,7 +316,7 @@ export async function handleConverse(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: urlPath,
@@ -516,7 +516,7 @@ export async function handleConverseStream(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -526,7 +526,7 @@ export async function handleConverseStream(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: urlPath,

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -350,7 +350,7 @@ export async function handleBedrock(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -360,7 +360,7 @@ export async function handleBedrock(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: urlPath,
@@ -707,7 +707,7 @@ export async function handleBedrockStream(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -717,7 +717,7 @@ export async function handleBedrockStream(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: urlPath,

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -342,6 +342,7 @@ export async function handleBedrock(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )
@@ -699,6 +700,7 @@ export async function handleBedrockStream(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/chaos.ts
+++ b/src/chaos.ts
@@ -137,6 +137,10 @@ interface ChaosJournalContext {
 /**
  * Apply chaos to a request. Returns true if chaos was applied (caller should
  * return early), false if the request should proceed normally.
+ *
+ * `source` is required so the invariant "this handler only applies chaos in
+ * the <X> phase" is enforced at the type level. A future handler that grows
+ * a proxy path MUST pass `"proxy"` explicitly; the default can't drift silently.
  */
 export function applyChaos(
   res: http.ServerResponse,
@@ -145,14 +149,13 @@ export function applyChaos(
   rawHeaders: http.IncomingHttpHeaders,
   journal: Journal,
   context: ChaosJournalContext,
+  source: "fixture" | "proxy",
   registry?: MetricsRegistry,
   logger?: Logger,
 ): boolean {
   const action = evaluateChaos(fixture, serverDefaults, rawHeaders, logger);
   if (!action) return false;
-  // Existing callers (non-chat handlers) only apply chaos in fixture-serving
-  // contexts; "fixture" is the correct default source for them.
-  applyChaosAction(action, res, fixture, journal, context, "fixture", registry);
+  applyChaosAction(action, res, fixture, journal, context, source, registry);
   return true;
 }
 

--- a/src/chaos.ts
+++ b/src/chaos.ts
@@ -150,7 +150,24 @@ export function applyChaos(
 ): boolean {
   const action = evaluateChaos(fixture, serverDefaults, rawHeaders, logger);
   if (!action) return false;
+  applyChaosAction(action, res, fixture, journal, context, registry);
+  return true;
+}
 
+/**
+ * Apply a specific (already-rolled) chaos action. Exposed so callers that roll
+ * the dice themselves can dispatch without re-rolling — important when the
+ * caller wants to branch on the action before committing (e.g. pre-flight vs.
+ * post-response phases).
+ */
+export function applyChaosAction(
+  action: ChaosAction,
+  res: http.ServerResponse,
+  fixture: Fixture | null,
+  journal: Journal,
+  context: ChaosJournalContext,
+  registry?: MetricsRegistry,
+): void {
   if (registry) {
     registry.incrementCounter("aimock_chaos_triggered_total", { action });
   }
@@ -172,7 +189,7 @@ export function applyChaos(
           },
         }),
       );
-      return true;
+      return;
     }
     case "malformed": {
       journal.add({
@@ -181,7 +198,7 @@ export function applyChaos(
       });
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end("{malformed json: <<<chaos>>>");
-      return true;
+      return;
     }
     case "disconnect": {
       journal.add({
@@ -189,12 +206,12 @@ export function applyChaos(
         response: { status: 0, fixture, chaosAction: "disconnect" },
       });
       res.destroy();
-      return true;
+      return;
     }
     default: {
       const _exhaustive: never = action;
       void _exhaustive;
-      return false;
+      return;
     }
   }
 }

--- a/src/chaos.ts
+++ b/src/chaos.ts
@@ -131,7 +131,7 @@ interface ChaosJournalContext {
   method: string;
   path: string;
   headers: Record<string, string>;
-  body: ChatCompletionRequest;
+  body: ChatCompletionRequest | null;
 }
 
 /**

--- a/src/chaos.ts
+++ b/src/chaos.ts
@@ -177,7 +177,7 @@ export function applyChaosAction(
   registry?: MetricsRegistry,
 ): void {
   if (registry) {
-    registry.incrementCounter("aimock_chaos_triggered_total", { action });
+    registry.incrementCounter("aimock_chaos_triggered_total", { action, source });
   }
 
   switch (action) {

--- a/src/chaos.ts
+++ b/src/chaos.ts
@@ -150,7 +150,9 @@ export function applyChaos(
 ): boolean {
   const action = evaluateChaos(fixture, serverDefaults, rawHeaders, logger);
   if (!action) return false;
-  applyChaosAction(action, res, fixture, journal, context, registry);
+  // Existing callers (non-chat handlers) only apply chaos in fixture-serving
+  // contexts; "fixture" is the correct default source for them.
+  applyChaosAction(action, res, fixture, journal, context, "fixture", registry);
   return true;
 }
 
@@ -159,6 +161,11 @@ export function applyChaos(
  * the dice themselves can dispatch without re-rolling — important when the
  * caller wants to branch on the action before committing (e.g. pre-flight vs.
  * post-response phases).
+ *
+ * `source` is required (not optional) so callers can't silently omit it on
+ * one branch and journal an ambiguous entry. Pass `"fixture"` when a fixture
+ * matched (or would have) and `"proxy"` when the request was headed for the
+ * proxy path.
  */
 export function applyChaosAction(
   action: ChaosAction,
@@ -166,6 +173,7 @@ export function applyChaosAction(
   fixture: Fixture | null,
   journal: Journal,
   context: ChaosJournalContext,
+  source: "fixture" | "proxy",
   registry?: MetricsRegistry,
 ): void {
   if (registry) {
@@ -176,7 +184,7 @@ export function applyChaosAction(
     case "drop": {
       journal.add({
         ...context,
-        response: { status: 500, fixture, chaosAction: "drop" },
+        response: { status: 500, fixture, chaosAction: "drop", source },
       });
       writeErrorResponse(
         res,
@@ -194,7 +202,7 @@ export function applyChaosAction(
     case "malformed": {
       journal.add({
         ...context,
-        response: { status: 200, fixture, chaosAction: "malformed" },
+        response: { status: 200, fixture, chaosAction: "malformed", source },
       });
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end("{malformed json: <<<chaos>>>");
@@ -203,7 +211,7 @@ export function applyChaosAction(
     case "disconnect": {
       journal.add({
         ...context,
-        response: { status: 0, fixture, chaosAction: "disconnect" },
+        response: { status: 0, fixture, chaosAction: "disconnect", source },
       });
       res.destroy();
       return;

--- a/src/cohere.ts
+++ b/src/cohere.ts
@@ -500,7 +500,7 @@ export async function handleCohere(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -510,7 +510,7 @@ export async function handleCohere(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: req.url ?? "/v2/chat",

--- a/src/cohere.ts
+++ b/src/cohere.ts
@@ -492,6 +492,7 @@ export async function handleCohere(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -113,6 +113,7 @@ export async function handleEmbeddings(
         headers: flattenHeaders(req.headers),
         body: syntheticReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -176,7 +176,7 @@ export async function handleEmbeddings(
 
   // No fixture match — try record-and-replay proxy if configured
   if (defaults.record) {
-    const proxied = await proxyAndRecord(
+    const outcome = await proxyAndRecord(
       req,
       res,
       syntheticReq,
@@ -186,7 +186,7 @@ export async function handleEmbeddings(
       defaults,
       raw,
     );
-    if (proxied) {
+    if (outcome !== "not_configured") {
       journal.add({
         method: req.method ?? "POST",
         path: req.url ?? "/v1/embeddings",

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -570,7 +570,7 @@ export async function handleGemini(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -580,7 +580,7 @@ export async function handleGemini(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path,

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -562,6 +562,7 @@ export async function handleGemini(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/images.ts
+++ b/src/images.ts
@@ -106,7 +106,7 @@ export async function handleImages(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         syntheticReq,
@@ -116,7 +116,7 @@ export async function handleImages(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method,
           path,

--- a/src/images.ts
+++ b/src/images.ts
@@ -98,6 +98,7 @@ export async function handleImages(
       req.headers,
       journal,
       { method, path, headers: flattenHeaders(req.headers), body: syntheticReq },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -760,7 +760,7 @@ export async function handleMessages(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -770,7 +770,7 @@ export async function handleMessages(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: req.url ?? "/v1/messages",

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -752,6 +752,7 @@ export async function handleMessages(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -415,6 +415,7 @@ export async function handleOllama(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )
@@ -674,6 +675,7 @@ export async function handleOllamaGenerate(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -423,7 +423,7 @@ export async function handleOllama(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -433,7 +433,7 @@ export async function handleOllama(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: urlPath,
@@ -682,7 +682,7 @@ export async function handleOllamaGenerate(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -692,7 +692,7 @@ export async function handleOllamaGenerate(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: urlPath,

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -158,7 +158,11 @@ export async function proxyAndRecord(
     return "relayed";
   }
 
-  // Detect streaming response and collapse if necessary
+  // Detect streaming response and collapse if necessary.
+  // NOTE: collapse buffers the entire upstream body in memory. Fine for
+  // current chat-completions traffic (responses are small), but revisit if
+  // this path ever proxies long-lived or large streams — both the buffer
+  // here and the hook below receive the full payload.
   const contentType = upstreamHeaders["content-type"];
   const ctString = Array.isArray(contentType) ? contentType.join(", ") : (contentType ?? "");
   const isBinaryStream = ctString.toLowerCase().includes("application/vnd.amazon.eventstream");
@@ -261,7 +265,10 @@ export async function proxyAndRecord(
         warnings.push("Stream response was truncated — fixture may be incomplete");
       }
 
-      // Auth headers are forwarded to upstream but excluded from saved fixtures for security
+      // Auth headers are forwarded to upstream but excluded from saved fixtures for security.
+      // NOTE: the persisted fixture is always the real upstream response, even when chaos
+      // later mutates the relay (e.g. malformed via beforeWriteResponse). Chaos is a live-traffic
+      // decoration; the recorded artifact must stay truthful so replay sees what upstream said.
       const fileContent: Record<string, unknown> = { fixtures: [fixture] };
       if (warnings.length > 0) {
         fileContent._warning = warnings.join("; ");

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -37,6 +37,28 @@ const STRIP_HEADERS = new Set([
 ]);
 
 /**
+ * Captured upstream response, exposed to the `beforeWriteResponse` hook so
+ * callers can decide whether to relay it or mutate it (e.g. chaos injection).
+ */
+export interface ProxyCapturedResponse {
+  status: number;
+  contentType: string;
+  body: Buffer;
+  isBinary: boolean;
+}
+
+export interface ProxyOptions {
+  /**
+   * Called after the upstream response has been captured and recorded, but
+   * before the relay to the client. If the hook writes its own response and
+   * returns `true`, the default relay is skipped. Returning `false` (or
+   * omitting the hook) lets proxyAndRecord relay the upstream response
+   * normally. Rejected promises propagate and leave the response unwritten.
+   */
+  beforeWriteResponse?: (response: ProxyCapturedResponse) => boolean | Promise<boolean>;
+}
+
+/**
  * Proxy an unmatched request to the real upstream provider, record the
  * response as a fixture on disk and in memory, then relay the response
  * back to the original client.
@@ -57,6 +79,7 @@ export async function proxyAndRecord(
     requestTransform?: (req: ChatCompletionRequest) => ChatCompletionRequest;
   },
   rawBody?: string,
+  options?: ProxyOptions,
 ): Promise<boolean> {
   const record = defaults.record;
   if (!record) return false;
@@ -258,6 +281,19 @@ export async function proxyAndRecord(
   // progressively by makeUpstreamRequest — headers and body are already on
   // the wire).
   if (!streamedToClient) {
+    // Give the caller a chance to mutate or replace the response before relay.
+    // Used by the chaos layer to turn a successful proxy into a malformed body.
+    // `body` is the raw upstream bytes so binary payloads survive round-tripping.
+    if (options?.beforeWriteResponse) {
+      const handled = await options.beforeWriteResponse({
+        status: upstreamStatus,
+        contentType: ctString,
+        body: rawBuffer,
+        isBinary: isBinaryStream,
+      });
+      if (handled) return true;
+    }
+
     const relayHeaders: Record<string, string> = {};
     if (ctString) {
       relayHeaders["Content-Type"] = ctString;

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -49,12 +49,29 @@ export interface ProxyCapturedResponse {
 export interface ProxyOptions {
   /**
    * Called after the upstream response has been captured and recorded, but
-   * before the relay to the client. If the hook writes its own response and
-   * returns `true`, the default relay is skipped. Returning `false` (or
-   * omitting the hook) lets proxyAndRecord relay the upstream response
-   * normally. Rejected promises propagate and leave the response unwritten.
+   * before the relay to the client. Contract when the hook returns `true`:
+   *   1. It wrote its own response body on `res`.
+   *   2. It journaled the outcome (proxyAndRecord will NOT journal it).
+   *   3. proxyAndRecord skips its default relay and returns `"handled_by_hook"`.
+   *
+   * Returning `false` (or omitting the hook) lets proxyAndRecord relay the
+   * upstream response normally and leaves journaling to the caller via the
+   * `"relayed"` outcome. Rejected promises propagate and leave the response
+   * unwritten.
+   *
+   * NOT invoked when the upstream response was streamed progressively to the
+   * client (SSE) — the bytes are already on the wire and can't be mutated.
+   * Callers that need to observe the bypass should pass `onHookBypassed`.
    */
   beforeWriteResponse?: (response: ProxyCapturedResponse) => boolean | Promise<boolean>;
+  /**
+   * Called when `beforeWriteResponse` was provided but could not be invoked
+   * because the upstream response was streamed to the client progressively.
+   * The hook was rolled + wired but the bytes left before it could fire.
+   * Intended for observability (log/metric/journal annotation) — proxyAndRecord
+   * still returns `"relayed"`.
+   */
+  onHookBypassed?: (reason: "sse_streamed") => void;
 }
 
 /**
@@ -297,7 +314,14 @@ export async function proxyAndRecord(
   // Relay upstream response to client (skip when SSE was already streamed
   // progressively by makeUpstreamRequest — headers and body are already on
   // the wire).
-  if (!streamedToClient) {
+  if (streamedToClient) {
+    // SSE: the hook can't run because the body is already on the wire. Surface
+    // the bypass so the caller (typically the chaos layer) can record it —
+    // otherwise a configured chaos action silently no-ops on SSE traffic.
+    if (options?.beforeWriteResponse && options.onHookBypassed) {
+      options.onHookBypassed("sse_streamed");
+    }
+  } else {
     // Give the caller a chance to mutate or replace the response before relay.
     // Used by the chaos layer to turn a successful proxy into a malformed body.
     // `body` is the raw upstream bytes so binary payloads survive round-tripping.

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -44,7 +44,6 @@ export interface ProxyCapturedResponse {
   status: number;
   contentType: string;
   body: Buffer;
-  isBinary: boolean;
 }
 
 export interface ProxyOptions {
@@ -59,12 +58,23 @@ export interface ProxyOptions {
 }
 
 /**
+ * Outcome of a proxyAndRecord call, returned so the caller can decide whether
+ * to journal, fall through, or stop — without sharing a mutable flag with the
+ * `beforeWriteResponse` hook.
+ *
+ * - `"not_configured"` — no upstream URL for this provider; caller should fall
+ *    through to its next branch (typically strict/404).
+ * - `"relayed"` — the default code path wrote a response (upstream success or
+ *    synthesized 502 error). Caller should journal the outcome.
+ * - `"handled_by_hook"` — the hook wrote + journaled its own response. Caller
+ *    should not double-journal.
+ */
+export type ProxyOutcome = "not_configured" | "relayed" | "handled_by_hook";
+
+/**
  * Proxy an unmatched request to the real upstream provider, record the
  * response as a fixture on disk and in memory, then relay the response
  * back to the original client.
- *
- * Returns `true` if the request was proxied (provider configured),
- * `false` if no upstream URL is configured for the given provider key.
  */
 export async function proxyAndRecord(
   req: http.IncomingMessage,
@@ -80,16 +90,16 @@ export async function proxyAndRecord(
   },
   rawBody?: string,
   options?: ProxyOptions,
-): Promise<boolean> {
+): Promise<ProxyOutcome> {
   const record = defaults.record;
-  if (!record) return false;
+  if (!record) return "not_configured";
 
   const providers = record.providers;
   const upstreamUrl = providers[providerKey];
 
   if (!upstreamUrl) {
     defaults.logger.warn(`No upstream URL configured for provider "${providerKey}" — cannot proxy`);
-    return false;
+    return "not_configured";
   }
 
   const fixturePath = record.fixturePath ?? "./fixtures/recorded";
@@ -105,7 +115,7 @@ export async function proxyAndRecord(
         error: { message: `Invalid upstream URL: ${upstreamUrl}`, type: "proxy_error" },
       }),
     );
-    return true;
+    return "relayed";
   }
 
   defaults.logger.warn(`NO FIXTURE MATCH — proxying to ${upstreamUrl}${pathname}`);
@@ -145,7 +155,7 @@ export async function proxyAndRecord(
         error: { message: `Proxy to upstream failed: ${msg}`, type: "proxy_error" },
       }),
     );
-    return true;
+    return "relayed";
   }
 
   // Detect streaming response and collapse if necessary
@@ -289,9 +299,8 @@ export async function proxyAndRecord(
         status: upstreamStatus,
         contentType: ctString,
         body: rawBuffer,
-        isBinary: isBinaryStream,
       });
-      if (handled) return true;
+      if (handled) return "handled_by_hook";
     }
 
     const relayHeaders: Record<string, string> = {};
@@ -302,7 +311,7 @@ export async function proxyAndRecord(
     res.end(isBinaryStream ? rawBuffer : upstreamBody);
   }
 
-  return true;
+  return "relayed";
 }
 
 // ---------------------------------------------------------------------------

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -883,7 +883,7 @@ export async function handleResponses(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         completionReq,
@@ -893,7 +893,7 @@ export async function handleResponses(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: req.url ?? "/v1/responses",

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -875,6 +875,7 @@ export async function handleResponses(
         headers: flattenHeaders(req.headers),
         body: completionReq,
       },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/server.ts
+++ b/src/server.ts
@@ -466,6 +466,11 @@ async function handleCompletions(
       const hookOptions =
         chaosAction === "malformed"
           ? {
+              // Malformed is emitted as a hardcoded invalid-JSON body, so the
+              // captured upstream response isn't used here (the parameter is
+              // intentionally omitted rather than declared-and-ignored).
+              // Future dispatch (phase 3: non-JSON / streaming) will accept
+              // the response and branch on contentType.
               beforeWriteResponse: () => {
                 applyChaosAction(
                   chaosAction,

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,7 +48,7 @@ import { handleWebSocketResponses } from "./ws-responses.js";
 import { handleWebSocketRealtime } from "./ws-realtime.js";
 import { handleWebSocketGeminiLive } from "./ws-gemini-live.js";
 import { Logger } from "./logger.js";
-import { applyChaos } from "./chaos.js";
+import { applyChaos, applyChaosAction, evaluateChaos } from "./chaos.js";
 import { createMetricsRegistry, normalizePathLabel } from "./metrics.js";
 import { proxyAndRecord } from "./recorder.js";
 
@@ -404,25 +404,23 @@ async function handleCompletions(
   // Set endpoint type once early so router/recorder and journal see it
   body._endpointType = "chat";
 
-  // Pre-flight chaos: run before fixture matching or proxying
-  if (
-    applyChaos(
+  // Pre-flight chaos: only transport-level actions (drop, disconnect) fire
+  // before upstream is called. Malformed is deferred to post-response so the
+  // proxy path actually calls upstream before mutating the body. Rolling the
+  // dice here and dispatching explicitly (rather than calling applyChaos,
+  // which would re-roll internally) keeps the pre-flight action committed.
+  const preflightAction = evaluateChaos(null, defaults.chaos, req.headers, defaults.logger);
+  if (preflightAction === "drop" || preflightAction === "disconnect") {
+    applyChaosAction(
+      preflightAction,
       res,
       null,
-      defaults.chaos,
-      req.headers,
       journal,
-      {
-        method,
-        path,
-        headers: flatHeaders,
-        body,
-      },
+      { method, path, headers: flatHeaders, body },
       defaults.registry,
-      defaults.logger,
-    )
-  )
+    );
     return;
+  }
 
   // Match fixture
   const testId = getTestId(req);
@@ -437,32 +435,41 @@ async function handleCompletions(
     journal.incrementFixtureMatchCount(fixture, fixtures, testId);
   }
 
-  // NOTE: Chaos may be evaluated twice (pre-flight + post-match), which
-  // increases effective trigger probability for non-boundary rates.
-  // This is an intentional tradeoff to enable pre-flight chaos without
-  // refactoring the existing applyChaos flow.
-  if (
-    applyChaos(
-      res,
-      fixture,
-      defaults.chaos,
-      req.headers,
-      journal,
-      {
-        method,
-        path,
-        headers: flatHeaders,
-        body,
-      },
-      defaults.registry,
-      defaults.logger,
+  // Post-match chaos: only for the fixture path. When there's no fixture, the
+  // request either goes to the proxy (which does its own post-response chaos
+  // via the beforeWriteResponse hook below) or falls through to strict/404.
+  // NOTE: Chaos may still be evaluated twice on the fixture path (pre-flight
+  // + post-match), which increases effective trigger probability for
+  // non-boundary rates. Intentional tradeoff to preserve fixture-level chaos
+  // overrides without refactoring applyChaos's roll.
+  if (fixture) {
+    if (
+      applyChaos(
+        res,
+        fixture,
+        defaults.chaos,
+        req.headers,
+        journal,
+        {
+          method,
+          path,
+          headers: flatHeaders,
+          body,
+        },
+        defaults.registry,
+        defaults.logger,
+      )
     )
-  )
-    return;
+      return;
+  }
 
   if (!fixture) {
     // Try record-and-replay proxy if configured
     if (defaults.record && providerKey) {
+      // If chaos rolls malformed post-upstream, the hook writes + journals
+      // and signals "handled" so the default relay + outer journal are
+      // skipped (prevents double-journaling the same request).
+      let chaosHandled = false;
       const proxied = await proxyAndRecord(
         req,
         res,
@@ -472,15 +479,33 @@ async function handleCompletions(
         fixtures,
         defaults,
         raw,
+        {
+          beforeWriteResponse: () => {
+            const action = evaluateChaos(null, defaults.chaos, req.headers, defaults.logger);
+            if (action !== "malformed") return false;
+            applyChaosAction(
+              action,
+              res,
+              null,
+              journal,
+              { method, path, headers: flatHeaders, body },
+              defaults.registry,
+            );
+            chaosHandled = true;
+            return true;
+          },
+        },
       );
       if (proxied) {
-        journal.add({
-          method: req.method ?? "POST",
-          path: req.url ?? COMPLETIONS_PATH,
-          headers: flattenHeaders(req.headers),
-          body,
-          response: { status: res.statusCode ?? 200, fixture: null },
-        });
+        if (!chaosHandled) {
+          journal.add({
+            method: req.method ?? "POST",
+            path: req.url ?? COMPLETIONS_PATH,
+            headers: flattenHeaders(req.headers),
+            body,
+            response: { status: res.statusCode ?? 200, fixture: null },
+          });
+        }
         return;
       }
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1196,7 +1196,7 @@ export async function createServer(
     const videoStatusMatch = pathname.match(VIDEOS_STATUS_RE);
     if (videoStatusMatch && req.method === "GET") {
       const videoId = videoStatusMatch[1];
-      handleVideoStatus(req, res, videoId, journal, setCorsHeaders, videoStates);
+      handleVideoStatus(req, res, videoId, journal, defaults, setCorsHeaders, videoStates);
       return;
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -483,6 +483,20 @@ async function handleCompletions(
                 );
                 return true;
               },
+              // SSE can't be mutated post-facto (bytes already on the wire).
+              // Record the bypass so the rolled action isn't invisible in
+              // logs / Prometheus — otherwise malformedRate: 1.0 on SSE
+              // traffic silently means 0%.
+              onHookBypassed: (reason: "sse_streamed") => {
+                defaults.logger.warn(
+                  `[chaos] malformed bypassed on proxy: upstream returned SSE (${reason})`,
+                );
+                defaults.registry?.incrementCounter("aimock_chaos_bypassed_total", {
+                  action: "malformed",
+                  source: "proxy",
+                  reason,
+                });
+              },
             }
           : undefined;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,7 +48,7 @@ import { handleWebSocketResponses } from "./ws-responses.js";
 import { handleWebSocketRealtime } from "./ws-realtime.js";
 import { handleWebSocketGeminiLive } from "./ws-gemini-live.js";
 import { Logger } from "./logger.js";
-import { applyChaos, applyChaosAction, evaluateChaos } from "./chaos.js";
+import { applyChaosAction, evaluateChaos } from "./chaos.js";
 import { createMetricsRegistry, normalizePathLabel } from "./metrics.js";
 import { proxyAndRecord } from "./recorder.js";
 
@@ -404,25 +404,9 @@ async function handleCompletions(
   // Set endpoint type once early so router/recorder and journal see it
   body._endpointType = "chat";
 
-  // Pre-flight chaos: only transport-level actions (drop, disconnect) fire
-  // before upstream is called. Malformed is deferred to post-response so the
-  // proxy path actually calls upstream before mutating the body. Rolling the
-  // dice here and dispatching explicitly (rather than calling applyChaos,
-  // which would re-roll internally) keeps the pre-flight action committed.
-  const preflightAction = evaluateChaos(null, defaults.chaos, req.headers, defaults.logger);
-  if (preflightAction === "drop" || preflightAction === "disconnect") {
-    applyChaosAction(
-      preflightAction,
-      res,
-      null,
-      journal,
-      { method, path, headers: flatHeaders, body },
-      defaults.registry,
-    );
-    return;
-  }
-
-  // Match fixture
+  // Match fixture first — chaos resolution depends on fixture-level overrides
+  // (headers > fixture.chaos > server defaults), so the fixture has to be
+  // known before we can roll with the right config.
   const testId = getTestId(req);
   const fixture = matchFixture(
     fixtures,
@@ -435,40 +419,45 @@ async function handleCompletions(
     journal.incrementFixtureMatchCount(fixture, fixtures, testId);
   }
 
-  // Post-match chaos: only for the fixture path. When there's no fixture, the
-  // request either goes to the proxy (which does its own post-response chaos
-  // via the beforeWriteResponse hook below) or falls through to strict/404.
-  // NOTE: Chaos may still be evaluated twice on the fixture path (pre-flight
-  // + post-match), which increases effective trigger probability for
-  // non-boundary rates. Intentional tradeoff to preserve fixture-level chaos
-  // overrides without refactoring applyChaos's roll.
-  if (fixture) {
-    if (
-      applyChaos(
-        res,
-        fixture,
-        defaults.chaos,
-        req.headers,
-        journal,
-        {
-          method,
-          path,
-          headers: flatHeaders,
-          body,
-        },
-        defaults.registry,
-        defaults.logger,
-      )
-    )
-      return;
+  // Roll chaos once per request. Dispatch by action + path:
+  //   drop / disconnect → apply immediately; upstream is never called and no
+  //                       response body is produced.
+  //   malformed, fixture path → write invalid JSON instead of the fixture.
+  //   malformed, proxy path  → proxy to upstream, then swap body via the
+  //                            beforeWriteResponse hook (closure captures the
+  //                            pre-rolled action so the hook doesn't re-roll).
+  const chaosAction = evaluateChaos(fixture, defaults.chaos, req.headers, defaults.logger);
+
+  if (chaosAction === "drop" || chaosAction === "disconnect") {
+    applyChaosAction(
+      chaosAction,
+      res,
+      fixture,
+      journal,
+      { method, path, headers: flatHeaders, body },
+      defaults.registry,
+    );
+    return;
+  }
+
+  if (fixture && chaosAction === "malformed") {
+    applyChaosAction(
+      chaosAction,
+      res,
+      fixture,
+      journal,
+      { method, path, headers: flatHeaders, body },
+      defaults.registry,
+    );
+    return;
   }
 
   if (!fixture) {
     // Try record-and-replay proxy if configured
     if (defaults.record && providerKey) {
-      // If chaos rolls malformed post-upstream, the hook writes + journals
-      // and signals "handled" so the default relay + outer journal are
-      // skipped (prevents double-journaling the same request).
+      // If chaos rolled malformed, the hook writes invalid JSON + journals
+      // with chaosAction and signals "handled" so the default relay + outer
+      // journal are skipped (prevents double-journaling the same request).
       let chaosHandled = false;
       const proxied = await proxyAndRecord(
         req,
@@ -481,10 +470,9 @@ async function handleCompletions(
         raw,
         {
           beforeWriteResponse: () => {
-            const action = evaluateChaos(null, defaults.chaos, req.headers, defaults.logger);
-            if (action !== "malformed") return false;
+            if (chaosAction !== "malformed") return false;
             applyChaosAction(
-              action,
+              chaosAction,
               res,
               null,
               journal,

--- a/src/server.ts
+++ b/src/server.ts
@@ -397,8 +397,34 @@ async function handleCompletions(
     return;
   }
 
-  // Match fixture
+  const method = req.method ?? "POST";
+  const path = req.url ?? COMPLETIONS_PATH;
+  const flatHeaders = flattenHeaders(req.headers);
+
+  // Set endpoint type once early so router/recorder and journal see it
   body._endpointType = "chat";
+
+  // Pre-flight chaos: run before fixture matching or proxying
+  if (
+    applyChaos(
+      res,
+      null,
+      defaults.chaos,
+      req.headers,
+      journal,
+      {
+        method,
+        path,
+        headers: flatHeaders,
+        body,
+      },
+      defaults.registry,
+      defaults.logger,
+    )
+  )
+    return;
+
+  // Match fixture
   const testId = getTestId(req);
   const fixture = matchFixture(
     fixtures,
@@ -411,11 +437,10 @@ async function handleCompletions(
     journal.incrementFixtureMatchCount(fixture, fixtures, testId);
   }
 
-  const method = req.method ?? "POST";
-  const path = req.url ?? COMPLETIONS_PATH;
-  const flatHeaders = flattenHeaders(req.headers);
-
-  // Apply chaos before normal response handling
+  // NOTE: Chaos may be evaluated twice (pre-flight + post-match), which
+  // increases effective trigger probability for non-boundary rates.
+  // This is an intentional tradeoff to enable pre-flight chaos without
+  // refactoring the existing applyChaos flow.
   if (
     applyChaos(
       res,

--- a/src/server.ts
+++ b/src/server.ts
@@ -424,9 +424,11 @@ async function handleCompletions(
   //                       response body is produced.
   //   malformed, fixture path → write invalid JSON instead of the fixture.
   //   malformed, proxy path  → proxy to upstream, then swap body via the
-  //                            beforeWriteResponse hook (closure captures the
-  //                            pre-rolled action so the hook doesn't re-roll).
+  //                            beforeWriteResponse hook (passed only when the
+  //                            action is malformed, so the hook doesn't need
+  //                            to re-check the action).
   const chaosAction = evaluateChaos(fixture, defaults.chaos, req.headers, defaults.logger);
+  const chaosContext = { method, path, headers: flatHeaders, body };
 
   if (chaosAction === "drop" || chaosAction === "disconnect") {
     applyChaosAction(
@@ -434,7 +436,8 @@ async function handleCompletions(
       res,
       fixture,
       journal,
-      { method, path, headers: flatHeaders, body },
+      chaosContext,
+      fixture ? "fixture" : "proxy",
       defaults.registry,
     );
     return;
@@ -446,7 +449,8 @@ async function handleCompletions(
       res,
       fixture,
       journal,
-      { method, path, headers: flatHeaders, body },
+      chaosContext,
+      "fixture",
       defaults.registry,
     );
     return;
@@ -455,11 +459,29 @@ async function handleCompletions(
   if (!fixture) {
     // Try record-and-replay proxy if configured
     if (defaults.record && providerKey) {
-      // If chaos rolled malformed, the hook writes invalid JSON + journals
-      // with chaosAction and signals "handled" so the default relay + outer
-      // journal are skipped (prevents double-journaling the same request).
-      let chaosHandled = false;
-      const proxied = await proxyAndRecord(
+      // Hook is only passed when chaos wants to mutate the response. When
+      // it's passed, it unconditionally applies malformed + journals + tells
+      // proxyAndRecord to skip its default relay. The hook has no branching
+      // logic — that decision is made here, at the call site.
+      const hookOptions =
+        chaosAction === "malformed"
+          ? {
+              beforeWriteResponse: () => {
+                applyChaosAction(
+                  chaosAction,
+                  res,
+                  null,
+                  journal,
+                  chaosContext,
+                  "proxy",
+                  defaults.registry,
+                );
+                return true;
+              },
+            }
+          : undefined;
+
+      const outcome = await proxyAndRecord(
         req,
         res,
         body,
@@ -468,34 +490,20 @@ async function handleCompletions(
         fixtures,
         defaults,
         raw,
-        {
-          beforeWriteResponse: () => {
-            if (chaosAction !== "malformed") return false;
-            applyChaosAction(
-              chaosAction,
-              res,
-              null,
-              journal,
-              { method, path, headers: flatHeaders, body },
-              defaults.registry,
-            );
-            chaosHandled = true;
-            return true;
-          },
-        },
+        hookOptions,
       );
-      if (proxied) {
-        if (!chaosHandled) {
-          journal.add({
-            method: req.method ?? "POST",
-            path: req.url ?? COMPLETIONS_PATH,
-            headers: flattenHeaders(req.headers),
-            body,
-            response: { status: res.statusCode ?? 200, fixture: null },
-          });
-        }
+      if (outcome === "handled_by_hook") return;
+      if (outcome === "relayed") {
+        journal.add({
+          method: req.method ?? "POST",
+          path: req.url ?? COMPLETIONS_PATH,
+          headers: flattenHeaders(req.headers),
+          body,
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
+        });
         return;
       }
+      // outcome === "not_configured" — fall through to strict/404
     }
 
     const strictStatus = defaults.strict ? 503 : 404;

--- a/src/speech.ts
+++ b/src/speech.ts
@@ -85,6 +85,7 @@ export async function handleSpeech(
       req.headers,
       journal,
       { method, path, headers: flattenHeaders(req.headers), body: syntheticReq },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/speech.ts
+++ b/src/speech.ts
@@ -93,7 +93,7 @@ export async function handleSpeech(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         syntheticReq,
@@ -103,7 +103,7 @@ export async function handleSpeech(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method,
           path,

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -71,7 +71,7 @@ export async function handleTranscription(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         syntheticReq,
@@ -81,7 +81,7 @@ export async function handleTranscription(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method,
           path,

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -63,6 +63,7 @@ export async function handleTranscription(
       req.headers,
       journal,
       { method, path, headers: flattenHeaders(req.headers), body: syntheticReq },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,15 @@ export interface StreamingProfile {
   jitter?: number; // Random variance factor (0-1), default 0
 }
 
+/**
+ * Probabilistic chaos injection rates.
+ *
+ * Rates are evaluated sequentially per request — drop → malformed → disconnect
+ * — and the first hit wins. Consequently malformedRate is conditional on drop
+ * not firing, and disconnectRate is conditional on neither drop nor malformed
+ * firing. A config of `{ dropRate: 0.5, malformedRate: 0.5 }` yields a ~25 %
+ * effective malformed rate, not 50 %.
+ */
 export interface ChaosConfig {
   dropRate?: number;
   malformedRate?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,6 +305,13 @@ export interface JournalEntry {
     interrupted?: boolean;
     interruptReason?: string;
     chaosAction?: ChaosAction;
+    /**
+     * What was going to serve this request. "fixture" = a fixture matched (or
+     * would have, before chaos intervened). "proxy" = no fixture matched and
+     * proxy was configured. Absent when the distinction doesn't apply (e.g.
+     * 404/503 fallback where nothing was going to serve).
+     */
+    source?: "fixture" | "proxy";
   };
 }
 

--- a/src/video.ts
+++ b/src/video.ts
@@ -191,12 +191,28 @@ export function handleVideoStatus(
   res: http.ServerResponse,
   videoId: string,
   journal: Journal,
+  defaults: HandlerDefaults,
   setCorsHeaders: (res: http.ServerResponse) => void,
   videoStates: VideoStateMap,
 ): void {
   setCorsHeaders(res);
   const path = req.url ?? `/v1/videos/${videoId}`;
   const method = req.method ?? "GET";
+
+  if (
+    applyChaos(
+      res,
+      null,
+      defaults.chaos,
+      req.headers,
+      journal,
+      { method, path, headers: flattenHeaders(req.headers), body: null },
+      "fixture",
+      defaults.registry,
+      defaults.logger,
+    )
+  )
+    return;
 
   const testId = getTestId(req);
   const stateKey = `${testId}:${videoId}`;

--- a/src/video.ts
+++ b/src/video.ts
@@ -77,6 +77,7 @@ export async function handleVideoCreate(
       req.headers,
       journal,
       { method, path, headers: flattenHeaders(req.headers), body: syntheticReq },
+      fixture ? "fixture" : "proxy",
       defaults.registry,
       defaults.logger,
     )

--- a/src/video.ts
+++ b/src/video.ts
@@ -85,7 +85,7 @@ export async function handleVideoCreate(
 
   if (!fixture) {
     if (defaults.record) {
-      const proxied = await proxyAndRecord(
+      const outcome = await proxyAndRecord(
         req,
         res,
         syntheticReq,
@@ -95,7 +95,7 @@ export async function handleVideoCreate(
         defaults,
         raw,
       );
-      if (proxied) {
+      if (outcome !== "not_configured") {
         journal.add({
           method,
           path,


### PR DESCRIPTION
## Summary

Chaos (drop, disconnect, malformed) now applies in proxy mode. Previously chaos was skipped for proxied requests, making them unrealistically reliable.

Clean replacement for PR #122 — fresh branch off current main, only the chaos-proxy work, organized as 13 commits by area of concern.

## What it does

- **Pre-flight drop/disconnect** pre-empt upstream (nothing is contacted).
- **Post-response malformed** proxies to upstream, captures the response, replaces the body with invalid JSON before relay.
- Chaos is rolled **once per request**, after fixture match, with resolved config (headers > fixture.chaos > server defaults).
- **SSE bypass**: when upstream streams SSE progressively, malformed chaos is skipped (bytes are already on the wire) and `aimock_chaos_bypassed_total` fires so the bypass is visible.
- **Source labeling**: `aimock_chaos_triggered_total` and journal entries carry `source: "fixture" | "proxy"`.
- **Video status**: `handleVideoStatus` (GET `/v1/videos/:id`) now evaluates chaos, consistent with other handlers.

## Design highlights

- `applyChaos` split into roll+dispatch (`applyChaosAction`) so callers that pre-roll can't re-roll by accident.
- `proxyAndRecord` returns `"not_configured" | "relayed" | "handled_by_hook"` instead of a ghost flag shared with the hook.
- `beforeWriteResponse` hook on `proxyAndRecord` for post-response mutation; `onHookBypassed` companion for SSE visibility.
- `JournalEntry.response.source` disambiguates null-fixture entries.
- `applyChaos` requires an explicit `source` parameter so a future handler that grows a proxy path can't silently journal the wrong label.

## Commits

1. `feat: apply pre-flight chaos to proxy mode (phase 1)`
2. `test: add fixture-mode pre-flight chaos test`
3. `feat: post-response chaos for proxy mode (malformed)`
4. `refactor: single chaos roll per request`
5. `refactor: apply review feedback — explicit API, no ghost flag`
6. `test: pin binary-safe hook contract + signal unused response arg`
7. `test: proxy-failure integration through handleCompletions`
8. `refactor: address remaining review points`
9. `refactor(chaos): require explicit source on applyChaos`
10. `feat(chaos): record SSE bypass when hook can't mutate streamed response`
11. `test(metrics): assert source label on chaos counter (fixture + proxy)`
12. `docs: chaos in proxy mode + sequential rate semantics`
13. `feat(chaos): extend chaos support to handleVideoStatus`

## Scope

In: drop / disconnect / malformed for proxy mode, non-streaming.
Deferred: `status_override`, `truncate`, streaming (SSE/NDJSON) mutation.

## Test plan

- Pre-flight drop/disconnect: upstream counter stays at 0, client gets 500/disconnect
- Post-response malformed: upstream IS called, body is invalid JSON, journal records chaosAction
- Single-roll semantics: drop journals the matched fixture + increments match count
- SSE bypass: malformed chaos skipped, bypass metric emitted, triggered metric NOT emitted
- Proxy failure interaction: 502 reaches client, journal correct, no chaosAction
- Prometheus source labels: `source="fixture"` vs `source="proxy"` on chaos counter
- Video status chaos: drop fires before video-not-found 404
- Binary-safe hook: `beforeWriteResponse` receives raw upstream bytes
- Content-type preserved on no-chaos replay

`pnpm format:check` ✓ `pnpm lint` ✓ `pnpm test` ✓ (2504 passed)

## Context

Supersedes #122, which collected a large backlog of unrelated fixes via merged blitz/omnibus branches and became difficult to review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiG2pgjMPDoKK79qqsxugL)_