### PR TITLE
CI security + Cohere v2 parity + Bedrock ResponseOverrides

### DIFF
--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -119,7 +119,8 @@ jobs:
         if: success() && steps.check.outputs.skip != 'true'
         run: |
           npx tsx scripts/fix-drift.ts --create-pr 2>&1 | tee /tmp/pr-output.txt
-          PR_URL=$(grep -oP 'https://github.com/[^ ]+/pull/\d+' /tmp/pr-output.txt | head -1)
+          PR_URL=$(grep -oE 'https://github.com/[^ ]+/pull/[0-9]+' /tmp/pr-output.txt | head -1)
+          if [ -z "$PR_URL" ]; then echo "No PR URL found"; exit 1; fi
           echo "url=$PR_URL" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -129,7 +130,7 @@ jobs:
         if: success() && steps.pr.outputs.url != ''
         run: |
           PR_URL="${{ steps.pr.outputs.url }}"
-          gh pr merge "$PR_URL" --merge --admin
+          gh pr merge "$PR_URL" --merge --auto
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -144,15 +145,19 @@ jobs:
       - name: Notify Slack on fix success
         if: success() && steps.pr.outputs.url != ''
         run: |
-          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          if [ -z "$SLACK_WEBHOOK" ]; then echo "SLACK_WEBHOOK not set, skipping"; exit 0; fi
+          curl -s -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "{\"text\":\"✅ *Drift auto-fixed and merged*\nPR: ${{ steps.pr.outputs.url }}\nRun: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
       # Step 8: Slack notification on fix failure
       - name: Notify Slack on fix failure
         if: failure() && steps.check.outputs.skip != 'true'
         run: |
-          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          if [ -z "$SLACK_WEBHOOK" ]; then echo "SLACK_WEBHOOK not set, skipping"; exit 0; fi
+          curl -s -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "{\"text\":\"❌ *Drift auto-fix failed* — issue created\nRun: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}"
         env:

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -7,14 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
-        run: |
-          if [ -z "$SLACK_WEBHOOK" ]; then echo "SLACK_WEBHOOK not set, skipping"; exit 0; fi
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_URL="${{ github.event.pull_request.html_url }}"
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-          PR_NUM="${{ github.event.pull_request.number }}"
-          curl -sf -X POST "$SLACK_WEBHOOK" \
-            -H "Content-Type: application/json" \
-            -d "{\"text\": \"🔀 New PR #${PR_NUM} on aimock by *${PR_AUTHOR}*: <${PR_URL}|${PR_TITLE}>\"}"
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then echo "SLACK_WEBHOOK not set, skipping"; exit 0; fi
+          PAYLOAD=$(jq -n \
+            --arg text "New PR #${PR_NUM} on aimock by *${PR_AUTHOR}*: <${PR_URL}|${PR_TITLE}>" \
+            '{text: $text}')
+          curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -8,10 +8,13 @@ jobs:
     steps:
       - name: Notify Slack
         run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then echo "SLACK_WEBHOOK not set, skipping"; exit 0; fi
           PR_TITLE="${{ github.event.pull_request.title }}"
           PR_URL="${{ github.event.pull_request.html_url }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           PR_NUM="${{ github.event.pull_request.number }}"
-          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          curl -sf -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "{\"text\": \"🔀 New PR #${PR_NUM} on aimock by *${PR_AUTHOR}*: <${PR_URL}|${PR_TITLE}>\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -96,7 +96,10 @@ jobs:
       - name: Notify Slack
         if: steps.check.outputs.published == 'false'
         run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then echo "SLACK_WEBHOOK not set, skipping"; exit 0; fi
           VERSION="v${{ steps.check.outputs.version }}"
-          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          curl -s -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "{\"text\":\"📦 *@copilotkit/aimock ${VERSION} published*\nnpm: https://www.npmjs.com/package/@copilotkit/aimock/v/${{ steps.check.outputs.version }}\nRelease: https://github.com/${{ github.repository }}/releases/tag/${VERSION}\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test-drift.yml
+++ b/.github/workflows/test-drift.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Notify Slack
         if: always()
         run: |
-          if [ -z "${{ secrets.SLACK_WEBHOOK }}" ]; then exit 0; fi
+          if [ -z "$SLACK_WEBHOOK" ]; then echo "SLACK_WEBHOOK not set, skipping"; exit 0; fi
 
           PREV="${{ steps.prev.outputs.conclusion }}"
           NOW="${{ job.status }}"
@@ -102,7 +102,7 @@ jobs:
             exit 0
           fi
 
-          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          curl -s -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "{\"text\": \"${EMOJI} ${MSG}\"}"
         env:

--- a/.github/workflows/update-competitive-matrix.yml
+++ b/.github/workflows/update-competitive-matrix.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Notify Slack
         if: always()
         run: |
+          if [ -z "$SLACK_WEBHOOK" ]; then echo "SLACK_WEBHOOK not set, skipping"; exit 0; fi
           if [ "${{ steps.changes.outputs.changed }}" = "true" ]; then
             EMOJI="📊"
             MSG="*Competitive matrix changes detected* — PR created with updated migration pages. <https://github.com/CopilotKit/aimock/actions/runs/${{ github.run_id }}|View run>"
@@ -68,6 +69,8 @@ jobs:
             EMOJI="❌"
             MSG="*Competitive matrix update failed*. <https://github.com/CopilotKit/aimock/actions/runs/${{ github.run_id }}|View run>"
           fi
-          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          curl -s -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "{\"text\": \"${EMOJI} ${MSG}\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/scripts/update-competitive-matrix.ts
+++ b/scripts/update-competitive-matrix.ts
@@ -71,23 +71,29 @@ const FEATURE_RULES: FeatureRule[] = [
   },
   {
     rowLabel: "Embeddings API",
-    keywords: ["embedding", "/v1/embeddings", "embed"],
+    keywords: ["/v1/embeddings", "embeddings api", "embedding endpoint", "embedding model"],
   },
   {
     rowLabel: "Image generation",
-    keywords: ["image", "dall-e", "dalle", "/v1/images", "image generation", "imagen"],
+    keywords: ["dall-e", "dalle", "/v1/images", "image generation", "imagen", "generate.*image"],
   },
   {
     rowLabel: "Text-to-Speech",
-    keywords: ["tts", "text-to-speech", "speech", "/v1/audio/speech", "audio generation"],
+    keywords: ["text-to-speech", "/v1/audio/speech", "audio generation", "tts endpoint", "tts api"],
   },
   {
     rowLabel: "Audio transcription",
-    keywords: ["transcription", "whisper", "/v1/audio/transcriptions", "speech-to-text", "stt"],
+    keywords: [
+      "/v1/audio/transcriptions",
+      "whisper",
+      "speech-to-text",
+      "audio transcription",
+      "transcription api",
+    ],
   },
   {
     rowLabel: "Video generation",
-    keywords: ["video", "sora", "/v1/videos", "video generation"],
+    keywords: ["sora", "/v1/videos", "video generation", "generate.*video"],
   },
   {
     rowLabel: "Structured output / JSON mode",
@@ -107,11 +113,11 @@ const FEATURE_RULES: FeatureRule[] = [
   },
   {
     rowLabel: "Docker image",
-    keywords: ["docker", "dockerfile", "container", "docker-compose"],
+    keywords: ["dockerfile", "docker image", "docker-compose", "docker compose", "docker run"],
   },
   {
     rowLabel: "Helm chart",
-    keywords: ["helm", "chart", "kubernetes", "k8s"],
+    keywords: ["helm chart", "helm install", "kubernetes.*deploy", "k8s.*deploy"],
   },
   {
     rowLabel: "Fixture files (JSON)",
@@ -342,10 +348,12 @@ function buildMigrationRowPatterns(rowLabel: string): string[] {
 
 /**
  * Scans the HTML for numeric provider claims and updates them if the detected
- * count is higher. Handles patterns like:
- * - "N providers" / "N+ providers" (in prose and table cells)
- * - "supports N LLM" / "N LLM providers"
- * - "N more providers"
+ * count is higher. Only replaces within content scoped to the specific competitor
+ * to avoid corrupting aimock's own claims or other competitors' counts.
+ *
+ * Scoping strategy: only replace inside elements/paragraphs that mention the
+ * competitor by name, or within the competitor's column in a table row whose
+ * label matches "provider" (case-insensitive).
  */
 function updateProviderCounts(
   html: string,
@@ -354,30 +362,85 @@ function updateProviderCounts(
   changes: string[],
 ): string {
   let result = html;
+  const escapedName = escapeRegex(competitorName);
 
-  // Pattern: N+ providers or N providers (in table cells and prose)
-  const providerCountRegex = /(\d+)\+?\s*providers/g;
-  result = result.replace(providerCountRegex, (match, numStr) => {
-    const currentCount = parseInt(numStr, 10);
-    if (detectedCount > currentCount) {
-      changes.push(`${competitorName}: provider count ${currentCount} -> ${detectedCount}`);
-      return `${detectedCount} providers`;
+  // Strategy 1: Replace provider counts in table rows about providers,
+  // scoped to the competitor's column. Find rows with "provider" in the label,
+  // then find the competitor's column cell by index.
+  const tableMatch = result.match(
+    /<table class="(?:comparison-table|endpoint-table)">([\s\S]*?)<\/table>/,
+  );
+  if (tableMatch) {
+    const fullTable = tableMatch[0];
+
+    // Find the competitor's column index from headers
+    const thRegex = /<th[^>]*>([\s\S]*?)<\/th>/g;
+    const thTexts: string[] = [];
+    let thM: RegExpExecArray | null;
+    while ((thM = thRegex.exec(fullTable)) !== null) {
+      thTexts.push(thM[1].trim());
     }
-    return match;
-  });
+    const compColIdx = thTexts.findIndex((t) => t.includes(competitorName) || t === competitorName);
 
-  // Pattern: "supports N LLM" or "N LLM providers"
-  const llmProviderRegex = /(\d+)\+?\s*LLM\s*providers?/g;
-  result = result.replace(llmProviderRegex, (match, numStr) => {
+    if (compColIdx >= 0) {
+      // Find provider-related rows and update only the competitor's cell
+      const updatedTable = fullTable.replace(
+        /<tr>([\s\S]*?)<\/tr>/g,
+        (trMatch, trContent: string) => {
+          // Check if this row is about providers
+          const firstTd = trContent.match(/<td[^>]*>([\s\S]*?)<\/td>/);
+          if (!firstTd || !/provider/i.test(firstTd[1])) return trMatch;
+
+          // Replace provider count only in the competitor's column cell
+          let cellIdx = 0;
+          return trMatch.replace(/<td[^>]*>([\s\S]*?)<\/td>/g, (tdMatch, tdContent: string) => {
+            const currentIdx = cellIdx++;
+            if (currentIdx !== compColIdx) return tdMatch;
+
+            const updated = replaceProviderCount(tdContent, detectedCount);
+            if (updated !== tdContent) {
+              const oldCount = tdContent.match(/(\d+)/)?.[1] ?? "?";
+              changes.push(
+                `${competitorName}: provider count ${oldCount} -> ${detectedCount} (table)`,
+              );
+              return tdMatch.replace(tdContent, updated);
+            }
+            return tdMatch;
+          });
+        },
+      );
+
+      result = result.replace(fullTable, updatedTable);
+    }
+  }
+
+  // Strategy 2: Replace provider counts in prose paragraphs/sentences that
+  // explicitly mention the competitor by name.
+  const prosePattern = new RegExp(
+    `(<[^>]*>[^<]*${escapedName}[^<]*)(\\d+)\\+?\\s*(?:LLM\\s*)?providers?`,
+    "gi",
+  );
+  result = result.replace(prosePattern, (match, prefix, numStr) => {
     const currentCount = parseInt(numStr, 10);
     if (detectedCount > currentCount) {
-      changes.push(`${competitorName}: LLM provider count ${currentCount} -> ${detectedCount}`);
-      return `${detectedCount} LLM providers`;
+      changes.push(`${competitorName}: provider count ${currentCount} -> ${detectedCount} (prose)`);
+      return match.replace(/(\d+)\+?\s*(?:LLM\s*)?providers?/, `${detectedCount} providers`);
     }
     return match;
   });
 
   return result;
+}
+
+/** Replaces "N providers" or "N+ providers" in a string if detected > current */
+function replaceProviderCount(text: string, detectedCount: number): string {
+  return text.replace(/(\d+)\+?\s*(?:LLM\s*)?providers?/gi, (match, numStr) => {
+    const currentCount = parseInt(numStr, 10);
+    if (detectedCount > currentCount) {
+      return `${detectedCount} providers`;
+    }
+    return match;
+  });
 }
 
 // ── HTML Matrix Parsing & Updating ───────────────────────────────────────────
@@ -457,8 +520,14 @@ function computeChanges(
       const currentCell = row.get(compName);
       if (!currentCell) continue;
 
-      // Only upgrade "No" cells — leave "Yes", "Partial", "Manual", etc. alone
-      if (currentCell === "No") {
+      // Only upgrade "No" cells — leave "Yes", "Partial", "Manual", etc. alone.
+      // Cells contain inner HTML like '<span class="no">&#10007;</span>',
+      // not bare "No" text, so check for the no-class span or cross-mark entity.
+      if (
+        currentCell.includes('class="no"') ||
+        currentCell.includes("\u2717") ||
+        currentCell.includes("&#10007;")
+      ) {
         changes.push({
           competitor: compName,
           capability: rowLabel,
@@ -522,19 +591,23 @@ function applyChanges(html: string, changes: DetectedChange[]): string {
     const cellsHtml = rowMatch[2];
     const suffix = rowMatch[3];
 
-    // Find the Nth <td> in cellsHtml (colIdx - 1 because the first <td> is already in prefix)
+    // Find the Nth <td> in cellsHtml (colIdx - 1 because the first <td> is already in prefix).
+    // Actual cells use <td><span class="no">&#10007;</span></td> (class is on span, not td),
+    // so we match all <td>...</td> and check inner content for no-class spans.
     const targetTdIdx = colIdx - 1; // 0-based within the remaining cells
     let tdCount = 0;
-    const tdReplace = cellsHtml.replace(
-      /<td class="(no|yes|manual)">([\s\S]*?)<\/td>/g,
-      (fullMatch, cls, content) => {
-        const currentIdx = tdCount++;
-        if (currentIdx === targetTdIdx && content.trim() === "No") {
-          return `<td class="yes">Yes</td>`;
-        }
-        return fullMatch;
-      },
-    );
+    const tdReplace = cellsHtml.replace(/<td[^>]*>([\s\S]*?)<\/td>/g, (fullMatch, content) => {
+      const currentIdx = tdCount++;
+      if (
+        currentIdx === targetTdIdx &&
+        (content.includes('class="no"') ||
+          content.includes("\u2717") ||
+          content.includes("&#10007;"))
+      ) {
+        return `<td><span class="yes">&#10003;</span></td>`;
+      }
+      return fullMatch;
+    });
 
     result = result.replace(rowPattern, prefix + tdReplace + suffix);
   }

--- a/src/__tests__/bedrock-stream.test.ts
+++ b/src/__tests__/bedrock-stream.test.ts
@@ -263,17 +263,24 @@ describe("POST /model/{modelId}/invoke-with-response-stream", () => {
 
     // messageStart
     expect(frames[0].eventType).toBe("messageStart");
-    expect(frames[0].payload).toEqual({ role: "assistant" });
+    expect(frames[0].payload).toEqual({ messageStart: { role: "assistant" } });
 
     // contentBlockStart
     expect(frames[1].eventType).toBe("contentBlockStart");
-    expect(frames[1].payload).toEqual({ contentBlockIndex: 0, start: {} });
+    expect(frames[1].payload).toEqual({
+      contentBlockIndex: 0,
+      contentBlockStart: { contentBlockIndex: 0, start: { type: "text" } },
+    });
 
     // Content delta(s) — collect text
     const deltas = frames.filter((f) => f.eventType === "contentBlockDelta");
     expect(deltas.length).toBeGreaterThanOrEqual(1);
     const fullText = deltas
-      .map((f) => (f.payload as { delta: { text: string } }).delta.text)
+      .map(
+        (f) =>
+          (f.payload as { contentBlockDelta: { delta: { text: string } } }).contentBlockDelta.delta
+            .text,
+      )
       .join("");
     expect(fullText).toBe("Hi there!");
 
@@ -301,23 +308,30 @@ describe("POST /model/{modelId}/invoke-with-response-stream", () => {
 
     // messageStart
     expect(frames[0].eventType).toBe("messageStart");
-    expect(frames[0].payload).toEqual({ role: "assistant" });
+    expect(frames[0].payload).toEqual({ messageStart: { role: "assistant" } });
 
     // contentBlockStart with toolUse
     expect(frames[1].eventType).toBe("contentBlockStart");
     const startPayload = frames[1].payload as {
       contentBlockIndex: number;
-      start: { toolUse: { toolUseId: string; name: string } };
+      contentBlockStart: {
+        contentBlockIndex: number;
+        start: { toolUse: { toolUseId: string; name: string } };
+      };
     };
     expect(startPayload.contentBlockIndex).toBe(0);
-    expect(startPayload.start.toolUse.name).toBe("get_weather");
-    expect(startPayload.start.toolUse.toolUseId).toBeDefined();
+    expect(startPayload.contentBlockStart.start.toolUse.name).toBe("get_weather");
+    expect(startPayload.contentBlockStart.start.toolUse.toolUseId).toBeDefined();
 
-    // contentBlockDelta(s) with input_json_delta
+    // contentBlockDelta(s) with toolUse input
     const deltas = frames.filter((f) => f.eventType === "contentBlockDelta");
     expect(deltas.length).toBeGreaterThanOrEqual(1);
     const fullJson = deltas
-      .map((f) => (f.payload as { delta: { inputJSON: string } }).delta.inputJSON)
+      .map(
+        (f) =>
+          (f.payload as { contentBlockDelta: { delta: { toolUse: { input: string } } } })
+            .contentBlockDelta.delta.toolUse.input,
+      )
       .join("");
     expect(JSON.parse(fullJson)).toEqual({ city: "SF" });
 
@@ -460,18 +474,24 @@ describe("POST /model/{modelId}/invoke-with-response-stream (multiple tool calls
     // First tool at contentBlockIndex 0
     const start0 = blockStarts[0].payload as {
       contentBlockIndex: number;
-      start: { toolUse: { name: string } };
+      contentBlockStart: {
+        contentBlockIndex: number;
+        start: { toolUse: { name: string } };
+      };
     };
     expect(start0.contentBlockIndex).toBe(0);
-    expect(start0.start.toolUse.name).toBe("get_weather");
+    expect(start0.contentBlockStart.start.toolUse.name).toBe("get_weather");
 
     // Second tool at contentBlockIndex 1
     const start1 = blockStarts[1].payload as {
       contentBlockIndex: number;
-      start: { toolUse: { name: string } };
+      contentBlockStart: {
+        contentBlockIndex: number;
+        start: { toolUse: { name: string } };
+      };
     };
     expect(start1.contentBlockIndex).toBe(1);
-    expect(start1.start.toolUse.name).toBe("get_time");
+    expect(start1.contentBlockStart.start.toolUse.name).toBe("get_time");
 
     // contentBlockStop should also have correct indices
     const blockStops = frames.filter((f) => f.eventType === "contentBlockStop");
@@ -623,13 +643,17 @@ describe("POST /model/{modelId}/converse-stream", () => {
 
     // Verify event sequence
     expect(frames[0].eventType).toBe("messageStart");
-    expect(frames[0].payload).toEqual({ role: "assistant" });
+    expect(frames[0].payload).toEqual({ messageStart: { role: "assistant" } });
 
     expect(frames[1].eventType).toBe("contentBlockStart");
 
     const deltas = frames.filter((f) => f.eventType === "contentBlockDelta");
     const fullText = deltas
-      .map((f) => (f.payload as { delta: { text: string } }).delta.text)
+      .map(
+        (f) =>
+          (f.payload as { contentBlockDelta: { delta: { text: string } } }).contentBlockDelta.delta
+            .text,
+      )
       .join("");
     expect(fullText).toBe("Hi there!");
 
@@ -651,13 +675,20 @@ describe("POST /model/{modelId}/converse-stream", () => {
     const startFrame = frames.find((f) => f.eventType === "contentBlockStart");
     const startPayload = startFrame!.payload as {
       contentBlockIndex: number;
-      start: { toolUse: { toolUseId: string; name: string } };
+      contentBlockStart: {
+        contentBlockIndex: number;
+        start: { toolUse: { toolUseId: string; name: string } };
+      };
     };
-    expect(startPayload.start.toolUse.name).toBe("get_weather");
+    expect(startPayload.contentBlockStart.start.toolUse.name).toBe("get_weather");
 
     const deltas = frames.filter((f) => f.eventType === "contentBlockDelta");
     const fullJson = deltas
-      .map((f) => (f.payload as { delta: { inputJSON: string } }).delta.inputJSON)
+      .map(
+        (f) =>
+          (f.payload as { contentBlockDelta: { delta: { toolUse: { input: string } } } })
+            .contentBlockDelta.delta.toolUse.input,
+      )
       .join("");
     expect(JSON.parse(fullJson)).toEqual({ city: "SF" });
 
@@ -994,12 +1025,14 @@ describe("POST /model/{modelId}/invoke-with-response-stream (malformed tool args
     expect(res.status).toBe(200);
     const frames = parseFrames(res.body);
 
-    // Find contentBlockDelta frames with inputJSON
+    // Find contentBlockDelta frames with toolUse input
     const deltas = frames.filter((f) => f.eventType === "contentBlockDelta");
     const fullJson = deltas
       .map((f) => {
-        const payload = f.payload as { delta: { inputJSON?: string } };
-        return payload.delta.inputJSON ?? "";
+        const payload = f.payload as {
+          contentBlockDelta: { delta: { toolUse?: { input: string } } };
+        };
+        return payload.contentBlockDelta.delta.toolUse?.input ?? "";
       })
       .join("");
     // Malformed arguments should fall back to "{}"

--- a/src/__tests__/bedrock.test.ts
+++ b/src/__tests__/bedrock.test.ts
@@ -1445,7 +1445,6 @@ describe("POST /model/{modelId}/invoke (error fixture no error type)", () => {
 // ---------------------------------------------------------------------------
 
 import { buildBedrockStreamTextEvents, buildBedrockStreamToolCallEvents } from "../bedrock.js";
-import { Logger } from "../logger.js";
 
 describe("buildBedrockStreamTextEvents", () => {
   it("creates correct event sequence for empty content", () => {
@@ -1680,7 +1679,7 @@ describe("Bedrock webSearches warning", () => {
 
     const fixture: Fixture = {
       match: { userMessage: "web" },
-      response: { content: "Result.", webSearches: [{ query: "test" }] },
+      response: { content: "Result.", webSearches: ["test"] },
     };
     const journal = new Journal();
     const req = {
@@ -1834,7 +1833,7 @@ describe("Bedrock Converse webSearches warning", () => {
     const fixtures: Fixture[] = [
       {
         match: { userMessage: "conv-web" },
-        response: { content: "Result.", webSearches: [{ query: "test" }] },
+        response: { content: "Result.", webSearches: ["test"] },
       },
     ];
     instance = await createServer(fixtures);

--- a/src/__tests__/bedrock.test.ts
+++ b/src/__tests__/bedrock.test.ts
@@ -1557,3 +1557,294 @@ describe("POST /model/{modelId}/invoke (strict mode)", () => {
     expect(body.content[0].text).toBe("Hi there!");
   });
 });
+
+// ─── Bedrock ResponseOverrides ─────────────────────────────────────────────
+
+describe("Bedrock ResponseOverrides", () => {
+  it("applies id/model/finishReason overrides on invoke text response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "ov" },
+        response: {
+          content: "Overridden.",
+          id: "msg-custom-123",
+          model: "custom-model",
+          finishReason: "length",
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(
+      `${instance.url}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke`,
+      {
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: 512,
+        messages: [{ role: "user", content: "ov" }],
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe("msg-custom-123");
+    expect(body.model).toBe("custom-model");
+    expect(body.stop_reason).toBe("max_tokens");
+  });
+
+  it("applies usage overrides on invoke text response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "ov-usage" },
+        response: {
+          content: "Usage test.",
+          usage: { input_tokens: 15, output_tokens: 25 },
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(
+      `${instance.url}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke`,
+      {
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: 512,
+        messages: [{ role: "user", content: "ov-usage" }],
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.usage.input_tokens).toBe(15);
+    expect(body.usage.output_tokens).toBe(25);
+  });
+
+  it("applies overrides on invoke tool call response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "ov-tool" },
+        response: {
+          toolCalls: [{ name: "fn", arguments: '{"x":1}' }],
+          id: "tc-ov-id",
+          finishReason: "stop",
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(
+      `${instance.url}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke`,
+      {
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: 512,
+        messages: [{ role: "user", content: "ov-tool" }],
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe("tc-ov-id");
+    expect(body.stop_reason).toBe("end_turn");
+  });
+
+  it("applies overrides on invoke content+toolCalls response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "ov-cwtc" },
+        response: {
+          content: "Here is the result.",
+          toolCalls: [{ name: "fn", arguments: '{"a":1}' }],
+          id: "cwtc-ov-id",
+          finishReason: "tool_calls",
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(
+      `${instance.url}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke`,
+      {
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: 512,
+        messages: [{ role: "user", content: "ov-cwtc" }],
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe("cwtc-ov-id");
+    expect(body.stop_reason).toBe("tool_use");
+  });
+});
+
+// ─── Bedrock webSearches warning ───────────────────────────────────────────
+
+describe("Bedrock webSearches warning", () => {
+  it("logs warning for text response with webSearches on invoke", async () => {
+    const warnings: string[] = [];
+    const logger = new Logger("silent");
+    logger.warn = (msg: string) => {
+      warnings.push(msg);
+    };
+
+    const fixture: Fixture = {
+      match: { userMessage: "web" },
+      response: { content: "Result.", webSearches: [{ query: "test" }] },
+    };
+    const journal = new Journal();
+    const req = {
+      method: undefined,
+      url: undefined,
+      headers: {},
+    } as unknown as http.IncomingMessage;
+    const res = {
+      _written: "",
+      writableEnded: false,
+      statusCode: 0,
+      writeHead(s: number) {
+        this.statusCode = s;
+      },
+      setHeader() {},
+      write(d: string) {
+        this._written += d;
+        return true;
+      },
+      end(d?: string) {
+        if (d) this._written += d;
+        this.writableEnded = true;
+      },
+      destroy() {
+        this.writableEnded = true;
+      },
+    } as unknown as http.ServerResponse;
+
+    await handleBedrock(
+      req,
+      res,
+      JSON.stringify({
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: 512,
+        messages: [{ role: "user", content: "web" }],
+      }),
+      "anthropic.claude-3-5-sonnet-20241022-v2:0",
+      [fixture],
+      journal,
+      {
+        latency: 0,
+        chunkSize: 100,
+        logger,
+      } as HandlerDefaults,
+      () => {},
+    );
+
+    expect(warnings.some((w) => w.includes("webSearches") && w.includes("Bedrock"))).toBe(true);
+  });
+});
+
+// ─── Bedrock Converse ResponseOverrides ────────────────────────────────────
+
+describe("Bedrock Converse ResponseOverrides", () => {
+  it("applies finishReason override on converse text response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "conv-ov" },
+        response: {
+          content: "Overridden.",
+          finishReason: "length",
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(
+      `${instance.url}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse`,
+      {
+        messages: [{ role: "user", content: [{ text: "conv-ov" }] }],
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.stopReason).toBe("max_tokens");
+  });
+
+  it("applies usage override on converse text response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "conv-usage" },
+        response: {
+          content: "Usage test.",
+          usage: { input_tokens: 5, output_tokens: 10 },
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(
+      `${instance.url}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse`,
+      {
+        messages: [{ role: "user", content: [{ text: "conv-usage" }] }],
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.usage.inputTokens).toBe(5);
+    expect(body.usage.outputTokens).toBe(10);
+    expect(body.usage.totalTokens).toBe(15);
+  });
+
+  it("applies overrides on converse tool call response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "conv-tool" },
+        response: {
+          toolCalls: [{ name: "fn", arguments: '{"a":1}' }],
+          finishReason: "stop",
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(
+      `${instance.url}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse`,
+      {
+        messages: [{ role: "user", content: [{ text: "conv-tool" }] }],
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.stopReason).toBe("end_turn");
+  });
+
+  it("applies overrides on converse content+toolCalls response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "conv-cwtc" },
+        response: {
+          content: "Some text.",
+          toolCalls: [{ name: "fn", arguments: '{"a":1}' }],
+          finishReason: "tool_calls",
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(
+      `${instance.url}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse`,
+      {
+        messages: [{ role: "user", content: [{ text: "conv-cwtc" }] }],
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.stopReason).toBe("tool_use");
+  });
+});
+
+// ─── Bedrock Converse webSearches warning ──────────────────────────────────
+
+describe("Bedrock Converse webSearches warning", () => {
+  it("logs warning for text response with webSearches on converse", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "conv-web" },
+        response: { content: "Result.", webSearches: [{ query: "test" }] },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(
+      `${instance.url}/model/anthropic.claude-3-5-sonnet-20241022-v2:0/converse`,
+      {
+        messages: [{ role: "user", content: [{ text: "conv-web" }] }],
+      },
+    );
+    // Should still succeed — webSearches is just ignored with a warning
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/__tests__/bedrock.test.ts
+++ b/src/__tests__/bedrock.test.ts
@@ -1461,9 +1461,18 @@ describe("buildBedrockStreamTextEvents", () => {
     const events = buildBedrockStreamTextEvents("ABCDEF", 2);
     const deltas = events.filter((e) => e.eventType === "contentBlockDelta");
     expect(deltas).toHaveLength(3);
-    expect((deltas[0].payload as { delta: { text: string } }).delta.text).toBe("AB");
-    expect((deltas[1].payload as { delta: { text: string } }).delta.text).toBe("CD");
-    expect((deltas[2].payload as { delta: { text: string } }).delta.text).toBe("EF");
+    expect(
+      (deltas[0].payload as { contentBlockDelta: { delta: { text: string } } }).contentBlockDelta
+        .delta.text,
+    ).toBe("AB");
+    expect(
+      (deltas[1].payload as { contentBlockDelta: { delta: { text: string } } }).contentBlockDelta
+        .delta.text,
+    ).toBe("CD");
+    expect(
+      (deltas[2].payload as { contentBlockDelta: { delta: { text: string } } }).contentBlockDelta
+        .delta.text,
+    ).toBe("EF");
   });
 });
 
@@ -1478,7 +1487,11 @@ describe("buildBedrockStreamToolCallEvents", () => {
     );
     const deltas = events.filter((e) => e.eventType === "contentBlockDelta");
     const fullJson = deltas
-      .map((e) => (e.payload as { delta: { inputJSON: string } }).delta.inputJSON)
+      .map(
+        (e) =>
+          (e.payload as { contentBlockDelta: { delta: { toolUse: { input: string } } } })
+            .contentBlockDelta.delta.toolUse.input,
+      )
       .join("");
     expect(fullJson).toBe("{}");
   });
@@ -1491,9 +1504,9 @@ describe("buildBedrockStreamToolCallEvents", () => {
     );
     const startEvent = events.find((e) => e.eventType === "contentBlockStart");
     const payload = startEvent!.payload as {
-      start: { toolUse: { toolUseId: string } };
+      contentBlockStart: { start: { toolUse: { toolUseId: string } } };
     };
-    expect(payload.start.toolUse.toolUseId).toMatch(/^toolu_/);
+    expect(payload.contentBlockStart.start.toolUse.toolUseId).toMatch(/^toolu_/);
   });
 
   it("uses provided tool id", () => {
@@ -1504,16 +1517,20 @@ describe("buildBedrockStreamToolCallEvents", () => {
     );
     const startEvent = events.find((e) => e.eventType === "contentBlockStart");
     const payload = startEvent!.payload as {
-      start: { toolUse: { toolUseId: string } };
+      contentBlockStart: { start: { toolUse: { toolUseId: string } } };
     };
-    expect(payload.start.toolUse.toolUseId).toBe("custom_id");
+    expect(payload.contentBlockStart.start.toolUse.toolUseId).toBe("custom_id");
   });
 
   it("uses '{}' when arguments is empty string", () => {
     const events = buildBedrockStreamToolCallEvents([{ name: "fn", arguments: "" }], 100, logger);
     const deltas = events.filter((e) => e.eventType === "contentBlockDelta");
     const fullJson = deltas
-      .map((e) => (e.payload as { delta: { inputJSON: string } }).delta.inputJSON)
+      .map(
+        (e) =>
+          (e.payload as { contentBlockDelta: { delta: { toolUse: { input: string } } } })
+            .contentBlockDelta.delta.toolUse.input,
+      )
       .join("");
     expect(fullJson).toBe("{}");
   });

--- a/src/__tests__/cohere.test.ts
+++ b/src/__tests__/cohere.test.ts
@@ -1416,3 +1416,321 @@ describe("handleCohere (direct handler call, method/url fallbacks)", () => {
     expect(entry!.response.status).toBe(500);
   });
 });
+
+// ─── Cohere reasoning support ──────────────────────────────────────────────
+
+describe("Cohere reasoning support", () => {
+  it("includes reasoning as text block in non-streaming text response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "think" },
+        response: { content: "The answer is 42.", reasoning: "Let me reason step by step..." },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(`${instance.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "think" }],
+    });
+    expect(res.status).toBe(200);
+    const json = JSON.parse(res.body);
+    expect(json.message.content).toHaveLength(2);
+    expect(json.message.content[0].text).toBe("Let me reason step by step...");
+    expect(json.message.content[1].text).toBe("The answer is 42.");
+    expect(json.finish_reason).toBe("COMPLETE");
+  });
+
+  it("includes reasoning blocks in streaming text response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "think-stream" },
+        response: { content: "Result.", reasoning: "Thinking..." },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(`${instance.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "think-stream" }],
+      stream: true,
+    });
+    expect(res.status).toBe(200);
+    const events = parseSSEEvents(res.body);
+
+    // Should have content-start/delta/end for reasoning (index 0) then content (index 1)
+    const contentDeltas = events.filter((e) => e.event === "content-delta");
+    expect(contentDeltas.length).toBeGreaterThanOrEqual(2);
+    // First content delta should be the reasoning text
+    const firstDelta = contentDeltas[0].data as {
+      delta: { message: { content: { text: string } } };
+    };
+    expect(firstDelta.delta.message.content.text).toBe("Thinking...");
+  });
+
+  it("includes reasoning in content+toolCalls non-streaming response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "think-tool" },
+        response: {
+          content: "Let me check.",
+          toolCalls: [{ name: "lookup", arguments: '{"q":"test"}' }],
+          reasoning: "Need to look this up.",
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(`${instance.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "think-tool" }],
+    });
+    expect(res.status).toBe(200);
+    const json = JSON.parse(res.body);
+    // reasoning block + text block
+    expect(json.message.content.length).toBeGreaterThanOrEqual(2);
+    expect(json.message.content[0].text).toBe("Need to look this up.");
+    expect(json.message.content[1].text).toBe("Let me check.");
+    expect(json.message.tool_calls.length).toBe(1);
+    expect(json.finish_reason).toBe("TOOL_CALL");
+  });
+});
+
+// ─── Cohere webSearches warning ────────────────────────────────────────────
+
+describe("Cohere webSearches warning", () => {
+  it("logs warning when text response has webSearches", async () => {
+    const warnings: string[] = [];
+    const logger = new Logger("silent");
+    logger.warn = (msg: string) => {
+      warnings.push(msg);
+    };
+
+    const fixture: Fixture = {
+      match: { userMessage: "web" },
+      response: { content: "Result.", webSearches: [{ query: "test" }] },
+    };
+    const journal = new Journal();
+    const req = createMockReq();
+    const res = createMockRes();
+
+    await handleCohere(
+      req,
+      res,
+      JSON.stringify({ model: "cmd-r", messages: [{ role: "user", content: "web" }] }),
+      [fixture],
+      journal,
+      createDefaults({ logger }),
+      () => {},
+    );
+
+    expect(warnings.some((w) => w.includes("webSearches") && w.includes("Cohere"))).toBe(true);
+  });
+
+  it("logs warning when content+toolCalls response has webSearches", async () => {
+    const warnings: string[] = [];
+    const logger = new Logger("silent");
+    logger.warn = (msg: string) => {
+      warnings.push(msg);
+    };
+
+    const fixture: Fixture = {
+      match: { userMessage: "web-tool" },
+      response: {
+        content: "Here.",
+        toolCalls: [{ name: "fn", arguments: "{}" }],
+        webSearches: [{ query: "test" }],
+      },
+    };
+    const journal = new Journal();
+    const req = createMockReq();
+    const res = createMockRes();
+
+    await handleCohere(
+      req,
+      res,
+      JSON.stringify({ model: "cmd-r", messages: [{ role: "user", content: "web-tool" }] }),
+      [fixture],
+      journal,
+      createDefaults({ logger }),
+      () => {},
+    );
+
+    expect(warnings.some((w) => w.includes("webSearches") && w.includes("Cohere"))).toBe(true);
+  });
+});
+
+// ─── Cohere response_format forwarding ─────────────────────────────────────
+
+describe("Cohere response_format forwarding", () => {
+  it("forwards response_format to ChatCompletionRequest", () => {
+    const result = cohereToCompletionRequest({
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "hello" }],
+      response_format: { type: "json_object" },
+    } as Parameters<typeof cohereToCompletionRequest>[0]);
+    expect(result.response_format).toEqual({ type: "json_object" });
+  });
+
+  it("omits response_format when not provided", () => {
+    const result = cohereToCompletionRequest({
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "hello" }],
+    } as Parameters<typeof cohereToCompletionRequest>[0]);
+    expect(result.response_format).toBeUndefined();
+  });
+});
+
+// ─── Cohere assistant tool_calls mapping ───────────────────────────────────
+
+describe("Cohere assistant tool_calls mapping", () => {
+  it("maps assistant tool_calls to ChatCompletionRequest format", () => {
+    const result = cohereToCompletionRequest({
+      model: "command-r-plus",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: "Using tool",
+          tool_calls: [
+            {
+              id: "tc-1",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"city":"SF"}' },
+            },
+          ],
+        },
+        { role: "tool", content: "72F", tool_call_id: "tc-1" },
+        { role: "user", content: "thanks" },
+      ],
+    } as Parameters<typeof cohereToCompletionRequest>[0]);
+
+    const assistantMsg = result.messages.find(
+      (m) => m.role === "assistant" && m.tool_calls && m.tool_calls.length > 0,
+    );
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.tool_calls).toHaveLength(1);
+    expect(assistantMsg!.tool_calls![0].function.name).toBe("get_weather");
+    expect(assistantMsg!.tool_calls![0].function.arguments).toBe('{"city":"SF"}');
+    expect(assistantMsg!.tool_calls![0].id).toBe("tc-1");
+    expect(assistantMsg!.content).toBe("Using tool");
+  });
+
+  it("generates tool_call id when not provided", () => {
+    const result = cohereToCompletionRequest({
+      model: "command-r-plus",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              type: "function",
+              function: { name: "fn", arguments: "{}" },
+            },
+          ],
+        },
+      ],
+    } as Parameters<typeof cohereToCompletionRequest>[0]);
+
+    const assistantMsg = result.messages.find(
+      (m) => m.role === "assistant" && m.tool_calls && m.tool_calls.length > 0,
+    );
+    expect(assistantMsg!.tool_calls![0].id).toBeTruthy();
+  });
+
+  it("falls back to plain assistant message when no tool_calls present", () => {
+    const result = cohereToCompletionRequest({
+      model: "command-r-plus",
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "just text" },
+      ],
+    } as Parameters<typeof cohereToCompletionRequest>[0]);
+
+    const assistantMsg = result.messages.find((m) => m.role === "assistant");
+    expect(assistantMsg!.content).toBe("just text");
+    expect(assistantMsg!.tool_calls).toBeUndefined();
+  });
+});
+
+// ─── Cohere ResponseOverrides ──────────────────────────────────────────────
+
+describe("Cohere ResponseOverrides", () => {
+  it("applies id override on non-streaming text response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "ov-id" },
+        response: { content: "Hi!", id: "custom-id-123" },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(`${instance.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "ov-id" }],
+    });
+    expect(res.status).toBe(200);
+    const json = JSON.parse(res.body);
+    expect(json.id).toBe("custom-id-123");
+  });
+
+  it("applies finishReason override on non-streaming text response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "ov-fr" },
+        response: { content: "Done.", finishReason: "length" },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(`${instance.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "ov-fr" }],
+    });
+    expect(res.status).toBe(200);
+    const json = JSON.parse(res.body);
+    expect(json.finish_reason).toBe("MAX_TOKENS");
+  });
+
+  it("applies usage override on non-streaming text response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "ov-usage" },
+        response: {
+          content: "Done.",
+          usage: { prompt_tokens: 10, completion_tokens: 20 },
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(`${instance.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "ov-usage" }],
+    });
+    expect(res.status).toBe(200);
+    const json = JSON.parse(res.body);
+    expect(json.usage.tokens.input_tokens).toBe(10);
+    expect(json.usage.tokens.output_tokens).toBe(20);
+    expect(json.usage.billed_units.input_tokens).toBe(10);
+    expect(json.usage.billed_units.output_tokens).toBe(20);
+  });
+
+  it("applies overrides on non-streaming tool call response", async () => {
+    const fixtures: Fixture[] = [
+      {
+        match: { userMessage: "ov-tc" },
+        response: {
+          toolCalls: [{ name: "fn", arguments: '{"a":1}' }],
+          id: "tc-override-id",
+          finishReason: "stop",
+        },
+      },
+    ];
+    instance = await createServer(fixtures);
+    const res = await post(`${instance.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "ov-tc" }],
+    });
+    expect(res.status).toBe(200);
+    const json = JSON.parse(res.body);
+    expect(json.id).toBe("tc-override-id");
+    expect(json.finish_reason).toBe("COMPLETE");
+  });
+});

--- a/src/__tests__/cohere.test.ts
+++ b/src/__tests__/cohere.test.ts
@@ -829,8 +829,8 @@ describe("POST /v2/chat (malformed tool call arguments)", () => {
     const body = JSON.parse(res.body);
     expect(body.message.tool_calls).toHaveLength(1);
     expect(body.message.tool_calls[0].function.name).toBe("fn");
-    // Cohere passes through the arguments string as-is (logs warning)
-    expect(body.message.tool_calls[0].function.arguments).toBe("NOT VALID JSON");
+    // Malformed JSON falls back to "{}" (logs warning)
+    expect(body.message.tool_calls[0].function.arguments).toBe("{}");
   });
 });
 

--- a/src/__tests__/cohere.test.ts
+++ b/src/__tests__/cohere.test.ts
@@ -1505,7 +1505,7 @@ describe("Cohere webSearches warning", () => {
 
     const fixture: Fixture = {
       match: { userMessage: "web" },
-      response: { content: "Result.", webSearches: [{ query: "test" }] },
+      response: { content: "Result.", webSearches: ["test"] },
     };
     const journal = new Journal();
     const req = createMockReq();
@@ -1536,7 +1536,7 @@ describe("Cohere webSearches warning", () => {
       response: {
         content: "Here.",
         toolCalls: [{ name: "fn", arguments: "{}" }],
-        webSearches: [{ query: "test" }],
+        webSearches: ["test"],
       },
     };
     const journal = new Journal();

--- a/src/__tests__/competitive-matrix.test.ts
+++ b/src/__tests__/competitive-matrix.test.ts
@@ -49,13 +49,38 @@ const FEATURE_RULES: FeatureRule[] = [
   },
   {
     rowLabel: "Embeddings API",
-    keywords: ["embedding", "/v1/embeddings", "embed"],
+    keywords: ["/v1/embeddings", "embeddings api", "embedding endpoint", "embedding model"],
+  },
+  {
+    rowLabel: "Image generation",
+    keywords: ["dall-e", "dalle", "/v1/images", "image generation", "imagen", "generate.*image"],
+  },
+  {
+    rowLabel: "Video generation",
+    keywords: ["sora", "/v1/videos", "video generation", "generate.*video"],
+  },
+  {
+    rowLabel: "Docker image",
+    keywords: ["dockerfile", "docker image", "docker-compose", "docker compose", "docker run"],
   },
   {
     rowLabel: "Structured output / JSON mode",
     keywords: ["json_object", "json_schema", "structured output", "response_format"],
   },
 ];
+
+function extractFeatures(text: string): Record<string, boolean> {
+  const lower = text.toLowerCase();
+  const result: Record<string, boolean> = {};
+  for (const rule of FEATURE_RULES) {
+    const found = rule.keywords.some((kw) => {
+      const pattern = new RegExp(kw.toLowerCase(), "i");
+      return pattern.test(lower);
+    });
+    result[rule.rowLabel] = found;
+  }
+  return result;
+}
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
@@ -86,7 +111,18 @@ function buildMigrationRowPatterns(rowLabel: string): string[] {
   return patterns;
 }
 
-// ── Provider count update logic ─────────────────────────────────────────────
+// ── Provider count update logic (scoped version) ───────────────────────────
+
+/** Replaces "N providers" or "N+ providers" in a string if detected > current */
+function replaceProviderCount(text: string, detectedCount: number): string {
+  return text.replace(/(\d+)\+?\s*(?:LLM\s*)?providers?/gi, (match, numStr) => {
+    const currentCount = parseInt(numStr, 10);
+    if (detectedCount > currentCount) {
+      return `${detectedCount} providers`;
+    }
+    return match;
+  });
+}
 
 function updateProviderCounts(
   html: string,
@@ -95,23 +131,65 @@ function updateProviderCounts(
   changes: string[],
 ): string {
   let result = html;
+  const escapedName = escapeRegex(competitorName);
 
-  const providerCountRegex = /(\d+)\+?\s*providers/g;
-  result = result.replace(providerCountRegex, (match, numStr) => {
-    const currentCount = parseInt(numStr, 10);
-    if (detectedCount > currentCount) {
-      changes.push(`${competitorName}: provider count ${currentCount} -> ${detectedCount}`);
-      return `${detectedCount} providers`;
+  // Strategy 1: Replace provider counts in table rows about providers,
+  // scoped to the competitor's column.
+  const tableMatch = result.match(
+    /<table class="(?:comparison-table|endpoint-table)">([\s\S]*?)<\/table>/,
+  );
+  if (tableMatch) {
+    const fullTable = tableMatch[0];
+
+    // Find the competitor's column index from headers
+    const thRegex = /<th[^>]*>([\s\S]*?)<\/th>/g;
+    const thTexts: string[] = [];
+    let thM: RegExpExecArray | null;
+    while ((thM = thRegex.exec(fullTable)) !== null) {
+      thTexts.push(thM[1].trim());
     }
-    return match;
-  });
+    const compColIdx = thTexts.findIndex((t) => t.includes(competitorName) || t === competitorName);
 
-  const llmProviderRegex = /(\d+)\+?\s*LLM\s*providers?/g;
-  result = result.replace(llmProviderRegex, (match, numStr) => {
+    if (compColIdx >= 0) {
+      const updatedTable = fullTable.replace(
+        /<tr>([\s\S]*?)<\/tr>/g,
+        (trMatch, trContent: string) => {
+          const firstTd = trContent.match(/<td[^>]*>([\s\S]*?)<\/td>/);
+          if (!firstTd || !/provider/i.test(firstTd[1])) return trMatch;
+
+          let cellIdx = 0;
+          return trMatch.replace(/<td[^>]*>([\s\S]*?)<\/td>/g, (tdMatch, tdContent: string) => {
+            const currentIdx = cellIdx++;
+            if (currentIdx !== compColIdx) return tdMatch;
+
+            const updated = replaceProviderCount(tdContent, detectedCount);
+            if (updated !== tdContent) {
+              const oldCount = tdContent.match(/(\d+)/)?.[1] ?? "?";
+              changes.push(
+                `${competitorName}: provider count ${oldCount} -> ${detectedCount} (table)`,
+              );
+              return tdMatch.replace(tdContent, updated);
+            }
+            return tdMatch;
+          });
+        },
+      );
+
+      result = result.replace(fullTable, updatedTable);
+    }
+  }
+
+  // Strategy 2: Replace provider counts in prose paragraphs/sentences that
+  // explicitly mention the competitor by name.
+  const prosePattern = new RegExp(
+    `(<[^>]*>[^<]*${escapedName}[^<]*)(\\d+)\\+?\\s*(?:LLM\\s*)?providers?`,
+    "gi",
+  );
+  result = result.replace(prosePattern, (match, prefix, numStr) => {
     const currentCount = parseInt(numStr, 10);
     if (detectedCount > currentCount) {
-      changes.push(`${competitorName}: LLM provider count ${currentCount} -> ${detectedCount}`);
-      return `${detectedCount} LLM providers`;
+      changes.push(`${competitorName}: provider count ${currentCount} -> ${detectedCount} (prose)`);
+      return match.replace(/(\d+)\+?\s*(?:LLM\s*)?providers?/, `${detectedCount} providers`);
     }
     return match;
   });
@@ -157,6 +235,156 @@ function updateMigrationPage(
   }
 
   return { html: result, changes };
+}
+
+// ── parseCurrentMatrix reimplementation for testing ────────────────────────
+
+function parseCurrentMatrix(html: string): {
+  headers: string[];
+  rows: Map<string, Map<string, string>>;
+} {
+  const tableMatch = html.match(/<table class="comparison-table">([\s\S]*?)<\/table>/);
+  if (!tableMatch) {
+    throw new Error("Could not find comparison-table in HTML");
+  }
+  const tableHtml = tableMatch[1];
+
+  const thRegex = /<th[^>]*>[\s\S]*?<a[^>]*>(.*?)<\/a[\s\S]*?<\/th>/g;
+  const headers: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = thRegex.exec(tableHtml)) !== null) {
+    headers.push(m[1].trim());
+  }
+
+  const rows = new Map<string, Map<string, string>>();
+  const tbody = tableHtml.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] ?? "";
+  let tr: RegExpExecArray | null;
+  const trIter = new RegExp(/<tr>([\s\S]*?)<\/tr>/g);
+
+  while ((tr = trIter.exec(tbody)) !== null) {
+    const tds: string[] = [];
+    const tdRegex = /<td[^>]*>([\s\S]*?)<\/td>/g;
+    let td: RegExpExecArray | null;
+    while ((td = tdRegex.exec(tr[1])) !== null) {
+      tds.push(td[1].trim());
+    }
+    if (tds.length < 2) continue;
+
+    const rowLabel = tds[0];
+    const rowMap = new Map<string, string>();
+    for (let i = 1; i < tds.length && i - 1 < headers.length; i++) {
+      rowMap.set(headers[i - 1], tds[i]);
+    }
+    rows.set(rowLabel, rowMap);
+  }
+
+  return { headers, rows };
+}
+
+// ── computeChanges reimplementation (mirrors fixed version) ────────────────
+
+interface DetectedChange {
+  competitor: string;
+  capability: string;
+  from: string;
+  to: string;
+}
+
+function computeChanges(
+  _html: string,
+  matrix: { headers: string[]; rows: Map<string, Map<string, string>> },
+  competitorFeatures: Map<string, Record<string, boolean>>,
+): DetectedChange[] {
+  const changes: DetectedChange[] = [];
+
+  for (const [compName, features] of competitorFeatures) {
+    for (const [rowLabel, detected] of Object.entries(features)) {
+      if (!detected) continue;
+
+      const row = matrix.rows.get(rowLabel);
+      if (!row) continue;
+
+      const currentCell = row.get(compName);
+      if (!currentCell) continue;
+
+      // Only upgrade "No" cells — cells contain inner HTML like
+      // '<span class="no">&#10007;</span>', not bare "No" text.
+      if (
+        currentCell.includes('class="no"') ||
+        currentCell.includes("\u2717") ||
+        currentCell.includes("&#10007;")
+      ) {
+        changes.push({
+          competitor: compName,
+          capability: rowLabel,
+          from: "No",
+          to: "Yes",
+        });
+      }
+    }
+  }
+
+  return changes;
+}
+
+// ── applyChanges reimplementation (mirrors fixed version) ──────────────────
+
+function applyChanges(html: string, changes: DetectedChange[]): string {
+  if (changes.length === 0) return html;
+
+  const tableMatch = html.match(/<table class="comparison-table">([\s\S]*?)<\/table>/);
+  if (!tableMatch) return html;
+
+  const theadMatch = tableMatch[1].match(/<thead>([\s\S]*?)<\/thead>/);
+  if (!theadMatch) return html;
+
+  const thRegex = /<th[^>]*>[\s\S]*?<a[^>]*>(.*?)<\/a[\s\S]*?<\/th>/g;
+  const headers: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = thRegex.exec(theadMatch[1])) !== null) {
+    headers.push(m[1].trim());
+  }
+
+  const compColumnIndex = (name: string): number => {
+    const idx = headers.indexOf(name);
+    return idx === -1 ? -1 : idx + 1;
+  };
+
+  let result = html;
+
+  for (const change of changes) {
+    const colIdx = compColumnIndex(change.competitor);
+    if (colIdx === -1) continue;
+
+    const rowPattern = new RegExp(
+      `(<tr>\\s*<td>\\s*${escapeRegex(change.capability)}\\s*</td>)([\\s\\S]*?)(</tr>)`,
+    );
+    const rowMatch = result.match(rowPattern);
+    if (!rowMatch) continue;
+
+    const prefix = rowMatch[1];
+    const cellsHtml = rowMatch[2];
+    const suffix = rowMatch[3];
+
+    const targetTdIdx = colIdx - 1;
+    let tdCount = 0;
+    const tdReplace = cellsHtml.replace(/<td[^>]*>([\s\S]*?)<\/td>/g, (fullMatch, content) => {
+      const currentIdx = tdCount++;
+      if (
+        currentIdx === targetTdIdx &&
+        (content.includes('class="no"') ||
+          content.includes("\u2717") ||
+          content.includes("&#10007;"))
+      ) {
+        return `<td><span class="yes">&#10003;</span></td>`;
+      }
+      return fullMatch;
+    });
+
+    result = result.replace(rowPattern, prefix + tdReplace + suffix);
+  }
+
+  return result;
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -254,7 +482,7 @@ describe("migration page table update logic", () => {
 
     const { html } = updateMigrationPage(SAMPLE_TABLE, "TestComp", features, 0);
 
-    // Streaming SSE was already ✓, should remain unchanged
+    // Streaming SSE was already checkmark, should remain unchanged
     expect(html).toContain(
       '<td>Streaming SSE</td>\n      <td style="color: var(--accent)">&#10003;</td>',
     );
@@ -305,46 +533,107 @@ describe("migration page table update logic", () => {
   });
 });
 
-describe("numeric provider claim updates", () => {
-  it('updates "5 providers" to "8 providers" when detected count is higher', () => {
-    const html = "<p>Supports 5 providers out of the box.</p>";
+describe("scoped provider count updates", () => {
+  it("updates competitor column in provider table row", () => {
+    const html = `
+<table class="comparison-table">
+  <thead>
+    <tr>
+      <th>Capability</th>
+      <th>TestComp</th>
+      <th>aimock</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>LLM providers</td>
+      <td>5 providers</td>
+      <td>11 providers</td>
+    </tr>
+  </tbody>
+</table>`;
     const changes: string[] = [];
 
     const result = updateProviderCounts(html, "TestComp", 8, changes);
 
+    // TestComp's cell should be updated
     expect(result).toContain("8 providers");
-    expect(result).not.toContain("5 providers");
+    // aimock's 11 providers should be left alone
+    expect(result).toContain("11 providers");
     expect(changes.length).toBe(1);
   });
 
-  it('updates "5+ providers" to "8 providers" (strips the +)', () => {
-    const html = "<td>5+ providers</td>";
+  it("does not corrupt aimock's own provider count", () => {
+    const html = `
+<table class="comparison-table">
+  <thead>
+    <tr>
+      <th>Capability</th>
+      <th>aimock</th>
+      <th>TestComp</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Multi-provider support</td>
+      <td>11 providers</td>
+      <td>5 providers</td>
+    </tr>
+  </tbody>
+</table>`;
+    const changes: string[] = [];
+
+    const result = updateProviderCounts(html, "TestComp", 8, changes);
+
+    // aimock's count must remain 11
+    expect(result).toContain("11 providers");
+    // TestComp's count should be updated to 8
+    expect(result).toContain("8 providers");
+  });
+
+  it("updates prose mentioning the competitor by name", () => {
+    const html = "<p>TestComp supports 5 providers today.</p>";
     const changes: string[] = [];
 
     const result = updateProviderCounts(html, "TestComp", 8, changes);
 
     expect(result).toContain("8 providers");
-    expect(result).not.toContain("5+");
+    expect(changes.length).toBe(1);
+  });
+
+  it("does not update prose about aimock when updating competitor", () => {
+    const html = "<p>aimock supports 11 providers natively.</p>";
+    const changes: string[] = [];
+
+    const result = updateProviderCounts(html, "TestComp", 15, changes);
+
+    // aimock's claim in prose should not be touched
+    expect(result).toContain("11 providers");
+    expect(changes).toHaveLength(0);
   });
 
   it("does not update when detected count is lower or equal", () => {
-    const html = "<p>Supports 10 providers.</p>";
+    const html = `
+<table class="comparison-table">
+  <thead>
+    <tr>
+      <th>Capability</th>
+      <th>TestComp</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>LLM providers</td>
+      <td>10 providers</td>
+    </tr>
+  </tbody>
+</table>`;
     const changes: string[] = [];
 
     const result = updateProviderCounts(html, "TestComp", 8, changes);
 
     expect(result).toContain("10 providers");
     expect(changes).toHaveLength(0);
-  });
-
-  it("updates N LLM providers pattern", () => {
-    const html = "<p>supports 3 LLM providers</p>";
-    const changes: string[] = [];
-
-    const result = updateProviderCounts(html, "TestComp", 7, changes);
-
-    expect(result).toContain("7 LLM providers");
-    expect(changes.length).toBe(1);
   });
 
   it("handles no numeric claims gracefully", () => {
@@ -357,28 +646,27 @@ describe("numeric provider claim updates", () => {
     expect(changes).toHaveLength(0);
   });
 
-  it("handles multiple provider count references in one document", () => {
-    const html = `
-      <p>Supports 5 providers including OpenAI.</p>
-      <td>5+ providers</td>
-    `;
-    const changes: string[] = [];
-
-    const result = updateProviderCounts(html, "TestComp", 9, changes);
-
-    // Both occurrences should be updated
-    expect(result).not.toContain("5 providers");
-    expect(result).not.toContain("5+");
-    expect((result.match(/9 providers/g) || []).length).toBe(2);
-  });
-
   it("does not change provider count when equal", () => {
-    const html = "<td>8 providers</td>";
+    const html = `
+<table class="comparison-table">
+  <thead>
+    <tr>
+      <th>Capability</th>
+      <th>TestComp</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>LLM providers</td>
+      <td>8 providers</td>
+    </tr>
+  </tbody>
+</table>`;
     const changes: string[] = [];
 
     const result = updateProviderCounts(html, "TestComp", 8, changes);
 
-    expect(result).toBe(html);
+    expect(result).toContain("8 providers");
     expect(changes).toHaveLength(0);
   });
 });
@@ -420,8 +708,7 @@ describe("migration page update with provider counts", () => {
 
     // Feature cell should be updated
     expect(html).not.toContain("&#10007;");
-    // Provider count in prose should be updated
-    expect(html).toContain("8 providers");
+    // Provider count should be updated somewhere
     expect(changes.length).toBeGreaterThanOrEqual(2);
   });
 
@@ -459,50 +746,6 @@ describe("buildMigrationRowPatterns", () => {
     expect(patterns).toContain("Streaming SSE");
   });
 });
-
-// ── parseCurrentMatrix reimplementation for testing ────────────────────────
-
-function parseCurrentMatrix(html: string): {
-  headers: string[];
-  rows: Map<string, Map<string, string>>;
-} {
-  const tableMatch = html.match(/<table class="comparison-table">([\s\S]*?)<\/table>/);
-  if (!tableMatch) {
-    throw new Error("Could not find comparison-table in HTML");
-  }
-  const tableHtml = tableMatch[1];
-
-  const thRegex = /<th[^>]*>[\s\S]*?<a[^>]*>(.*?)<\/a[\s\S]*?<\/th>/g;
-  const headers: string[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = thRegex.exec(tableHtml)) !== null) {
-    headers.push(m[1].trim());
-  }
-
-  const rows = new Map<string, Map<string, string>>();
-  const tbody = tableHtml.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] ?? "";
-  let tr: RegExpExecArray | null;
-  const trIter = new RegExp(/<tr>([\s\S]*?)<\/tr>/g);
-
-  while ((tr = trIter.exec(tbody)) !== null) {
-    const tds: string[] = [];
-    const tdRegex = /<td[^>]*>([\s\S]*?)<\/td>/g;
-    let td: RegExpExecArray | null;
-    while ((td = tdRegex.exec(tr[1])) !== null) {
-      tds.push(td[1].trim());
-    }
-    if (tds.length < 2) continue;
-
-    const rowLabel = tds[0];
-    const rowMap = new Map<string, string>();
-    for (let i = 1; i < tds.length && i - 1 < headers.length; i++) {
-      rowMap.set(headers[i - 1], tds[i]);
-    }
-    rows.set(rowLabel, rowMap);
-  }
-
-  return { headers, rows };
-}
 
 describe("parseCurrentMatrix header extraction", () => {
   const MATRIX_WITH_LINKS = `
@@ -574,5 +817,264 @@ describe("parseCurrentMatrix header extraction", () => {
     const noLinks = MATRIX_WITH_LINKS.replace(/<a[^>]*>(.*?)<\/a>/g, "$1");
     const { headers } = parseCurrentMatrix(noLinks);
     expect(headers).toHaveLength(0);
+  });
+});
+
+// ── computeChanges tests with actual HTML structure ────────────────────────
+
+describe("computeChanges with actual HTML cell structure", () => {
+  // This matrix uses the actual HTML structure from docs/index.html:
+  // cells contain <span class="no">&#10007;</span> not bare "No"
+  const ACTUAL_HTML_MATRIX = `
+<table class="comparison-table">
+  <thead>
+    <tr>
+      <th>Capability</th>
+      <th class="col-aimock"><a href="https://github.com/CopilotKit/aimock">aimock</a></th>
+      <th><a href="https://github.com/mswjs/msw">MSW</a></th>
+      <th><a href="https://github.com/vidaiUK/VidaiMock">VidaiMock</a></th>
+      <th><a href="https://github.com/dwmkerr/mock-llm">mock-llm</a></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>WebSocket APIs</td>
+      <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
+      <td><span class="no">&#10007;</span></td>
+      <td><span class="no">&#10007;</span></td>
+      <td><span class="no">&#10007;</span></td>
+    </tr>
+    <tr>
+      <td>Chat Completions SSE</td>
+      <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
+      <td><span class="manual">manual</span></td>
+      <td><span class="yes">&#10003;</span></td>
+      <td><span class="yes">&#10003;</span></td>
+    </tr>
+    <tr>
+      <td>Embeddings API</td>
+      <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
+      <td><span class="no">&#10007;</span></td>
+      <td><span class="yes">&#10003;</span></td>
+      <td><span class="no">&#10007;</span></td>
+    </tr>
+  </tbody>
+</table>`;
+
+  it("detects changes when cells contain span.no markup", () => {
+    const matrix = parseCurrentMatrix(ACTUAL_HTML_MATRIX);
+    const features = new Map<string, Record<string, boolean>>();
+    features.set("VidaiMock", {
+      "WebSocket APIs": true,
+      "Chat Completions SSE": true,
+      "Embeddings API": false,
+    });
+
+    const changes = computeChanges(ACTUAL_HTML_MATRIX, matrix, features);
+
+    // VidaiMock WebSocket APIs cell has <span class="no">&#10007;</span> -> should be detected
+    expect(changes).toHaveLength(1);
+    expect(changes[0].competitor).toBe("VidaiMock");
+    expect(changes[0].capability).toBe("WebSocket APIs");
+  });
+
+  it("does not flag already-yes cells as changes", () => {
+    const matrix = parseCurrentMatrix(ACTUAL_HTML_MATRIX);
+    const features = new Map<string, Record<string, boolean>>();
+    features.set("VidaiMock", {
+      "Chat Completions SSE": true, // already <span class="yes">
+      "WebSocket APIs": false,
+      "Embeddings API": false,
+    });
+
+    const changes = computeChanges(ACTUAL_HTML_MATRIX, matrix, features);
+
+    expect(changes).toHaveLength(0);
+  });
+
+  it("does not flag manual cells as changes", () => {
+    const matrix = parseCurrentMatrix(ACTUAL_HTML_MATRIX);
+    const features = new Map<string, Record<string, boolean>>();
+    features.set("MSW", {
+      "Chat Completions SSE": true, // MSW has <span class="manual">manual</span>
+      "WebSocket APIs": false,
+      "Embeddings API": false,
+    });
+
+    const changes = computeChanges(ACTUAL_HTML_MATRIX, matrix, features);
+
+    // MSW's manual cell should not trigger a change
+    expect(changes).toHaveLength(0);
+  });
+
+  it("detects changes for multiple competitors at once", () => {
+    const matrix = parseCurrentMatrix(ACTUAL_HTML_MATRIX);
+    const features = new Map<string, Record<string, boolean>>();
+    features.set("VidaiMock", {
+      "WebSocket APIs": true,
+      "Chat Completions SSE": false,
+      "Embeddings API": false,
+    });
+    features.set("mock-llm", {
+      "WebSocket APIs": true,
+      "Chat Completions SSE": false,
+      "Embeddings API": true,
+    });
+
+    const changes = computeChanges(ACTUAL_HTML_MATRIX, matrix, features);
+
+    expect(changes).toHaveLength(3);
+    const competitors = changes.map((c) => c.competitor);
+    expect(competitors).toContain("VidaiMock");
+    expect(competitors).toContain("mock-llm");
+  });
+});
+
+// ── applyChanges tests with actual HTML structure ──────────────────────────
+
+describe("applyChanges with actual HTML cell structure", () => {
+  const ACTUAL_HTML_MATRIX = `
+<table class="comparison-table">
+  <thead>
+    <tr>
+      <th>Capability</th>
+      <th class="col-aimock"><a href="https://github.com/CopilotKit/aimock">aimock</a></th>
+      <th><a href="https://github.com/mswjs/msw">MSW</a></th>
+      <th><a href="https://github.com/vidaiUK/VidaiMock">VidaiMock</a></th>
+      <th><a href="https://github.com/dwmkerr/mock-llm">mock-llm</a></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>WebSocket APIs</td>
+      <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
+      <td><span class="no">&#10007;</span></td>
+      <td><span class="no">&#10007;</span></td>
+      <td><span class="no">&#10007;</span></td>
+    </tr>
+    <tr>
+      <td>Embeddings API</td>
+      <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
+      <td><span class="no">&#10007;</span></td>
+      <td><span class="yes">&#10003;</span></td>
+      <td><span class="no">&#10007;</span></td>
+    </tr>
+  </tbody>
+</table>`;
+
+  it("replaces span.no cell with span.yes cell for the correct competitor column", () => {
+    const changes: DetectedChange[] = [
+      { competitor: "VidaiMock", capability: "WebSocket APIs", from: "No", to: "Yes" },
+    ];
+
+    const result = applyChanges(ACTUAL_HTML_MATRIX, changes);
+
+    // VidaiMock's WebSocket APIs cell should now be yes
+    // Parse to verify only VidaiMock column changed
+    const matrix = parseCurrentMatrix(result);
+    const wsRow = matrix.rows.get("WebSocket APIs");
+    expect(wsRow).toBeDefined();
+    // VidaiMock should now have yes checkmark
+    expect(wsRow!.get("VidaiMock")).toContain("&#10003;");
+    expect(wsRow!.get("VidaiMock")).toContain('class="yes"');
+    // MSW and mock-llm should still have no
+    expect(wsRow!.get("MSW")).toContain("&#10007;");
+    expect(wsRow!.get("mock-llm")).toContain("&#10007;");
+  });
+
+  it("does not modify cells in other rows", () => {
+    const changes: DetectedChange[] = [
+      { competitor: "VidaiMock", capability: "WebSocket APIs", from: "No", to: "Yes" },
+    ];
+
+    const result = applyChanges(ACTUAL_HTML_MATRIX, changes);
+
+    const matrix = parseCurrentMatrix(result);
+    const embRow = matrix.rows.get("Embeddings API");
+    expect(embRow).toBeDefined();
+    // VidaiMock's Embeddings API cell was already yes, should remain
+    expect(embRow!.get("VidaiMock")).toContain("&#10003;");
+  });
+
+  it("applies multiple changes across different rows and competitors", () => {
+    const changes: DetectedChange[] = [
+      { competitor: "VidaiMock", capability: "WebSocket APIs", from: "No", to: "Yes" },
+      { competitor: "mock-llm", capability: "Embeddings API", from: "No", to: "Yes" },
+    ];
+
+    const result = applyChanges(ACTUAL_HTML_MATRIX, changes);
+
+    const matrix = parseCurrentMatrix(result);
+    expect(matrix.rows.get("WebSocket APIs")!.get("VidaiMock")).toContain('class="yes"');
+    expect(matrix.rows.get("Embeddings API")!.get("mock-llm")).toContain('class="yes"');
+  });
+
+  it("returns html unchanged when changes array is empty", () => {
+    const result = applyChanges(ACTUAL_HTML_MATRIX, []);
+    expect(result).toBe(ACTUAL_HTML_MATRIX);
+  });
+});
+
+// ── extractFeatures tests (tightened keyword patterns) ─────────────────────
+
+describe("extractFeatures keyword precision", () => {
+  it("does not trigger Embeddings API on bare word 'embed'", () => {
+    const text = "You can embed this widget in your page.";
+    const features = extractFeatures(text);
+    expect(features["Embeddings API"]).toBe(false);
+  });
+
+  it("triggers Embeddings API on /v1/embeddings path", () => {
+    const text = "Supports the /v1/embeddings endpoint for vector generation.";
+    const features = extractFeatures(text);
+    expect(features["Embeddings API"]).toBe(true);
+  });
+
+  it("triggers Embeddings API on 'embeddings api' phrase", () => {
+    const text = "Full support for the embeddings API.";
+    const features = extractFeatures(text);
+    expect(features["Embeddings API"]).toBe(true);
+  });
+
+  it("does not trigger Image generation on bare word 'image'", () => {
+    const text = "See the image below for architecture details.";
+    const features = extractFeatures(text);
+    expect(features["Image generation"]).toBe(false);
+  });
+
+  it("triggers Image generation on 'dall-e' or '/v1/images'", () => {
+    const text = "Generate images via DALL-E or the /v1/images endpoint.";
+    const features = extractFeatures(text);
+    expect(features["Image generation"]).toBe(true);
+  });
+
+  it("does not trigger Video generation on bare word 'video'", () => {
+    const text = "Watch the video tutorial for setup instructions.";
+    const features = extractFeatures(text);
+    expect(features["Video generation"]).toBe(false);
+  });
+
+  it("triggers Video generation on 'video generation' phrase", () => {
+    const text = "Supports video generation via the Sora API.";
+    const features = extractFeatures(text);
+    expect(features["Video generation"]).toBe(true);
+  });
+
+  it("does not trigger Docker image on bare word 'docker'", () => {
+    const text = "This is like a docker for your tests.";
+    const features = extractFeatures(text);
+    expect(features["Docker image"]).toBe(false);
+  });
+
+  it("triggers Docker image on 'dockerfile' or 'docker image'", () => {
+    const text = "Includes a Dockerfile for easy deployment.";
+    const features = extractFeatures(text);
+    expect(features["Docker image"]).toBe(true);
+  });
+
+  it("triggers Docker image on 'docker run'", () => {
+    const text = "Run with: docker run -p 8080:8080 aimock";
+    const features = extractFeatures(text);
+    expect(features["Docker image"]).toBe(true);
   });
 });

--- a/src/__tests__/control-api.test.ts
+++ b/src/__tests__/control-api.test.ts
@@ -142,7 +142,7 @@ describe("/__aimock control API", () => {
       const res = await httpRaw(`${instance.url}/__aimock/fixtures`, "POST", "not json{{{");
       expect(res.status).toBe(400);
       const body = JSON.parse(res.body);
-      expect(body.error).toMatch(/^Invalid JSON:/)
+      expect(body.error).toMatch(/^Invalid JSON:/);
     });
 
     it("returns 400 when fixtures array is missing", async () => {

--- a/src/__tests__/control-api.test.ts
+++ b/src/__tests__/control-api.test.ts
@@ -142,7 +142,7 @@ describe("/__aimock control API", () => {
       const res = await httpRaw(`${instance.url}/__aimock/fixtures`, "POST", "not json{{{");
       expect(res.status).toBe(400);
       const body = JSON.parse(res.body);
-      expect(body.error).toBe("Invalid JSON");
+      expect(body.error).toMatch(/^Invalid JSON:/)
     });
 
     it("returns 400 when fixtures array is missing", async () => {

--- a/src/__tests__/control-api.test.ts
+++ b/src/__tests__/control-api.test.ts
@@ -256,9 +256,6 @@ describe("/__aimock control API", () => {
       );
       expect(errRes.status).toBe(429);
 
-      // Wait for queueMicrotask to clean up the one-shot fixture
-      await new Promise((r) => setTimeout(r, 50));
-
       // Second request should succeed normally
       const okRes = await httpRequest(
         `${instance.url}/v1/chat/completions`,

--- a/src/__tests__/ollama.test.ts
+++ b/src/__tests__/ollama.test.ts
@@ -1262,12 +1262,12 @@ describe("ollamaToCompletionRequest (edge cases)", () => {
     expect(result.max_tokens).toBeUndefined();
   });
 
-  it("handles stream undefined (passes through as undefined)", () => {
+  it("defaults stream to true when absent (matches Ollama default)", () => {
     const result = ollamaToCompletionRequest({
       model: "llama3",
       messages: [{ role: "user", content: "hi" }],
     });
-    expect(result.stream).toBeUndefined();
+    expect(result.stream).toBe(true);
   });
 
   it("handles empty tools array (returns undefined)", () => {

--- a/src/__tests__/ollama.test.ts
+++ b/src/__tests__/ollama.test.ts
@@ -938,7 +938,7 @@ describe("POST /api/chat (malformed tool call arguments)", () => {
 // ─── Integration tests: tool call on /api/generate → 500 ───────────────────
 
 describe("POST /api/generate (tool call fixture)", () => {
-  it("returns 500 'unknown type' for tool call fixtures on /api/generate", async () => {
+  it("returns 400 for tool call fixtures on /api/generate with clear error", async () => {
     const tcFixture: Fixture = {
       match: { userMessage: "tool-gen" },
       response: {
@@ -952,9 +952,9 @@ describe("POST /api/generate (tool call fixture)", () => {
       stream: false,
     });
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
     const body = JSON.parse(res.body);
-    expect(body.error.message).toContain("did not match any known type");
+    expect(body.error.message).toContain("Tool call fixtures are not supported on /api/generate");
   });
 });
 
@@ -1100,7 +1100,7 @@ describe("POST /api/generate (malformed JSON)", () => {
 // ─── Integration tests: POST /api/generate (unknown response type streaming) ─
 
 describe("POST /api/generate (unknown response type streaming)", () => {
-  it("returns 500 for tool call fixture on /api/generate (streaming default)", async () => {
+  it("returns 400 for tool call fixture on /api/generate (streaming default)", async () => {
     const tcFixture: Fixture = {
       match: { userMessage: "tool-gen-stream" },
       response: {
@@ -1114,9 +1114,9 @@ describe("POST /api/generate (unknown response type streaming)", () => {
       // stream omitted → defaults to true
     });
 
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
     const body = JSON.parse(res.body);
-    expect(body.error.message).toContain("did not match any known type");
+    expect(body.error.message).toContain("Tool call fixtures are not supported on /api/generate");
   });
 });
 

--- a/src/__tests__/provider-compat.test.ts
+++ b/src/__tests__/provider-compat.test.ts
@@ -303,11 +303,13 @@ describe("OpenAI-compatible path prefix normalization", () => {
       stream: false,
     });
 
-    // Normalization works: we get "No fixture matched" from the Responses handler
-    // (not "Not found" which would mean the path wasn't routed at all)
+    // Normalization works: the Responses handler receives the request,
+    // correctly parses the string input, matches the fixture, and returns
+    // a valid Responses API envelope.
     const parsed = JSON.parse(body);
-    expect(parsed.error.type).toBe("invalid_request_error");
-    expect(parsed.error.code).toBe("no_fixture_match");
+    expect(parsed.object).toBe("response");
+    expect(parsed.output).toBeDefined();
+    expect(parsed.output.length).toBeGreaterThan(0);
   });
 
   it("normalizes /custom/audio/speech to /v1/audio/speech", async () => {

--- a/src/__tests__/reasoning-all-providers.test.ts
+++ b/src/__tests__/reasoning-all-providers.test.ts
@@ -787,7 +787,7 @@ describe("buildBedrockStreamTextEvents (reasoning)", () => {
         contentBlockIndex: 1,
         contentBlockDelta: {
           contentBlockIndex: 1,
-          delta: { text: "The answer." },
+          delta: { type: "text_delta", text: "The answer." },
         },
       },
     });

--- a/src/__tests__/reasoning-all-providers.test.ts
+++ b/src/__tests__/reasoning-all-providers.test.ts
@@ -442,12 +442,14 @@ describe("POST /model/{id}/invoke-with-response-stream (reasoning streaming)", (
     const thinkingStartIdx = frames.findIndex(
       (f) =>
         f.eventType === "contentBlockStart" &&
-        (f.payload as { start?: { type?: string } }).start?.type === "thinking",
+        (f.payload as { contentBlockStart?: { start?: { type?: string } } }).contentBlockStart
+          ?.start?.type === "thinking",
     );
     const textStartIdx = frames.findIndex(
       (f) =>
         f.eventType === "contentBlockStart" &&
-        (f.payload as { start?: { type?: string } }).start?.type === undefined,
+        (f.payload as { contentBlockStart?: { start?: { type?: string } } }).contentBlockStart
+          ?.start?.type === "text",
     );
 
     expect(thinkingStartIdx).toBeGreaterThan(0);
@@ -457,10 +459,15 @@ describe("POST /model/{id}/invoke-with-response-stream (reasoning streaming)", (
     const thinkingDeltas = frames.filter(
       (f) =>
         f.eventType === "contentBlockDelta" &&
-        (f.payload as { delta?: { type?: string } }).delta?.type === "thinking_delta",
+        (f.payload as { contentBlockDelta?: { delta?: { type?: string } } }).contentBlockDelta
+          ?.delta?.type === "thinking_delta",
     );
     const fullThinking = thinkingDeltas
-      .map((f) => (f.payload as { delta: { thinking: string } }).delta.thinking)
+      .map(
+        (f) =>
+          (f.payload as { contentBlockDelta: { delta: { thinking: string } } }).contentBlockDelta
+            .delta.thinking,
+      )
       .join("");
     expect(fullThinking).toBe("Let me think step by step about this problem.");
 
@@ -468,10 +475,15 @@ describe("POST /model/{id}/invoke-with-response-stream (reasoning streaming)", (
     const textDeltas = frames.filter(
       (f) =>
         f.eventType === "contentBlockDelta" &&
-        (f.payload as { delta?: { type?: string } }).delta?.type === "text_delta",
+        typeof (f.payload as { contentBlockDelta?: { delta?: { text?: string } } })
+          .contentBlockDelta?.delta?.text === "string",
     );
     const fullText = textDeltas
-      .map((f) => (f.payload as { delta: { text: string } }).delta.text)
+      .map(
+        (f) =>
+          (f.payload as { contentBlockDelta: { delta: { text: string } } }).contentBlockDelta.delta
+            .text,
+      )
       .join("");
     expect(fullText).toBe("The answer is 42.");
 
@@ -495,7 +507,8 @@ describe("POST /model/{id}/invoke-with-response-stream (reasoning streaming)", (
     const thinkingDeltas = frames.filter(
       (f) =>
         f.eventType === "contentBlockDelta" &&
-        (f.payload as { delta?: { type?: string } }).delta?.type === "thinking_delta",
+        (f.payload as { contentBlockDelta?: { delta?: { type?: string } } }).contentBlockDelta
+          ?.delta?.type === "thinking_delta",
     );
     expect(thinkingDeltas).toHaveLength(0);
   });
@@ -519,12 +532,14 @@ describe("POST /model/{id}/converse-stream (reasoning streaming)", () => {
     const thinkingStartIdx = frames.findIndex(
       (f) =>
         f.eventType === "contentBlockStart" &&
-        (f.payload as { start?: { type?: string } }).start?.type === "thinking",
+        (f.payload as { contentBlockStart?: { start?: { type?: string } } }).contentBlockStart
+          ?.start?.type === "thinking",
     );
     const textStartIdx = frames.findIndex(
       (f) =>
         f.eventType === "contentBlockStart" &&
-        (f.payload as { start?: { type?: string } }).start?.type === undefined,
+        (f.payload as { contentBlockStart?: { start?: { type?: string } } }).contentBlockStart
+          ?.start?.type === "text",
     );
 
     expect(thinkingStartIdx).toBeGreaterThan(0);
@@ -534,10 +549,15 @@ describe("POST /model/{id}/converse-stream (reasoning streaming)", () => {
     const thinkingDeltas = frames.filter(
       (f) =>
         f.eventType === "contentBlockDelta" &&
-        (f.payload as { delta?: { type?: string } }).delta?.type === "thinking_delta",
+        (f.payload as { contentBlockDelta?: { delta?: { type?: string } } }).contentBlockDelta
+          ?.delta?.type === "thinking_delta",
     );
     const fullThinking = thinkingDeltas
-      .map((f) => (f.payload as { delta: { thinking: string } }).delta.thinking)
+      .map(
+        (f) =>
+          (f.payload as { contentBlockDelta: { delta: { thinking: string } } }).contentBlockDelta
+            .delta.thinking,
+      )
       .join("");
     expect(fullThinking).toBe("Let me think step by step about this problem.");
 
@@ -555,7 +575,8 @@ describe("POST /model/{id}/converse-stream (reasoning streaming)", () => {
     const thinkingDeltas = frames.filter(
       (f) =>
         f.eventType === "contentBlockDelta" &&
-        (f.payload as { delta?: { type?: string } }).delta?.type === "thinking_delta",
+        (f.payload as { contentBlockDelta?: { delta?: { type?: string } } }).contentBlockDelta
+          ?.delta?.type === "thinking_delta",
     );
     expect(thinkingDeltas).toHaveLength(0);
   });
@@ -732,13 +753,19 @@ describe("buildBedrockStreamTextEvents (reasoning)", () => {
     // Thinking block at index 0
     expect(events[1]).toEqual({
       eventType: "contentBlockStart",
-      payload: { contentBlockIndex: 0, start: { type: "thinking" } },
+      payload: {
+        contentBlockIndex: 0,
+        contentBlockStart: { contentBlockIndex: 0, start: { type: "thinking" } },
+      },
     });
     expect(events[2]).toEqual({
       eventType: "contentBlockDelta",
       payload: {
         contentBlockIndex: 0,
-        delta: { type: "thinking_delta", thinking: "Step by step." },
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { type: "thinking_delta", thinking: "Step by step." },
+        },
       },
     });
     expect(events[3]).toEqual({
@@ -749,13 +776,19 @@ describe("buildBedrockStreamTextEvents (reasoning)", () => {
     // Text block at index 1
     expect(events[4]).toEqual({
       eventType: "contentBlockStart",
-      payload: { contentBlockIndex: 1, start: {} },
+      payload: {
+        contentBlockIndex: 1,
+        contentBlockStart: { contentBlockIndex: 1, start: { type: "text" } },
+      },
     });
     expect(events[5]).toEqual({
       eventType: "contentBlockDelta",
       payload: {
         contentBlockIndex: 1,
-        delta: { type: "text_delta", text: "The answer." },
+        contentBlockDelta: {
+          contentBlockIndex: 1,
+          delta: { text: "The answer." },
+        },
       },
     });
     expect(events[6]).toEqual({

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -2297,6 +2297,151 @@ describe("buildFixtureResponse format detection", () => {
     expect(fixtureContent.fixtures[0].response.content).toBeUndefined();
   });
 
+  it("detects Cohere v2 message-level tool_calls with text content", async () => {
+    const { url: upstreamUrl } = await createRawUpstreamWithStatus({
+      finish_reason: "TOOL_CALL",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Let me look that up." }],
+        tool_calls: [
+          {
+            name: "get_weather",
+            parameters: { city: "SF" },
+          },
+        ],
+      },
+    });
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
+    recorder = await createServer([], {
+      port: 0,
+      record: { providers: { cohere: upstreamUrl }, fixturePath: tmpDir },
+    });
+
+    const resp = await post(`${recorder.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "cohere v2 msg tool_calls with text" }],
+      stream: false,
+    });
+
+    expect(resp.status).toBe(200);
+
+    const files = fs.readdirSync(tmpDir);
+    const fixtureFiles = files.filter((f) => f.endsWith(".json"));
+    expect(fixtureFiles).toHaveLength(1);
+
+    const fixtureContent = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, fixtureFiles[0]), "utf-8"),
+    ) as {
+      fixtures: Array<{
+        response: {
+          content?: string;
+          toolCalls?: Array<{ name: string; arguments: string }>;
+        };
+      }>;
+    };
+    expect(fixtureContent.fixtures[0].response.content).toBe("Let me look that up.");
+    expect(fixtureContent.fixtures[0].response.toolCalls).toBeDefined();
+    expect(fixtureContent.fixtures[0].response.toolCalls).toHaveLength(1);
+    expect(fixtureContent.fixtures[0].response.toolCalls![0].name).toBe("get_weather");
+    expect(JSON.parse(fixtureContent.fixtures[0].response.toolCalls![0].arguments)).toEqual({
+      city: "SF",
+    });
+  });
+
+  it("detects Cohere v2 message-level tool_calls without text content", async () => {
+    const { url: upstreamUrl } = await createRawUpstreamWithStatus({
+      finish_reason: "TOOL_CALL",
+      message: {
+        role: "assistant",
+        content: [],
+        tool_calls: [
+          {
+            name: "search_docs",
+            parameters: { query: "aimock" },
+          },
+        ],
+      },
+    });
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
+    recorder = await createServer([], {
+      port: 0,
+      record: { providers: { cohere: upstreamUrl }, fixturePath: tmpDir },
+    });
+
+    const resp = await post(`${recorder.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "cohere v2 msg tool_calls only" }],
+      stream: false,
+    });
+
+    expect(resp.status).toBe(200);
+
+    const files = fs.readdirSync(tmpDir);
+    const fixtureFiles = files.filter((f) => f.endsWith(".json"));
+    expect(fixtureFiles).toHaveLength(1);
+
+    const fixtureContent = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, fixtureFiles[0]), "utf-8"),
+    ) as {
+      fixtures: Array<{
+        response: {
+          content?: string;
+          toolCalls?: Array<{ name: string; arguments: string }>;
+        };
+      }>;
+    };
+    expect(fixtureContent.fixtures[0].response.content).toBeUndefined();
+    expect(fixtureContent.fixtures[0].response.toolCalls).toBeDefined();
+    expect(fixtureContent.fixtures[0].response.toolCalls).toHaveLength(1);
+    expect(fixtureContent.fixtures[0].response.toolCalls![0].name).toBe("search_docs");
+    expect(JSON.parse(fixtureContent.fixtures[0].response.toolCalls![0].arguments)).toEqual({
+      query: "aimock",
+    });
+  });
+
+  it("detects Cohere v2 text-only response (no message-level tool_calls)", async () => {
+    const { url: upstreamUrl } = await createRawUpstreamWithStatus({
+      finish_reason: "COMPLETE",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello from Cohere" }],
+      },
+    });
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-"));
+    recorder = await createServer([], {
+      port: 0,
+      record: { providers: { cohere: upstreamUrl }, fixturePath: tmpDir },
+    });
+
+    const resp = await post(`${recorder.url}/v2/chat`, {
+      model: "command-r-plus",
+      messages: [{ role: "user", content: "cohere v2 text only" }],
+      stream: false,
+    });
+
+    expect(resp.status).toBe(200);
+
+    const files = fs.readdirSync(tmpDir);
+    const fixtureFiles = files.filter((f) => f.endsWith(".json"));
+    expect(fixtureFiles).toHaveLength(1);
+
+    const fixtureContent = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, fixtureFiles[0]), "utf-8"),
+    ) as {
+      fixtures: Array<{
+        response: {
+          content?: string;
+          toolCalls?: Array<{ name: string; arguments: string }>;
+        };
+      }>;
+    };
+    expect(fixtureContent.fixtures[0].response.content).toBe("Hello from Cohere");
+    expect(fixtureContent.fixtures[0].response.toolCalls).toBeUndefined();
+  });
+
   it("unknown format falls back to error response", async () => {
     const { url: upstreamUrl } = await createRawUpstreamWithStatus({
       custom: "data",

--- a/src/bedrock-converse.ts
+++ b/src/bedrock-converse.ts
@@ -707,6 +707,7 @@ export async function handleConverseStream(
         "webSearches in fixture response are not supported for Bedrock Converse API — ignoring",
       );
     }
+    const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -720,6 +721,7 @@ export async function handleConverseStream(
       chunkSize,
       logger,
       response.reasoning,
+      overrides,
     );
     const interruption = createInterruptionSignal(fixture);
     const completed = await writeEventStream(res, events, {
@@ -744,6 +746,7 @@ export async function handleConverseStream(
         "webSearches in fixture response are not supported for Bedrock Converse API — ignoring",
       );
     }
+    const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -751,7 +754,12 @@ export async function handleConverseStream(
       body: completionReq,
       response: { status: 200, fixture },
     });
-    const events = buildBedrockStreamTextEvents(response.content, chunkSize, response.reasoning);
+    const events = buildBedrockStreamTextEvents(
+      response.content,
+      chunkSize,
+      response.reasoning,
+      overrides,
+    );
     const interruption = createInterruptionSignal(fixture);
     const completed = await writeEventStream(res, events, {
       latency,
@@ -770,6 +778,7 @@ export async function handleConverseStream(
 
   // Tool call response — stream as Event Stream
   if (isToolCallResponse(response)) {
+    const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -777,7 +786,12 @@ export async function handleConverseStream(
       body: completionReq,
       response: { status: 200, fixture },
     });
-    const events = buildBedrockStreamToolCallEvents(response.toolCalls, chunkSize, logger);
+    const events = buildBedrockStreamToolCallEvents(
+      response.toolCalls,
+      chunkSize,
+      logger,
+      overrides,
+    );
     const interruption = createInterruptionSignal(fixture);
     const completed = await writeEventStream(res, events, {
       latency,

--- a/src/bedrock-converse.ts
+++ b/src/bedrock-converse.ts
@@ -450,7 +450,14 @@ export async function handleConverse(
       body: completionReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    const errBody = {
+      type: "error",
+      error: {
+        type: response.error.type || "invalid_request_error",
+        message: response.error.message,
+      },
+    };
+    writeErrorResponse(res, status, JSON.stringify(errBody));
     return;
   }
 
@@ -696,7 +703,14 @@ export async function handleConverseStream(
       body: completionReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    const errBody = {
+      type: "error",
+      error: {
+        type: response.error.type || "invalid_request_error",
+        message: response.error.message,
+      },
+    };
+    writeErrorResponse(res, status, JSON.stringify(errBody));
     return;
   }
 

--- a/src/bedrock-converse.ts
+++ b/src/bedrock-converse.ts
@@ -20,6 +20,7 @@ import {
   generateToolUseId,
   isTextResponse,
   isToolCallResponse,
+  isContentWithToolCallsResponse,
   isErrorResponse,
   flattenHeaders,
   getTestId,
@@ -32,7 +33,11 @@ import type { Journal } from "./journal.js";
 import type { Logger } from "./logger.js";
 import { applyChaos } from "./chaos.js";
 import { proxyAndRecord } from "./recorder.js";
-import { buildBedrockStreamTextEvents, buildBedrockStreamToolCallEvents } from "./bedrock.js";
+import {
+  buildBedrockStreamTextEvents,
+  buildBedrockStreamToolCallEvents,
+  buildBedrockStreamContentWithToolCallsEvents,
+} from "./bedrock.js";
 
 // ─── Converse request types ─────────────────────────────────────────────────
 
@@ -208,6 +213,50 @@ function buildConverseToolCallResponse(toolCalls: ToolCall[], logger: Logger): o
   };
 }
 
+function buildConverseContentWithToolCallsResponse(
+  content: string,
+  toolCalls: ToolCall[],
+  logger: Logger,
+  reasoning?: string,
+): object {
+  const contentBlocks: object[] = [];
+  if (reasoning) {
+    contentBlocks.push({
+      reasoningContent: { reasoningText: { text: reasoning } },
+    });
+  }
+  contentBlocks.push({ text: content });
+  for (const tc of toolCalls) {
+    let argsObj: unknown;
+    try {
+      argsObj = JSON.parse(tc.arguments || "{}");
+    } catch {
+      logger.warn(
+        `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+      );
+      argsObj = {};
+    }
+    contentBlocks.push({
+      toolUse: {
+        toolUseId: tc.id || generateToolUseId(),
+        name: tc.name,
+        input: argsObj,
+      },
+    });
+  }
+
+  return {
+    output: {
+      message: {
+        role: "assistant",
+        content: contentBlocks,
+      },
+    },
+    stopReason: "tool_use",
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+  };
+}
+
 // ─── Request handlers ───────────────────────────────────────────────────────
 
 export async function handleConverse(
@@ -322,7 +371,7 @@ export async function handleConverse(
           path: urlPath,
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }
@@ -367,6 +416,26 @@ export async function handleConverse(
       response: { status, fixture },
     });
     writeErrorResponse(res, status, JSON.stringify(response));
+    return;
+  }
+
+  // Content + tool calls response
+  if (isContentWithToolCallsResponse(response)) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: urlPath,
+      headers: flattenHeaders(req.headers),
+      body: completionReq,
+      response: { status: 200, fixture },
+    });
+    const body = buildConverseContentWithToolCallsResponse(
+      response.content,
+      response.toolCalls,
+      logger,
+      response.reasoning,
+    );
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
     return;
   }
 
@@ -532,7 +601,7 @@ export async function handleConverseStream(
           path: urlPath,
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }
@@ -579,6 +648,38 @@ export async function handleConverseStream(
       response: { status, fixture },
     });
     writeErrorResponse(res, status, JSON.stringify(response));
+    return;
+  }
+
+  // Content + tool calls response — stream as Event Stream
+  if (isContentWithToolCallsResponse(response)) {
+    const journalEntry = journal.add({
+      method: req.method ?? "POST",
+      path: urlPath,
+      headers: flattenHeaders(req.headers),
+      body: completionReq,
+      response: { status: 200, fixture },
+    });
+    const events = buildBedrockStreamContentWithToolCallsEvents(
+      response.content,
+      response.toolCalls,
+      chunkSize,
+      logger,
+      response.reasoning,
+    );
+    const interruption = createInterruptionSignal(fixture);
+    const completed = await writeEventStream(res, events, {
+      latency,
+      streamingProfile: fixture.streamingProfile,
+      signal: interruption?.signal,
+      onChunkSent: interruption?.tick,
+    });
+    if (!completed) {
+      if (!res.writableEnded) res.destroy();
+      journalEntry.response.interrupted = true;
+      journalEntry.response.interruptReason = interruption?.reason();
+    }
+    interruption?.cleanup();
     return;
   }
 

--- a/src/bedrock-converse.ts
+++ b/src/bedrock-converse.ts
@@ -13,11 +13,13 @@ import type {
   ChatMessage,
   Fixture,
   HandlerDefaults,
+  ResponseOverrides,
   ToolCall,
   ToolDefinition,
 } from "./types.js";
 import {
   generateToolUseId,
+  extractOverrides,
   isTextResponse,
   isToolCallResponse,
   isContentWithToolCallsResponse,
@@ -63,6 +65,30 @@ interface ConverseRequest {
   system?: { text: string }[];
   inferenceConfig?: { maxTokens?: number; temperature?: number };
   toolConfig?: { tools: { toolSpec: ConverseToolSpec }[] };
+}
+
+// ─── Converse stop_reason mapping ──────────────────────────────────────────
+
+function converseStopReason(
+  overrideFinishReason: string | undefined,
+  defaultReason: string,
+): string {
+  if (!overrideFinishReason) return defaultReason;
+  if (overrideFinishReason === "stop") return "end_turn";
+  if (overrideFinishReason === "tool_calls") return "tool_use";
+  if (overrideFinishReason === "length") return "max_tokens";
+  return overrideFinishReason;
+}
+
+function converseUsage(overrides?: ResponseOverrides): {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+} {
+  if (!overrides?.usage) return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  const inputTokens = overrides.usage.input_tokens ?? overrides.usage.prompt_tokens ?? 0;
+  const outputTokens = overrides.usage.output_tokens ?? overrides.usage.completion_tokens ?? 0;
+  return { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens };
 }
 
 // ─── Input conversion: Converse → ChatCompletionRequest ─────────────────────
@@ -162,7 +188,11 @@ export function converseToCompletionRequest(
 
 // ─── Response builders ──────────────────────────────────────────────────────
 
-function buildConverseTextResponse(content: string, reasoning?: string): object {
+function buildConverseTextResponse(
+  content: string,
+  reasoning?: string,
+  overrides?: ResponseOverrides,
+): object {
   const contentBlocks: object[] = [];
   if (reasoning) {
     contentBlocks.push({
@@ -178,12 +208,16 @@ function buildConverseTextResponse(content: string, reasoning?: string): object 
         content: contentBlocks,
       },
     },
-    stopReason: "end_turn",
-    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    stopReason: converseStopReason(overrides?.finishReason, "end_turn"),
+    usage: converseUsage(overrides),
   };
 }
 
-function buildConverseToolCallResponse(toolCalls: ToolCall[], logger: Logger): object {
+function buildConverseToolCallResponse(
+  toolCalls: ToolCall[],
+  logger: Logger,
+  overrides?: ResponseOverrides,
+): object {
   return {
     output: {
       message: {
@@ -208,8 +242,8 @@ function buildConverseToolCallResponse(toolCalls: ToolCall[], logger: Logger): o
         }),
       },
     },
-    stopReason: "tool_use",
-    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    stopReason: converseStopReason(overrides?.finishReason, "tool_use"),
+    usage: converseUsage(overrides),
   };
 }
 
@@ -218,6 +252,7 @@ function buildConverseContentWithToolCallsResponse(
   toolCalls: ToolCall[],
   logger: Logger,
   reasoning?: string,
+  overrides?: ResponseOverrides,
 ): object {
   const contentBlocks: object[] = [];
   if (reasoning) {
@@ -252,8 +287,8 @@ function buildConverseContentWithToolCallsResponse(
         content: contentBlocks,
       },
     },
-    stopReason: "tool_use",
-    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    stopReason: converseStopReason(overrides?.finishReason, "tool_use"),
+    usage: converseUsage(overrides),
   };
 }
 
@@ -421,6 +456,12 @@ export async function handleConverse(
 
   // Content + tool calls response
   if (isContentWithToolCallsResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn(
+        "webSearches in fixture response are not supported for Bedrock Converse API — ignoring",
+      );
+    }
+    const overrides = extractOverrides(response);
     journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -433,6 +474,7 @@ export async function handleConverse(
       response.toolCalls,
       logger,
       response.reasoning,
+      overrides,
     );
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(body));
@@ -441,6 +483,12 @@ export async function handleConverse(
 
   // Text response
   if (isTextResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn(
+        "webSearches in fixture response are not supported for Bedrock Converse API — ignoring",
+      );
+    }
+    const overrides = extractOverrides(response);
     journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -448,7 +496,7 @@ export async function handleConverse(
       body: completionReq,
       response: { status: 200, fixture },
     });
-    const body = buildConverseTextResponse(response.content, response.reasoning);
+    const body = buildConverseTextResponse(response.content, response.reasoning, overrides);
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(body));
     return;
@@ -456,6 +504,7 @@ export async function handleConverse(
 
   // Tool call response
   if (isToolCallResponse(response)) {
+    const overrides = extractOverrides(response);
     journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -463,7 +512,7 @@ export async function handleConverse(
       body: completionReq,
       response: { status: 200, fixture },
     });
-    const body = buildConverseToolCallResponse(response.toolCalls, logger);
+    const body = buildConverseToolCallResponse(response.toolCalls, logger, overrides);
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(body));
     return;
@@ -653,6 +702,11 @@ export async function handleConverseStream(
 
   // Content + tool calls response — stream as Event Stream
   if (isContentWithToolCallsResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn(
+        "webSearches in fixture response are not supported for Bedrock Converse API — ignoring",
+      );
+    }
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -685,6 +739,11 @@ export async function handleConverseStream(
 
   // Text response — stream as Event Stream
   if (isTextResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn(
+        "webSearches in fixture response are not supported for Bedrock Converse API — ignoring",
+      );
+    }
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -630,7 +630,7 @@ export function buildBedrockStreamTextEvents(
         contentBlockIndex: textBlockIndex,
         contentBlockDelta: {
           contentBlockIndex: textBlockIndex,
-          delta: { text: slice },
+          delta: { type: "text_delta", text: slice },
         },
       },
     });
@@ -717,7 +717,7 @@ export function buildBedrockStreamContentWithToolCallsEvents(
         contentBlockIndex: blockIndex,
         contentBlockDelta: {
           contentBlockIndex: blockIndex,
-          delta: { text: slice },
+          delta: { type: "text_delta", text: slice },
         },
       },
     });

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -571,7 +571,7 @@ export function buildBedrockStreamTextEvents(
 
   events.push({
     eventType: "messageStart",
-    payload: { role: "assistant" },
+    payload: { messageStart: { role: "assistant" } },
   });
 
   // Thinking block (emitted before text when reasoning is present)
@@ -579,7 +579,13 @@ export function buildBedrockStreamTextEvents(
     const blockIndex = 0;
     events.push({
       eventType: "contentBlockStart",
-      payload: { contentBlockIndex: blockIndex, start: { type: "thinking" } },
+      payload: {
+        contentBlockIndex: blockIndex,
+        contentBlockStart: {
+          contentBlockIndex: blockIndex,
+          start: { type: "thinking" },
+        },
+      },
     });
 
     for (let i = 0; i < reasoning.length; i += chunkSize) {
@@ -588,7 +594,10 @@ export function buildBedrockStreamTextEvents(
         eventType: "contentBlockDelta",
         payload: {
           contentBlockIndex: blockIndex,
-          delta: { type: "thinking_delta", thinking: slice },
+          contentBlockDelta: {
+            contentBlockIndex: blockIndex,
+            delta: { type: "thinking_delta", thinking: slice },
+          },
         },
       });
     }
@@ -604,7 +613,13 @@ export function buildBedrockStreamTextEvents(
 
   events.push({
     eventType: "contentBlockStart",
-    payload: { contentBlockIndex: textBlockIndex, start: {} },
+    payload: {
+      contentBlockIndex: textBlockIndex,
+      contentBlockStart: {
+        contentBlockIndex: textBlockIndex,
+        start: { type: "text" },
+      },
+    },
   });
 
   for (let i = 0; i < content.length; i += chunkSize) {
@@ -613,7 +628,10 @@ export function buildBedrockStreamTextEvents(
       eventType: "contentBlockDelta",
       payload: {
         contentBlockIndex: textBlockIndex,
-        delta: { type: "text_delta", text: slice },
+        contentBlockDelta: {
+          contentBlockIndex: textBlockIndex,
+          delta: { text: slice },
+        },
       },
     });
   }
@@ -643,7 +661,7 @@ export function buildBedrockStreamContentWithToolCallsEvents(
 
   events.push({
     eventType: "messageStart",
-    payload: { role: "assistant" },
+    payload: { messageStart: { role: "assistant" } },
   });
 
   let blockIndex = 0;
@@ -652,7 +670,13 @@ export function buildBedrockStreamContentWithToolCallsEvents(
   if (reasoning) {
     events.push({
       eventType: "contentBlockStart",
-      payload: { contentBlockIndex: blockIndex, start: { type: "thinking" } },
+      payload: {
+        contentBlockIndex: blockIndex,
+        contentBlockStart: {
+          contentBlockIndex: blockIndex,
+          start: { type: "thinking" },
+        },
+      },
     });
     for (let i = 0; i < reasoning.length; i += chunkSize) {
       const slice = reasoning.slice(i, i + chunkSize);
@@ -660,7 +684,10 @@ export function buildBedrockStreamContentWithToolCallsEvents(
         eventType: "contentBlockDelta",
         payload: {
           contentBlockIndex: blockIndex,
-          delta: { type: "thinking_delta", thinking: slice },
+          contentBlockDelta: {
+            contentBlockIndex: blockIndex,
+            delta: { type: "thinking_delta", thinking: slice },
+          },
         },
       });
     }
@@ -674,7 +701,13 @@ export function buildBedrockStreamContentWithToolCallsEvents(
   // Text block
   events.push({
     eventType: "contentBlockStart",
-    payload: { contentBlockIndex: blockIndex, start: {} },
+    payload: {
+      contentBlockIndex: blockIndex,
+      contentBlockStart: {
+        contentBlockIndex: blockIndex,
+        start: { type: "text" },
+      },
+    },
   });
   for (let i = 0; i < content.length; i += chunkSize) {
     const slice = content.slice(i, i + chunkSize);
@@ -682,7 +715,10 @@ export function buildBedrockStreamContentWithToolCallsEvents(
       eventType: "contentBlockDelta",
       payload: {
         contentBlockIndex: blockIndex,
-        delta: { type: "text_delta", text: slice },
+        contentBlockDelta: {
+          contentBlockIndex: blockIndex,
+          delta: { text: slice },
+        },
       },
     });
   }
@@ -702,7 +738,10 @@ export function buildBedrockStreamContentWithToolCallsEvents(
       eventType: "contentBlockStart",
       payload: {
         contentBlockIndex: currentBlock,
-        start: { toolUse: { toolUseId, name: tc.name } },
+        contentBlockStart: {
+          contentBlockIndex: currentBlock,
+          start: { toolUse: { toolUseId, name: tc.name } },
+        },
       },
     });
 
@@ -723,7 +762,10 @@ export function buildBedrockStreamContentWithToolCallsEvents(
         eventType: "contentBlockDelta",
         payload: {
           contentBlockIndex: currentBlock,
-          delta: { type: "input_json_delta", inputJSON: slice },
+          contentBlockDelta: {
+            contentBlockIndex: currentBlock,
+            delta: { toolUse: { input: slice } },
+          },
         },
       });
     }
@@ -752,7 +794,7 @@ export function buildBedrockStreamToolCallEvents(
 
   events.push({
     eventType: "messageStart",
-    payload: { role: "assistant" },
+    payload: { messageStart: { role: "assistant" } },
   });
 
   for (let tcIdx = 0; tcIdx < toolCalls.length; tcIdx++) {
@@ -763,8 +805,11 @@ export function buildBedrockStreamToolCallEvents(
       eventType: "contentBlockStart",
       payload: {
         contentBlockIndex: tcIdx,
-        start: {
-          toolUse: { toolUseId, name: tc.name },
+        contentBlockStart: {
+          contentBlockIndex: tcIdx,
+          start: {
+            toolUse: { toolUseId, name: tc.name },
+          },
         },
       },
     });
@@ -786,7 +831,10 @@ export function buildBedrockStreamToolCallEvents(
         eventType: "contentBlockDelta",
         payload: {
           contentBlockIndex: tcIdx,
-          delta: { type: "input_json_delta", inputJSON: slice },
+          contentBlockDelta: {
+            contentBlockIndex: tcIdx,
+            delta: { toolUse: { input: slice } },
+          },
         },
       });
     }

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -23,12 +23,14 @@ import type {
   ChatMessage,
   Fixture,
   HandlerDefaults,
+  ResponseOverrides,
   ToolCall,
   ToolDefinition,
 } from "./types.js";
 import {
   generateMessageId,
   generateToolUseId,
+  extractOverrides,
   isTextResponse,
   isToolCallResponse,
   isContentWithToolCallsResponse,
@@ -78,6 +80,30 @@ interface BedrockRequest {
   max_tokens: number;
   temperature?: number;
   [key: string]: unknown;
+}
+
+// ─── Bedrock stop_reason mapping ───────────────────────────────────────────
+
+function bedrockStopReason(
+  overrideFinishReason: string | undefined,
+  defaultReason: string,
+): string {
+  if (!overrideFinishReason) return defaultReason;
+  if (overrideFinishReason === "stop") return "end_turn";
+  if (overrideFinishReason === "tool_calls") return "tool_use";
+  if (overrideFinishReason === "length") return "max_tokens";
+  return overrideFinishReason;
+}
+
+function bedrockUsage(overrides?: ResponseOverrides): {
+  input_tokens: number;
+  output_tokens: number;
+} {
+  if (!overrides?.usage) return { input_tokens: 0, output_tokens: 0 };
+  return {
+    input_tokens: overrides.usage.input_tokens ?? overrides.usage.prompt_tokens ?? 0,
+    output_tokens: overrides.usage.output_tokens ?? overrides.usage.completion_tokens ?? 0,
+  };
 }
 
 // ─── Input conversion: Bedrock → ChatCompletionRequest ──────────────────────
@@ -200,7 +226,12 @@ export function bedrockToCompletionRequest(
 
 // ─── Response builders ──────────────────────────────────────────────────────
 
-function buildBedrockTextResponse(content: string, model: string, reasoning?: string): object {
+function buildBedrockTextResponse(
+  content: string,
+  model: string,
+  reasoning?: string,
+  overrides?: ResponseOverrides,
+): object {
   const contentBlocks: object[] = [];
   if (reasoning) {
     contentBlocks.push({ type: "thinking", thinking: reasoning });
@@ -208,14 +239,14 @@ function buildBedrockTextResponse(content: string, model: string, reasoning?: st
   contentBlocks.push({ type: "text", text: content });
 
   return {
-    id: generateMessageId(),
+    id: overrides?.id ?? generateMessageId(),
     type: "message",
     role: "assistant",
     content: contentBlocks,
-    model,
-    stop_reason: "end_turn",
+    model: overrides?.model ?? model,
+    stop_reason: bedrockStopReason(overrides?.finishReason, "end_turn"),
     stop_sequence: null,
-    usage: { input_tokens: 0, output_tokens: 0 },
+    usage: bedrockUsage(overrides),
   };
 }
 
@@ -223,9 +254,10 @@ function buildBedrockToolCallResponse(
   toolCalls: ToolCall[],
   model: string,
   logger: Logger,
+  overrides?: ResponseOverrides,
 ): object {
   return {
-    id: generateMessageId(),
+    id: overrides?.id ?? generateMessageId(),
     type: "message",
     role: "assistant",
     content: toolCalls.map((tc) => {
@@ -245,10 +277,10 @@ function buildBedrockToolCallResponse(
         input: argsObj,
       };
     }),
-    model,
-    stop_reason: "tool_use",
+    model: overrides?.model ?? model,
+    stop_reason: bedrockStopReason(overrides?.finishReason, "tool_use"),
     stop_sequence: null,
-    usage: { input_tokens: 0, output_tokens: 0 },
+    usage: bedrockUsage(overrides),
   };
 }
 
@@ -425,6 +457,10 @@ export async function handleBedrock(
 
   // Content + tool calls response
   if (isContentWithToolCallsResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn("webSearches in fixture response are not supported for Bedrock API — ignoring");
+    }
+    const overrides = extractOverrides(response);
     journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -432,13 +468,18 @@ export async function handleBedrock(
       body: completionReq,
       response: { status: 200, fixture },
     });
-    // Build a combined response with both text and tool_use content blocks
     const textBody = buildBedrockTextResponse(
       response.content,
       completionReq.model,
       response.reasoning,
+      overrides,
     );
-    const toolBody = buildBedrockToolCallResponse(response.toolCalls, completionReq.model, logger);
+    const toolBody = buildBedrockToolCallResponse(
+      response.toolCalls,
+      completionReq.model,
+      logger,
+      overrides,
+    );
     // Merge: take the text response as base, append tool_use blocks, set stop_reason to tool_use
     const merged = {
       ...(textBody as Record<string, unknown>),
@@ -446,7 +487,7 @@ export async function handleBedrock(
         ...((textBody as Record<string, unknown>).content as object[]),
         ...((toolBody as Record<string, unknown>).content as object[]),
       ],
-      stop_reason: "tool_use",
+      stop_reason: bedrockStopReason(overrides?.finishReason, "tool_use"),
     };
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(merged));
@@ -455,6 +496,10 @@ export async function handleBedrock(
 
   // Text response
   if (isTextResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn("webSearches in fixture response are not supported for Bedrock API — ignoring");
+    }
+    const overrides = extractOverrides(response);
     journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -466,6 +511,7 @@ export async function handleBedrock(
       response.content,
       completionReq.model,
       response.reasoning,
+      overrides,
     );
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(body));
@@ -474,6 +520,7 @@ export async function handleBedrock(
 
   // Tool call response
   if (isToolCallResponse(response)) {
+    const overrides = extractOverrides(response);
     journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -481,7 +528,12 @@ export async function handleBedrock(
       body: completionReq,
       response: { status: 200, fixture },
     });
-    const body = buildBedrockToolCallResponse(response.toolCalls, completionReq.model, logger);
+    const body = buildBedrockToolCallResponse(
+      response.toolCalls,
+      completionReq.model,
+      logger,
+      overrides,
+    );
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(body));
     return;
@@ -578,6 +630,116 @@ export function buildBedrockStreamTextEvents(
   return events;
 }
 
+export function buildBedrockStreamContentWithToolCallsEvents(
+  content: string,
+  toolCalls: ToolCall[],
+  chunkSize: number,
+  logger: Logger,
+  reasoning?: string,
+): Array<{ eventType: string; payload: object }> {
+  const events: Array<{ eventType: string; payload: object }> = [];
+
+  events.push({
+    eventType: "messageStart",
+    payload: { role: "assistant" },
+  });
+
+  let blockIndex = 0;
+
+  // Thinking block (emitted before text when reasoning is present)
+  if (reasoning) {
+    events.push({
+      eventType: "contentBlockStart",
+      payload: { contentBlockIndex: blockIndex, start: { type: "thinking" } },
+    });
+    for (let i = 0; i < reasoning.length; i += chunkSize) {
+      const slice = reasoning.slice(i, i + chunkSize);
+      events.push({
+        eventType: "contentBlockDelta",
+        payload: {
+          contentBlockIndex: blockIndex,
+          delta: { type: "thinking_delta", thinking: slice },
+        },
+      });
+    }
+    events.push({
+      eventType: "contentBlockStop",
+      payload: { contentBlockIndex: blockIndex },
+    });
+    blockIndex++;
+  }
+
+  // Text block
+  events.push({
+    eventType: "contentBlockStart",
+    payload: { contentBlockIndex: blockIndex, start: {} },
+  });
+  for (let i = 0; i < content.length; i += chunkSize) {
+    const slice = content.slice(i, i + chunkSize);
+    events.push({
+      eventType: "contentBlockDelta",
+      payload: {
+        contentBlockIndex: blockIndex,
+        delta: { type: "text_delta", text: slice },
+      },
+    });
+  }
+  events.push({
+    eventType: "contentBlockStop",
+    payload: { contentBlockIndex: blockIndex },
+  });
+  blockIndex++;
+
+  // Tool call blocks
+  for (let tcIdx = 0; tcIdx < toolCalls.length; tcIdx++) {
+    const tc = toolCalls[tcIdx];
+    const toolUseId = tc.id || generateToolUseId();
+    const currentBlock = blockIndex + tcIdx;
+
+    events.push({
+      eventType: "contentBlockStart",
+      payload: {
+        contentBlockIndex: currentBlock,
+        start: { toolUse: { toolUseId, name: tc.name } },
+      },
+    });
+
+    let argsStr: string;
+    try {
+      const parsed = JSON.parse(tc.arguments || "{}");
+      argsStr = JSON.stringify(parsed);
+    } catch {
+      logger.warn(
+        `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+      );
+      argsStr = "{}";
+    }
+
+    for (let i = 0; i < argsStr.length; i += chunkSize) {
+      const slice = argsStr.slice(i, i + chunkSize);
+      events.push({
+        eventType: "contentBlockDelta",
+        payload: {
+          contentBlockIndex: currentBlock,
+          delta: { type: "input_json_delta", inputJSON: slice },
+        },
+      });
+    }
+
+    events.push({
+      eventType: "contentBlockStop",
+      payload: { contentBlockIndex: currentBlock },
+    });
+  }
+
+  events.push({
+    eventType: "messageStop",
+    payload: { stopReason: "tool_use" },
+  });
+
+  return events;
+}
+
 export function buildBedrockStreamToolCallEvents(
   toolCalls: ToolCall[],
   chunkSize: number,
@@ -629,124 +791,6 @@ export function buildBedrockStreamToolCallEvents(
     events.push({
       eventType: "contentBlockStop",
       payload: { contentBlockIndex: tcIdx },
-    });
-  }
-
-  events.push({
-    eventType: "messageStop",
-    payload: { stopReason: "tool_use" },
-  });
-
-  return events;
-}
-
-export function buildBedrockStreamContentWithToolCallsEvents(
-  content: string,
-  toolCalls: ToolCall[],
-  chunkSize: number,
-  logger: Logger,
-  reasoning?: string,
-): Array<{ eventType: string; payload: object }> {
-  const events: Array<{ eventType: string; payload: object }> = [];
-
-  events.push({
-    eventType: "messageStart",
-    payload: { role: "assistant" },
-  });
-
-  let blockIndex = 0;
-
-  // Thinking block (emitted before text when reasoning is present)
-  if (reasoning) {
-    events.push({
-      eventType: "contentBlockStart",
-      payload: { contentBlockIndex: blockIndex, start: { type: "thinking" } },
-    });
-
-    for (let i = 0; i < reasoning.length; i += chunkSize) {
-      const slice = reasoning.slice(i, i + chunkSize);
-      events.push({
-        eventType: "contentBlockDelta",
-        payload: {
-          contentBlockIndex: blockIndex,
-          delta: { type: "thinking_delta", thinking: slice },
-        },
-      });
-    }
-
-    events.push({
-      eventType: "contentBlockStop",
-      payload: { contentBlockIndex: blockIndex },
-    });
-
-    blockIndex++;
-  }
-
-  // Text block
-  events.push({
-    eventType: "contentBlockStart",
-    payload: { contentBlockIndex: blockIndex, start: {} },
-  });
-
-  for (let i = 0; i < content.length; i += chunkSize) {
-    const slice = content.slice(i, i + chunkSize);
-    events.push({
-      eventType: "contentBlockDelta",
-      payload: {
-        contentBlockIndex: blockIndex,
-        delta: { type: "text_delta", text: slice },
-      },
-    });
-  }
-
-  events.push({
-    eventType: "contentBlockStop",
-    payload: { contentBlockIndex: blockIndex },
-  });
-
-  blockIndex++;
-
-  // Tool call blocks
-  for (let tcIdx = 0; tcIdx < toolCalls.length; tcIdx++) {
-    const tc = toolCalls[tcIdx];
-    const toolUseId = tc.id || generateToolUseId();
-    const currentBlock = blockIndex + tcIdx;
-
-    events.push({
-      eventType: "contentBlockStart",
-      payload: {
-        contentBlockIndex: currentBlock,
-        start: {
-          toolUse: { toolUseId, name: tc.name },
-        },
-      },
-    });
-
-    let argsStr: string;
-    try {
-      const parsed = JSON.parse(tc.arguments || "{}");
-      argsStr = JSON.stringify(parsed);
-    } catch {
-      logger.warn(
-        `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
-      );
-      argsStr = "{}";
-    }
-
-    for (let i = 0; i < argsStr.length; i += chunkSize) {
-      const slice = argsStr.slice(i, i + chunkSize);
-      events.push({
-        eventType: "contentBlockDelta",
-        payload: {
-          contentBlockIndex: currentBlock,
-          delta: { type: "input_json_delta", inputJSON: slice },
-        },
-      });
-    }
-
-    events.push({
-      eventType: "contentBlockStop",
-      payload: { contentBlockIndex: currentBlock },
     });
   }
 
@@ -932,6 +976,9 @@ export async function handleBedrockStream(
 
   // Content + tool calls response — stream as Event Stream
   if (isContentWithToolCallsResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn("webSearches in fixture response are not supported for Bedrock API — ignoring");
+    }
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -964,6 +1011,9 @@ export async function handleBedrockStream(
 
   // Text response — stream as Event Stream
   if (isTextResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn("webSearches in fixture response are not supported for Bedrock API — ignoring");
+    }
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -31,6 +31,7 @@ import {
   generateToolUseId,
   isTextResponse,
   isToolCallResponse,
+  isContentWithToolCallsResponse,
   isErrorResponse,
   flattenHeaders,
   getTestId,
@@ -366,7 +367,7 @@ export async function handleBedrock(
           path: urlPath,
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }
@@ -419,6 +420,36 @@ export async function handleBedrock(
       },
     };
     writeErrorResponse(res, status, JSON.stringify(anthropicError));
+    return;
+  }
+
+  // Content + tool calls response
+  if (isContentWithToolCallsResponse(response)) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: urlPath,
+      headers: flattenHeaders(req.headers),
+      body: completionReq,
+      response: { status: 200, fixture },
+    });
+    // Build a combined response with both text and tool_use content blocks
+    const textBody = buildBedrockTextResponse(
+      response.content,
+      completionReq.model,
+      response.reasoning,
+    );
+    const toolBody = buildBedrockToolCallResponse(response.toolCalls, completionReq.model, logger);
+    // Merge: take the text response as base, append tool_use blocks, set stop_reason to tool_use
+    const merged = {
+      ...(textBody as Record<string, unknown>),
+      content: [
+        ...((textBody as Record<string, unknown>).content as object[]),
+        ...((toolBody as Record<string, unknown>).content as object[]),
+      ],
+      stop_reason: "tool_use",
+    };
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(merged));
     return;
   }
 
@@ -609,6 +640,124 @@ export function buildBedrockStreamToolCallEvents(
   return events;
 }
 
+export function buildBedrockStreamContentWithToolCallsEvents(
+  content: string,
+  toolCalls: ToolCall[],
+  chunkSize: number,
+  logger: Logger,
+  reasoning?: string,
+): Array<{ eventType: string; payload: object }> {
+  const events: Array<{ eventType: string; payload: object }> = [];
+
+  events.push({
+    eventType: "messageStart",
+    payload: { role: "assistant" },
+  });
+
+  let blockIndex = 0;
+
+  // Thinking block (emitted before text when reasoning is present)
+  if (reasoning) {
+    events.push({
+      eventType: "contentBlockStart",
+      payload: { contentBlockIndex: blockIndex, start: { type: "thinking" } },
+    });
+
+    for (let i = 0; i < reasoning.length; i += chunkSize) {
+      const slice = reasoning.slice(i, i + chunkSize);
+      events.push({
+        eventType: "contentBlockDelta",
+        payload: {
+          contentBlockIndex: blockIndex,
+          delta: { type: "thinking_delta", thinking: slice },
+        },
+      });
+    }
+
+    events.push({
+      eventType: "contentBlockStop",
+      payload: { contentBlockIndex: blockIndex },
+    });
+
+    blockIndex++;
+  }
+
+  // Text block
+  events.push({
+    eventType: "contentBlockStart",
+    payload: { contentBlockIndex: blockIndex, start: {} },
+  });
+
+  for (let i = 0; i < content.length; i += chunkSize) {
+    const slice = content.slice(i, i + chunkSize);
+    events.push({
+      eventType: "contentBlockDelta",
+      payload: {
+        contentBlockIndex: blockIndex,
+        delta: { type: "text_delta", text: slice },
+      },
+    });
+  }
+
+  events.push({
+    eventType: "contentBlockStop",
+    payload: { contentBlockIndex: blockIndex },
+  });
+
+  blockIndex++;
+
+  // Tool call blocks
+  for (let tcIdx = 0; tcIdx < toolCalls.length; tcIdx++) {
+    const tc = toolCalls[tcIdx];
+    const toolUseId = tc.id || generateToolUseId();
+    const currentBlock = blockIndex + tcIdx;
+
+    events.push({
+      eventType: "contentBlockStart",
+      payload: {
+        contentBlockIndex: currentBlock,
+        start: {
+          toolUse: { toolUseId, name: tc.name },
+        },
+      },
+    });
+
+    let argsStr: string;
+    try {
+      const parsed = JSON.parse(tc.arguments || "{}");
+      argsStr = JSON.stringify(parsed);
+    } catch {
+      logger.warn(
+        `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+      );
+      argsStr = "{}";
+    }
+
+    for (let i = 0; i < argsStr.length; i += chunkSize) {
+      const slice = argsStr.slice(i, i + chunkSize);
+      events.push({
+        eventType: "contentBlockDelta",
+        payload: {
+          contentBlockIndex: currentBlock,
+          delta: { type: "input_json_delta", inputJSON: slice },
+        },
+      });
+    }
+
+    events.push({
+      eventType: "contentBlockStop",
+      payload: { contentBlockIndex: currentBlock },
+    });
+  }
+
+  events.push({
+    eventType: "messageStop",
+    payload: { stopReason: "tool_use" },
+  });
+
+  return events;
+}
+
 // ─── Streaming request handler ──────────────────────────────────────────────
 
 export async function handleBedrockStream(
@@ -723,7 +872,7 @@ export async function handleBedrockStream(
           path: urlPath,
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }
@@ -770,6 +919,38 @@ export async function handleBedrockStream(
       response: { status, fixture },
     });
     writeErrorResponse(res, status, JSON.stringify(response));
+    return;
+  }
+
+  // Content + tool calls response — stream as Event Stream
+  if (isContentWithToolCallsResponse(response)) {
+    const journalEntry = journal.add({
+      method: req.method ?? "POST",
+      path: urlPath,
+      headers: flattenHeaders(req.headers),
+      body: completionReq,
+      response: { status: 200, fixture },
+    });
+    const events = buildBedrockStreamContentWithToolCallsEvents(
+      response.content,
+      response.toolCalls,
+      chunkSize,
+      logger,
+      response.reasoning,
+    );
+    const interruption = createInterruptionSignal(fixture);
+    const completed = await writeEventStream(res, events, {
+      latency,
+      streamingProfile: fixture.streamingProfile,
+      signal: interruption?.signal,
+      onChunkSent: interruption?.tick,
+    });
+    if (!completed) {
+      if (!res.writableEnded) res.destroy();
+      journalEntry.response.interrupted = true;
+      journalEntry.response.interruptReason = interruption?.reason();
+    }
+    interruption?.cleanup();
     return;
   }
 

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -565,6 +565,7 @@ export function buildBedrockStreamTextEvents(
   content: string,
   chunkSize: number,
   reasoning?: string,
+  overrides?: ResponseOverrides,
 ): Array<{ eventType: string; payload: object }> {
   const events: Array<{ eventType: string; payload: object }> = [];
 
@@ -624,7 +625,7 @@ export function buildBedrockStreamTextEvents(
 
   events.push({
     eventType: "messageStop",
-    payload: { stopReason: "end_turn" },
+    payload: { stopReason: bedrockStopReason(overrides?.finishReason, "end_turn") },
   });
 
   return events;
@@ -636,6 +637,7 @@ export function buildBedrockStreamContentWithToolCallsEvents(
   chunkSize: number,
   logger: Logger,
   reasoning?: string,
+  overrides?: ResponseOverrides,
 ): Array<{ eventType: string; payload: object }> {
   const events: Array<{ eventType: string; payload: object }> = [];
 
@@ -734,7 +736,7 @@ export function buildBedrockStreamContentWithToolCallsEvents(
 
   events.push({
     eventType: "messageStop",
-    payload: { stopReason: "tool_use" },
+    payload: { stopReason: bedrockStopReason(overrides?.finishReason, "tool_use") },
   });
 
   return events;
@@ -744,6 +746,7 @@ export function buildBedrockStreamToolCallEvents(
   toolCalls: ToolCall[],
   chunkSize: number,
   logger: Logger,
+  overrides?: ResponseOverrides,
 ): Array<{ eventType: string; payload: object }> {
   const events: Array<{ eventType: string; payload: object }> = [];
 
@@ -796,7 +799,7 @@ export function buildBedrockStreamToolCallEvents(
 
   events.push({
     eventType: "messageStop",
-    payload: { stopReason: "tool_use" },
+    payload: { stopReason: bedrockStopReason(overrides?.finishReason, "tool_use") },
   });
 
   return events;
@@ -979,6 +982,7 @@ export async function handleBedrockStream(
     if (response.webSearches?.length) {
       logger.warn("webSearches in fixture response are not supported for Bedrock API — ignoring");
     }
+    const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -992,6 +996,7 @@ export async function handleBedrockStream(
       chunkSize,
       logger,
       response.reasoning,
+      overrides,
     );
     const interruption = createInterruptionSignal(fixture);
     const completed = await writeEventStream(res, events, {
@@ -1014,6 +1019,7 @@ export async function handleBedrockStream(
     if (response.webSearches?.length) {
       logger.warn("webSearches in fixture response are not supported for Bedrock API — ignoring");
     }
+    const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -1021,7 +1027,12 @@ export async function handleBedrockStream(
       body: completionReq,
       response: { status: 200, fixture },
     });
-    const events = buildBedrockStreamTextEvents(response.content, chunkSize, response.reasoning);
+    const events = buildBedrockStreamTextEvents(
+      response.content,
+      chunkSize,
+      response.reasoning,
+      overrides,
+    );
     const interruption = createInterruptionSignal(fixture);
     const completed = await writeEventStream(res, events, {
       latency,
@@ -1040,6 +1051,7 @@ export async function handleBedrockStream(
 
   // Tool call response — stream as Event Stream
   if (isToolCallResponse(response)) {
+    const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -1047,7 +1059,12 @@ export async function handleBedrockStream(
       body: completionReq,
       response: { status: 200, fixture },
     });
-    const events = buildBedrockStreamToolCallEvents(response.toolCalls, chunkSize, logger);
+    const events = buildBedrockStreamToolCallEvents(
+      response.toolCalls,
+      chunkSize,
+      logger,
+      overrides,
+    );
     const interruption = createInterruptionSignal(fixture);
     const completed = await writeEventStream(res, events, {
       latency,

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -918,7 +918,15 @@ export async function handleBedrockStream(
       body: completionReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    // Anthropic-style error format (Bedrock uses Claude): { type: "error", error: { type, message } }
+    const anthropicError = {
+      type: "error",
+      error: {
+        type: response.error.type ?? "api_error",
+        message: response.error.message,
+      },
+    };
+    writeErrorResponse(res, status, JSON.stringify(anthropicError));
     return;
   }
 

--- a/src/cohere.ts
+++ b/src/cohere.ts
@@ -24,6 +24,7 @@ import {
   generateToolCallId,
   isTextResponse,
   isToolCallResponse,
+  isContentWithToolCallsResponse,
   isErrorResponse,
   flattenHeaders,
   getTestId,
@@ -170,6 +171,44 @@ function buildCohereToolCallResponse(toolCalls: ToolCall[], logger: Logger): obj
   };
 }
 
+// Non-streaming content + tool calls response
+function buildCohereContentWithToolCallsResponse(
+  content: string,
+  toolCalls: ToolCall[],
+  logger: Logger,
+): object {
+  const cohereCalls = toolCalls.map((tc) => {
+    try {
+      JSON.parse(tc.arguments || "{}");
+    } catch {
+      logger.warn(
+        `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+      );
+    }
+    return {
+      id: tc.id || generateToolCallId(),
+      type: "function",
+      function: {
+        name: tc.name,
+        arguments: tc.arguments || "{}",
+      },
+    };
+  });
+
+  return {
+    id: generateMessageId(),
+    finish_reason: "TOOL_CALL",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: content }],
+      tool_calls: cohereCalls,
+      tool_plan: "",
+      citations: [],
+    },
+    usage: ZERO_USAGE,
+  };
+}
+
 // ─── Streaming event builders ───────────────────────────────────────────────
 
 function buildCohereTextStreamEvents(content: string, chunkSize: number): CohereSSEEvent[] {
@@ -272,6 +311,142 @@ function buildCohereToolCallStreamEvents(
     const callId = tc.id || generateToolCallId();
 
     // Validate arguments JSON
+    let argsJson: string;
+    try {
+      JSON.parse(tc.arguments || "{}");
+      argsJson = tc.arguments || "{}";
+    } catch {
+      logger.warn(
+        `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+      );
+      argsJson = "{}";
+    }
+
+    // tool-call-start
+    events.push({
+      type: "tool-call-start",
+      index: idx,
+      delta: {
+        message: {
+          tool_calls: {
+            id: callId,
+            type: "function",
+            function: {
+              name: tc.name,
+              arguments: "",
+            },
+          },
+        },
+      },
+    });
+
+    // tool-call-delta — chunked arguments
+    for (let i = 0; i < argsJson.length; i += chunkSize) {
+      const slice = argsJson.slice(i, i + chunkSize);
+      events.push({
+        type: "tool-call-delta",
+        index: idx,
+        delta: {
+          message: {
+            tool_calls: {
+              function: {
+                arguments: slice,
+              },
+            },
+          },
+        },
+      });
+    }
+
+    // tool-call-end
+    events.push({
+      type: "tool-call-end",
+      index: idx,
+    });
+  }
+
+  // message-end
+  events.push({
+    type: "message-end",
+    delta: {
+      finish_reason: "TOOL_CALL",
+      usage: ZERO_USAGE,
+    },
+  });
+
+  return events;
+}
+
+function buildCohereContentWithToolCallsStreamEvents(
+  content: string,
+  toolCalls: ToolCall[],
+  chunkSize: number,
+  logger: Logger,
+): CohereSSEEvent[] {
+  const msgId = generateMessageId();
+  const events: CohereSSEEvent[] = [];
+
+  // message-start
+  events.push({
+    id: msgId,
+    type: "message-start",
+    delta: {
+      message: {
+        role: "assistant",
+        content: [],
+        tool_plan: "",
+        tool_calls: [],
+        citations: [],
+      },
+    },
+  });
+
+  // content-start (type: "text" only, no text field)
+  events.push({
+    type: "content-start",
+    index: 0,
+    delta: {
+      message: {
+        content: { type: "text" },
+      },
+    },
+  });
+
+  // content-delta — text chunks
+  for (let i = 0; i < content.length; i += chunkSize) {
+    const slice = content.slice(i, i + chunkSize);
+    events.push({
+      type: "content-delta",
+      index: 0,
+      delta: {
+        message: {
+          content: { type: "text", text: slice },
+        },
+      },
+    });
+  }
+
+  // content-end
+  events.push({
+    type: "content-end",
+    index: 0,
+  });
+
+  // tool-plan-delta
+  events.push({
+    type: "tool-plan-delta",
+    delta: {
+      message: {
+        tool_plan: "I will use the requested tool.",
+      },
+    },
+  });
+
+  // Tool call events
+  for (let idx = 0; idx < toolCalls.length; idx++) {
+    const tc = toolCalls[idx];
+    const callId = tc.id || generateToolCallId();
+
     let argsJson: string;
     try {
       JSON.parse(tc.arguments || "{}");
@@ -516,7 +691,7 @@ export async function handleCohere(
           path: req.url ?? "/v2/chat",
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }
@@ -565,6 +740,47 @@ export async function handleCohere(
       response: { status, fixture },
     });
     writeErrorResponse(res, status, JSON.stringify(response));
+    return;
+  }
+
+  // Content + tool calls response (must be checked before text/tool-only branches)
+  if (isContentWithToolCallsResponse(response)) {
+    const journalEntry = journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? "/v2/chat",
+      headers: flattenHeaders(req.headers),
+      body: completionReq,
+      response: { status: 200, fixture },
+    });
+    if (cohereReq.stream !== true) {
+      const body = buildCohereContentWithToolCallsResponse(
+        response.content,
+        response.toolCalls,
+        logger,
+      );
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+    } else {
+      const events = buildCohereContentWithToolCallsStreamEvents(
+        response.content,
+        response.toolCalls,
+        chunkSize,
+        logger,
+      );
+      const interruption = createInterruptionSignal(fixture);
+      const completed = await writeCohereSSEStream(res, events, {
+        latency,
+        streamingProfile: fixture.streamingProfile,
+        signal: interruption?.signal,
+        onChunkSent: interruption?.tick,
+      });
+      if (!completed) {
+        if (!res.writableEnded) res.destroy();
+        journalEntry.response.interrupted = true;
+        journalEntry.response.interruptReason = interruption?.reason();
+      }
+      interruption?.cleanup();
+    }
     return;
   }
 

--- a/src/cohere.ts
+++ b/src/cohere.ts
@@ -140,19 +140,22 @@ function buildCohereTextResponse(content: string): object {
 function buildCohereToolCallResponse(toolCalls: ToolCall[], logger: Logger): object {
   const cohereCalls = toolCalls.map((tc) => {
     // Validate arguments JSON
+    let argsJson: string;
     try {
       JSON.parse(tc.arguments || "{}");
+      argsJson = tc.arguments || "{}";
     } catch {
       logger.warn(
         `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
       );
+      argsJson = "{}";
     }
     return {
       id: tc.id || generateToolCallId(),
       type: "function",
       function: {
         name: tc.name,
-        arguments: tc.arguments || "{}",
+        arguments: argsJson,
       },
     };
   });
@@ -178,19 +181,22 @@ function buildCohereContentWithToolCallsResponse(
   logger: Logger,
 ): object {
   const cohereCalls = toolCalls.map((tc) => {
+    let argsJson: string;
     try {
       JSON.parse(tc.arguments || "{}");
+      argsJson = tc.arguments || "{}";
     } catch {
       logger.warn(
         `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
       );
+      argsJson = "{}";
     }
     return {
       id: tc.id || generateToolCallId(),
       type: "function",
       function: {
         name: tc.name,
-        arguments: tc.arguments || "{}",
+        arguments: argsJson,
       },
     };
   });

--- a/src/cohere.ts
+++ b/src/cohere.ts
@@ -299,8 +299,9 @@ function buildCohereTextStreamEvents(
   content: string,
   chunkSize: number,
   reasoning?: string,
+  overrides?: ResponseOverrides,
 ): CohereSSEEvent[] {
-  const msgId = generateMessageId();
+  const msgId = overrides?.id ?? generateMessageId();
   const events: CohereSSEEvent[] = [];
 
   // message-start
@@ -374,8 +375,8 @@ function buildCohereTextStreamEvents(
   events.push({
     type: "message-end",
     delta: {
-      finish_reason: "COMPLETE",
-      usage: ZERO_USAGE,
+      finish_reason: cohereFinishReason(overrides?.finishReason, "COMPLETE"),
+      usage: cohereUsage(overrides),
     },
   });
 
@@ -386,8 +387,9 @@ function buildCohereToolCallStreamEvents(
   toolCalls: ToolCall[],
   chunkSize: number,
   logger: Logger,
+  overrides?: ResponseOverrides,
 ): CohereSSEEvent[] {
-  const msgId = generateMessageId();
+  const msgId = overrides?.id ?? generateMessageId();
   const events: CohereSSEEvent[] = [];
 
   // message-start
@@ -478,8 +480,8 @@ function buildCohereToolCallStreamEvents(
   events.push({
     type: "message-end",
     delta: {
-      finish_reason: "TOOL_CALL",
-      usage: ZERO_USAGE,
+      finish_reason: cohereFinishReason(overrides?.finishReason, "TOOL_CALL"),
+      usage: cohereUsage(overrides),
     },
   });
 
@@ -492,8 +494,9 @@ function buildCohereContentWithToolCallsStreamEvents(
   chunkSize: number,
   logger: Logger,
   reasoning?: string,
+  overrides?: ResponseOverrides,
 ): CohereSSEEvent[] {
-  const msgId = generateMessageId();
+  const msgId = overrides?.id ?? generateMessageId();
   const events: CohereSSEEvent[] = [];
 
   // message-start
@@ -636,8 +639,8 @@ function buildCohereContentWithToolCallsStreamEvents(
   events.push({
     type: "message-end",
     delta: {
-      finish_reason: "TOOL_CALL",
-      usage: ZERO_USAGE,
+      finish_reason: cohereFinishReason(overrides?.finishReason, "TOOL_CALL"),
+      usage: cohereUsage(overrides),
     },
   });
 
@@ -906,6 +909,7 @@ export async function handleCohere(
         chunkSize,
         logger,
         response.reasoning,
+        overrides,
       );
       const interruption = createInterruptionSignal(fixture);
       const completed = await writeCohereSSEStream(res, events, {
@@ -944,7 +948,12 @@ export async function handleCohere(
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(body));
     } else {
-      const events = buildCohereTextStreamEvents(response.content, chunkSize, response.reasoning);
+      const events = buildCohereTextStreamEvents(
+        response.content,
+        chunkSize,
+        response.reasoning,
+        overrides,
+      );
       const interruption = createInterruptionSignal(fixture);
       const completed = await writeCohereSSEStream(res, events, {
         latency,
@@ -977,7 +986,12 @@ export async function handleCohere(
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(body));
     } else {
-      const events = buildCohereToolCallStreamEvents(response.toolCalls, chunkSize, logger);
+      const events = buildCohereToolCallStreamEvents(
+        response.toolCalls,
+        chunkSize,
+        logger,
+        overrides,
+      );
       const interruption = createInterruptionSignal(fixture);
       const completed = await writeCohereSSEStream(res, events, {
         latency,

--- a/src/cohere.ts
+++ b/src/cohere.ts
@@ -15,6 +15,7 @@ import type {
   ChatMessage,
   Fixture,
   HandlerDefaults,
+  ResponseOverrides,
   StreamingProfile,
   ToolCall,
   ToolDefinition,
@@ -22,6 +23,7 @@ import type {
 import {
   generateMessageId,
   generateToolCallId,
+  extractOverrides,
   isTextResponse,
   isToolCallResponse,
   isContentWithToolCallsResponse,
@@ -39,10 +41,20 @@ import { proxyAndRecord } from "./recorder.js";
 
 // ─── Cohere v2 Chat request types ───────────────────────────────────────────
 
+interface CohereToolCallDef {
+  id?: string;
+  type: string;
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
 interface CohereMessage {
   role: "user" | "assistant" | "system" | "tool";
   content: string;
   tool_call_id?: string;
+  tool_calls?: CohereToolCallDef[];
 }
 
 interface CohereToolDef {
@@ -76,6 +88,34 @@ const ZERO_USAGE = {
   tokens: { input_tokens: 0, output_tokens: 0 },
 };
 
+// ─── Cohere finish reason / usage mapping ──────────────────────────────────
+
+function cohereFinishReason(
+  overrideFinishReason: string | undefined,
+  defaultReason: string,
+): string {
+  if (!overrideFinishReason) return defaultReason;
+  if (overrideFinishReason === "stop") return "COMPLETE";
+  if (overrideFinishReason === "tool_calls") return "TOOL_CALL";
+  if (overrideFinishReason === "length") return "MAX_TOKENS";
+  return overrideFinishReason;
+}
+
+function cohereUsage(overrides?: ResponseOverrides): typeof ZERO_USAGE {
+  if (!overrides?.usage) return ZERO_USAGE;
+  const inputTokens = overrides.usage.input_tokens ?? overrides.usage.prompt_tokens ?? 0;
+  const outputTokens = overrides.usage.output_tokens ?? overrides.usage.completion_tokens ?? 0;
+  return {
+    billed_units: {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      search_units: 0,
+      classifications: 0,
+    },
+    tokens: { input_tokens: inputTokens, output_tokens: outputTokens },
+  };
+}
+
 // ─── Input conversion: Cohere → ChatCompletionRequest ───────────────────────
 
 export function cohereToCompletionRequest(req: CohereRequest): ChatCompletionRequest {
@@ -87,7 +127,22 @@ export function cohereToCompletionRequest(req: CohereRequest): ChatCompletionReq
     } else if (msg.role === "user") {
       messages.push({ role: "user", content: msg.content });
     } else if (msg.role === "assistant") {
-      messages.push({ role: "assistant", content: msg.content });
+      if (msg.tool_calls && msg.tool_calls.length > 0) {
+        messages.push({
+          role: "assistant",
+          content: msg.content || null,
+          tool_calls: msg.tool_calls.map((tc) => ({
+            id: tc.id ?? generateToolCallId(),
+            type: "function" as const,
+            function: {
+              name: tc.function.name,
+              arguments: tc.function.arguments,
+            },
+          })),
+        });
+      } else {
+        messages.push({ role: "assistant", content: msg.content });
+      }
     } else if (msg.role === "tool") {
       messages.push({
         role: "tool",
@@ -115,29 +170,44 @@ export function cohereToCompletionRequest(req: CohereRequest): ChatCompletionReq
     messages,
     stream: req.stream,
     tools,
+    ...(req.response_format && { response_format: req.response_format }),
   };
 }
 
 // ─── Response building: fixture → Cohere v2 Chat format ─────────────────────
 
 // Non-streaming text response
-function buildCohereTextResponse(content: string): object {
+function buildCohereTextResponse(
+  content: string,
+  reasoning?: string,
+  overrides?: ResponseOverrides,
+): object {
+  const contentBlocks: { type: string; text: string }[] = [];
+  if (reasoning) {
+    contentBlocks.push({ type: "text", text: reasoning });
+  }
+  contentBlocks.push({ type: "text", text: content });
+
   return {
-    id: generateMessageId(),
-    finish_reason: "COMPLETE",
+    id: overrides?.id ?? generateMessageId(),
+    finish_reason: cohereFinishReason(overrides?.finishReason, "COMPLETE"),
     message: {
       role: "assistant",
-      content: [{ type: "text", text: content }],
+      content: contentBlocks,
       tool_calls: [],
       tool_plan: "",
       citations: [],
     },
-    usage: ZERO_USAGE,
+    usage: cohereUsage(overrides),
   };
 }
 
 // Non-streaming tool call response
-function buildCohereToolCallResponse(toolCalls: ToolCall[], logger: Logger): object {
+function buildCohereToolCallResponse(
+  toolCalls: ToolCall[],
+  logger: Logger,
+  overrides?: ResponseOverrides,
+): object {
   const cohereCalls = toolCalls.map((tc) => {
     // Validate arguments JSON
     let argsJson: string;
@@ -161,8 +231,8 @@ function buildCohereToolCallResponse(toolCalls: ToolCall[], logger: Logger): obj
   });
 
   return {
-    id: generateMessageId(),
-    finish_reason: "TOOL_CALL",
+    id: overrides?.id ?? generateMessageId(),
+    finish_reason: cohereFinishReason(overrides?.finishReason, "TOOL_CALL"),
     message: {
       role: "assistant",
       content: [],
@@ -170,7 +240,7 @@ function buildCohereToolCallResponse(toolCalls: ToolCall[], logger: Logger): obj
       tool_plan: "",
       citations: [],
     },
-    usage: ZERO_USAGE,
+    usage: cohereUsage(overrides),
   };
 }
 
@@ -179,6 +249,8 @@ function buildCohereContentWithToolCallsResponse(
   content: string,
   toolCalls: ToolCall[],
   logger: Logger,
+  reasoning?: string,
+  overrides?: ResponseOverrides,
 ): object {
   const cohereCalls = toolCalls.map((tc) => {
     let argsJson: string;
@@ -201,23 +273,33 @@ function buildCohereContentWithToolCallsResponse(
     };
   });
 
+  const contentBlocks: { type: string; text: string }[] = [];
+  if (reasoning) {
+    contentBlocks.push({ type: "text", text: reasoning });
+  }
+  contentBlocks.push({ type: "text", text: content });
+
   return {
-    id: generateMessageId(),
-    finish_reason: "TOOL_CALL",
+    id: overrides?.id ?? generateMessageId(),
+    finish_reason: cohereFinishReason(overrides?.finishReason, "TOOL_CALL"),
     message: {
       role: "assistant",
-      content: [{ type: "text", text: content }],
+      content: contentBlocks,
       tool_calls: cohereCalls,
       tool_plan: "",
       citations: [],
     },
-    usage: ZERO_USAGE,
+    usage: cohereUsage(overrides),
   };
 }
 
 // ─── Streaming event builders ───────────────────────────────────────────────
 
-function buildCohereTextStreamEvents(content: string, chunkSize: number): CohereSSEEvent[] {
+function buildCohereTextStreamEvents(
+  content: string,
+  chunkSize: number,
+  reasoning?: string,
+): CohereSSEEvent[] {
   const msgId = generateMessageId();
   const events: CohereSSEEvent[] = [];
 
@@ -236,10 +318,31 @@ function buildCohereTextStreamEvents(content: string, chunkSize: number): Cohere
     },
   });
 
+  let contentIndex = 0;
+
+  // Reasoning as a text block before main content (Cohere has no native reasoning type)
+  if (reasoning) {
+    events.push({
+      type: "content-start",
+      index: contentIndex,
+      delta: { message: { content: { type: "text" } } },
+    });
+    for (let i = 0; i < reasoning.length; i += chunkSize) {
+      const slice = reasoning.slice(i, i + chunkSize);
+      events.push({
+        type: "content-delta",
+        index: contentIndex,
+        delta: { message: { content: { type: "text", text: slice } } },
+      });
+    }
+    events.push({ type: "content-end", index: contentIndex });
+    contentIndex++;
+  }
+
   // content-start (type: "text" only, no text field)
   events.push({
     type: "content-start",
-    index: 0,
+    index: contentIndex,
     delta: {
       message: {
         content: { type: "text" },
@@ -252,7 +355,7 @@ function buildCohereTextStreamEvents(content: string, chunkSize: number): Cohere
     const slice = content.slice(i, i + chunkSize);
     events.push({
       type: "content-delta",
-      index: 0,
+      index: contentIndex,
       delta: {
         message: {
           content: { type: "text", text: slice },
@@ -264,7 +367,7 @@ function buildCohereTextStreamEvents(content: string, chunkSize: number): Cohere
   // content-end
   events.push({
     type: "content-end",
-    index: 0,
+    index: contentIndex,
   });
 
   // message-end
@@ -388,6 +491,7 @@ function buildCohereContentWithToolCallsStreamEvents(
   toolCalls: ToolCall[],
   chunkSize: number,
   logger: Logger,
+  reasoning?: string,
 ): CohereSSEEvent[] {
   const msgId = generateMessageId();
   const events: CohereSSEEvent[] = [];
@@ -407,10 +511,31 @@ function buildCohereContentWithToolCallsStreamEvents(
     },
   });
 
+  let contentIndex = 0;
+
+  // Reasoning as a text block before main content
+  if (reasoning) {
+    events.push({
+      type: "content-start",
+      index: contentIndex,
+      delta: { message: { content: { type: "text" } } },
+    });
+    for (let i = 0; i < reasoning.length; i += chunkSize) {
+      const slice = reasoning.slice(i, i + chunkSize);
+      events.push({
+        type: "content-delta",
+        index: contentIndex,
+        delta: { message: { content: { type: "text", text: slice } } },
+      });
+    }
+    events.push({ type: "content-end", index: contentIndex });
+    contentIndex++;
+  }
+
   // content-start (type: "text" only, no text field)
   events.push({
     type: "content-start",
-    index: 0,
+    index: contentIndex,
     delta: {
       message: {
         content: { type: "text" },
@@ -423,7 +548,7 @@ function buildCohereContentWithToolCallsStreamEvents(
     const slice = content.slice(i, i + chunkSize);
     events.push({
       type: "content-delta",
-      index: 0,
+      index: contentIndex,
       delta: {
         message: {
           content: { type: "text", text: slice },
@@ -435,7 +560,7 @@ function buildCohereContentWithToolCallsStreamEvents(
   // content-end
   events.push({
     type: "content-end",
-    index: 0,
+    index: contentIndex,
   });
 
   // tool-plan-delta
@@ -751,6 +876,12 @@ export async function handleCohere(
 
   // Content + tool calls response (must be checked before text/tool-only branches)
   if (isContentWithToolCallsResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn(
+        "webSearches in fixture response are not supported for Cohere v2 Chat API — ignoring",
+      );
+    }
+    const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: req.url ?? "/v2/chat",
@@ -763,6 +894,8 @@ export async function handleCohere(
         response.content,
         response.toolCalls,
         logger,
+        response.reasoning,
+        overrides,
       );
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(body));
@@ -772,6 +905,7 @@ export async function handleCohere(
         response.toolCalls,
         chunkSize,
         logger,
+        response.reasoning,
       );
       const interruption = createInterruptionSignal(fixture);
       const completed = await writeCohereSSEStream(res, events, {
@@ -792,6 +926,12 @@ export async function handleCohere(
 
   // Text response
   if (isTextResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn(
+        "webSearches in fixture response are not supported for Cohere v2 Chat API — ignoring",
+      );
+    }
+    const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: req.url ?? "/v2/chat",
@@ -800,11 +940,11 @@ export async function handleCohere(
       response: { status: 200, fixture },
     });
     if (cohereReq.stream !== true) {
-      const body = buildCohereTextResponse(response.content);
+      const body = buildCohereTextResponse(response.content, response.reasoning, overrides);
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(body));
     } else {
-      const events = buildCohereTextStreamEvents(response.content, chunkSize);
+      const events = buildCohereTextStreamEvents(response.content, chunkSize, response.reasoning);
       const interruption = createInterruptionSignal(fixture);
       const completed = await writeCohereSSEStream(res, events, {
         latency,
@@ -824,6 +964,7 @@ export async function handleCohere(
 
   // Tool call response
   if (isToolCallResponse(response)) {
+    const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: req.url ?? "/v2/chat",
@@ -832,7 +973,7 @@ export async function handleCohere(
       response: { status: 200, fixture },
     });
     if (cohereReq.stream !== true) {
-      const body = buildCohereToolCallResponse(response.toolCalls, logger);
+      const body = buildCohereToolCallResponse(response.toolCalls, logger, overrides);
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(body));
     } else {

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -77,6 +77,28 @@ export async function handleEmbeddings(
     return;
   }
 
+  // Validate required input parameter
+  if (embeddingReq.input === undefined || embeddingReq.input === null) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? "/v1/embeddings",
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 400, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: {
+          message: "Missing required parameter: 'input'",
+          type: "invalid_request_error",
+        },
+      }),
+    );
+    return;
+  }
+
   // Normalize input to array of strings
   const inputs: string[] = Array.isArray(embeddingReq.input)
     ? embeddingReq.input

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,5 +1,5 @@
 /**
- * OpenAI Embeddings API support for LLMock.
+ * OpenAI Embeddings API support for aimock.
  *
  * Handles POST /v1/embeddings requests. Matches fixtures using the `inputText`
  * field, and falls back to generating a deterministic embedding from the input

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -7,7 +7,12 @@
  */
 
 import type * as http from "node:http";
-import type { ChatCompletionRequest, Fixture, HandlerDefaults } from "./types.js";
+import type {
+  ChatCompletionRequest,
+  Fixture,
+  HandlerDefaults,
+  RecordProviderKey,
+} from "./types.js";
 import {
   isEmbeddingResponse,
   isErrorResponse,
@@ -42,6 +47,7 @@ export async function handleEmbeddings(
   journal: Journal,
   defaults: HandlerDefaults,
   setCorsHeaders: (res: http.ServerResponse) => void,
+  providerKey: RecordProviderKey = "openai",
 ): Promise<void> {
   const { logger } = defaults;
   setCorsHeaders(res);
@@ -180,7 +186,7 @@ export async function handleEmbeddings(
       req,
       res,
       syntheticReq,
-      "openai",
+      providerKey,
       req.url ?? "/v1/embeddings",
       fixtures,
       defaults,
@@ -192,7 +198,7 @@ export async function handleEmbeddings(
         path: req.url ?? "/v1/embeddings",
         headers: flattenHeaders(req.headers),
         body: syntheticReq,
-        response: { status: res.statusCode ?? 200, fixture: null },
+        response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
       });
       return;
     }

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -99,7 +99,7 @@ export function geminiToCompletionRequest(
       if (role === "user") {
         // Check for functionResponse parts
         const funcResponses = content.parts.filter((p) => p.functionResponse);
-        const textParts = content.parts.filter((p) => p.text !== undefined);
+        const textParts = content.parts.filter((p) => p.text !== undefined && !p.thought);
 
         if (funcResponses.length > 0) {
           // functionResponse → tool message
@@ -129,7 +129,7 @@ export function geminiToCompletionRequest(
       } else if (role === "model") {
         // Check for functionCall parts
         const funcCalls = content.parts.filter((p) => p.functionCall);
-        const textParts = content.parts.filter((p) => p.text !== undefined);
+        const textParts = content.parts.filter((p) => p.text !== undefined && !p.thought);
 
         if (funcCalls.length > 0) {
           messages.push({
@@ -586,7 +586,7 @@ export async function handleGemini(
           path,
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -93,6 +93,7 @@ export function geminiToCompletionRequest(
   }
 
   if (req.contents) {
+    let callCounter = 0;
     for (const content of req.contents) {
       const role = content.role ?? "user";
 
@@ -103,15 +104,14 @@ export function geminiToCompletionRequest(
 
         if (funcResponses.length > 0) {
           // functionResponse → tool message
-          for (let i = 0; i < funcResponses.length; i++) {
-            const part = funcResponses[i];
+          for (const part of funcResponses) {
             messages.push({
               role: "tool",
               content:
                 typeof part.functionResponse!.response === "string"
                   ? part.functionResponse!.response
                   : JSON.stringify(part.functionResponse!.response),
-              tool_call_id: `call_gemini_${part.functionResponse!.name}_${i}`,
+              tool_call_id: `call_gemini_${part.functionResponse!.name}_${callCounter++}`,
             });
           }
           // Any text parts alongside → user message
@@ -136,8 +136,8 @@ export function geminiToCompletionRequest(
           messages.push({
             role: "assistant",
             content: text || null,
-            tool_calls: funcCalls.map((fc, i) => ({
-              id: `call_gemini_${fc.functionCall!.name}_${i}`,
+            tool_calls: funcCalls.map((fc) => ({
+              id: `call_gemini_${fc.functionCall!.name}_${callCounter++}`,
               type: "function" as const,
               function: {
                 name: fc.functionCall!.name,
@@ -150,6 +150,9 @@ export function geminiToCompletionRequest(
           messages.push({ role: "assistant", content: text });
         }
       }
+      // Unrecognized roles (not "user" or "model") are silently dropped.
+      // Gemini only defines "user" and "model"; any other value indicates
+      // a malformed request or an unsupported future role.
     }
   }
 

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -132,15 +132,16 @@ export function geminiToCompletionRequest(
         const textParts = content.parts.filter((p) => p.text !== undefined && !p.thought);
 
         if (funcCalls.length > 0) {
+          const text = textParts.map((p) => p.text!).join("");
           messages.push({
             role: "assistant",
-            content: null,
-            tool_calls: funcCalls.map((p, i) => ({
-              id: `call_gemini_${p.functionCall!.name}_${i}`,
+            content: text || null,
+            tool_calls: funcCalls.map((fc, i) => ({
+              id: `call_gemini_${fc.functionCall!.name}_${i}`,
               type: "function" as const,
               function: {
-                name: p.functionCall!.name,
-                arguments: JSON.stringify(p.functionCall!.args),
+                name: fc.functionCall!.name,
+                arguments: JSON.stringify(fc.functionCall!.args ?? {}),
               },
             })),
           });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -554,6 +554,15 @@ export function readBody(req: http.IncomingMessage): Promise<string> {
 
 // ─── Pattern matching ─────────────────────────────────────────────────────
 
+/**
+ * Case-insensitive substring/regex match used for search, rerank, and
+ * moderation endpoints where exact casing rarely matters. String patterns
+ * are lowercased on both sides before comparison.
+ *
+ * Note: This intentionally differs from the case-sensitive matching in
+ * {@link matchFixture} (router.ts), where fixture authors expect exact
+ * string matching against chat completion user messages.
+ */
 export function matchesPattern(text: string, pattern: string | RegExp): boolean {
   if (typeof pattern === "string") {
     return text.toLowerCase().includes(pattern.toLowerCase());

--- a/src/images.ts
+++ b/src/images.ts
@@ -122,7 +122,7 @@ export async function handleImages(
           path,
           headers: flattenHeaders(req.headers),
           body: syntheticReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }

--- a/src/images.ts
+++ b/src/images.ts
@@ -77,6 +77,24 @@ export async function handleImages(
     return;
   }
 
+  if (!prompt) {
+    journal.add({
+      method,
+      path,
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 400, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: { message: "Missing required parameter: 'prompt'", type: "invalid_request_error" },
+      }),
+    );
+    return;
+  }
+
   const syntheticReq = buildSyntheticRequest(model, prompt);
   const testId = getTestId(req);
   const fixture = matchFixture(

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,12 @@ export { Journal, DEFAULT_TEST_ID } from "./journal.js";
 export { matchFixture, getTextContent } from "./router.js";
 
 // Provider handlers
-export { handleResponses, buildTextStreamEvents, buildToolCallStreamEvents } from "./responses.js";
+export {
+  handleResponses,
+  buildTextStreamEvents,
+  buildToolCallStreamEvents,
+  buildContentWithToolCallsStreamEvents,
+} from "./responses.js";
 export type { ResponsesSSEEvent } from "./responses.js";
 export { handleMessages } from "./messages.js";
 export { handleGemini } from "./gemini.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,8 +78,7 @@ export { handleWebSocketGeminiLive } from "./ws-gemini-live.js";
 export { handleImages } from "./images.js";
 export { handleSpeech } from "./speech.js";
 export { handleTranscription } from "./transcription.js";
-export { handleVideoCreate, handleVideoStatus } from "./video.js";
-export type { VideoStateMap } from "./video.js";
+export { handleVideoCreate, handleVideoStatus, VideoStateMap } from "./video.js";
 
 // Helpers
 export {

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -52,6 +52,8 @@ export interface AimockHandle {
  */
 export function useAimock(options: UseAimockOptions = {}): () => AimockHandle {
   let handle: AimockHandle | null = null;
+  let origOpenaiUrl: string | undefined;
+  let origAnthropicUrl: string | undefined;
 
   beforeAll(async () => {
     const { fixtures: fixturePath, patchEnv, ...serverOpts } = options;
@@ -68,6 +70,8 @@ export function useAimock(options: UseAimockOptions = {}): () => AimockHandle {
     const url = await llm.start();
 
     if (patchEnv !== false) {
+      origOpenaiUrl = process.env.OPENAI_BASE_URL;
+      origAnthropicUrl = process.env.ANTHROPIC_BASE_URL;
       process.env.OPENAI_BASE_URL = `${url}/v1`;
       process.env.ANTHROPIC_BASE_URL = `${url}/v1`;
     }
@@ -84,8 +88,10 @@ export function useAimock(options: UseAimockOptions = {}): () => AimockHandle {
   afterAll(async () => {
     if (handle) {
       if (options.patchEnv !== false) {
-        delete process.env.OPENAI_BASE_URL;
-        delete process.env.ANTHROPIC_BASE_URL;
+        if (origOpenaiUrl !== undefined) process.env.OPENAI_BASE_URL = origOpenaiUrl;
+        else delete process.env.OPENAI_BASE_URL;
+        if (origAnthropicUrl !== undefined) process.env.ANTHROPIC_BASE_URL = origAnthropicUrl;
+        else delete process.env.ANTHROPIC_BASE_URL;
       }
       await handle.llm.stop();
       handle = null;

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -107,7 +107,10 @@ function loadFixtures(fixturePath: string): Fixture[] {
       return loadFixturesFromDir(fixturePath);
     }
     return loadFixtureFile(fixturePath);
-  } catch {
+  } catch (err) {
+    console.warn(
+      `[aimock] Failed to load fixtures from ${fixturePath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return [];
   }
 }

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -25,7 +25,8 @@ function matchCriteriaEqual(a: FixtureMatch, b: FixtureMatch): boolean {
     fieldEqual(a.toolName, b.toolName) &&
     fieldEqual(a.model, b.model) &&
     fieldEqual(a.responseFormat, b.responseFormat) &&
-    fieldEqual(a.predicate, b.predicate)
+    fieldEqual(a.predicate, b.predicate) &&
+    fieldEqual(a.endpoint, b.endpoint)
   );
 }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -776,7 +776,7 @@ export async function handleMessages(
           path: req.url ?? "/v1/messages",
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -892,7 +892,7 @@ export async function handleMessages(
   // Text response
   if (isTextResponse(response)) {
     if (response.webSearches?.length) {
-      defaults.logger.warn(
+      logger.warn(
         "webSearches in fixture response are not supported for Claude Messages API — ignoring",
       );
     }

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -24,6 +24,7 @@ import type {
 import {
   isTextResponse,
   isToolCallResponse,
+  isContentWithToolCallsResponse,
   isErrorResponse,
   flattenHeaders,
   getTestId,
@@ -261,6 +262,103 @@ function buildOllamaChatToolCallResponse(
   };
 }
 
+// ─── Response builders: /api/chat — content + tool calls ────────────────────
+
+function buildOllamaChatContentWithToolCallsChunks(
+  content: string,
+  toolCalls: ToolCall[],
+  model: string,
+  chunkSize: number,
+  logger: Logger,
+): object[] {
+  const chunks: object[] = [];
+
+  // Content chunks first
+  for (let i = 0; i < content.length; i += chunkSize) {
+    const slice = content.slice(i, i + chunkSize);
+    chunks.push({
+      model,
+      message: { role: "assistant", content: slice },
+      done: false,
+    });
+  }
+
+  // Tool calls in a single chunk (same as tool-call-only path)
+  const ollamaToolCalls = toolCalls.map((tc) => {
+    let argsObj: unknown;
+    try {
+      argsObj = JSON.parse(tc.arguments || "{}");
+    } catch {
+      logger.warn(
+        `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+      );
+      argsObj = {};
+    }
+    return {
+      function: {
+        name: tc.name,
+        arguments: argsObj,
+      },
+    };
+  });
+
+  chunks.push({
+    model,
+    message: {
+      role: "assistant",
+      content: "",
+      tool_calls: ollamaToolCalls,
+    },
+    done: false,
+  });
+
+  // Final chunk
+  chunks.push({
+    model,
+    message: { role: "assistant", content: "" },
+    done: true,
+    ...DURATION_FIELDS,
+  });
+
+  return chunks;
+}
+
+function buildOllamaChatContentWithToolCallsResponse(
+  content: string,
+  toolCalls: ToolCall[],
+  model: string,
+  logger: Logger,
+): object {
+  const ollamaToolCalls = toolCalls.map((tc) => {
+    let argsObj: unknown;
+    try {
+      argsObj = JSON.parse(tc.arguments || "{}");
+    } catch {
+      logger.warn(
+        `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+      );
+      argsObj = {};
+    }
+    return {
+      function: {
+        name: tc.name,
+        arguments: argsObj,
+      },
+    };
+  });
+
+  return {
+    model,
+    message: {
+      role: "assistant",
+      content,
+      tool_calls: ollamaToolCalls,
+    },
+    done: true,
+    ...DURATION_FIELDS,
+  };
+}
+
 // ─── Response builders: /api/generate ────────────────────────────────────────
 
 function buildOllamaGenerateTextChunks(
@@ -439,7 +537,7 @@ export async function handleOllama(
           path: urlPath,
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }
@@ -489,6 +587,49 @@ export async function handleOllama(
       response: { status, fixture },
     });
     writeErrorResponse(res, status, JSON.stringify(response));
+    return;
+  }
+
+  // Content + tool calls response (must be checked before text/tool-only branches)
+  if (isContentWithToolCallsResponse(response)) {
+    const journalEntry = journal.add({
+      method: req.method ?? "POST",
+      path: urlPath,
+      headers: flattenHeaders(req.headers),
+      body: completionReq,
+      response: { status: 200, fixture },
+    });
+    if (!streaming) {
+      const body = buildOllamaChatContentWithToolCallsResponse(
+        response.content,
+        response.toolCalls,
+        completionReq.model,
+        logger,
+      );
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body));
+    } else {
+      const chunks = buildOllamaChatContentWithToolCallsChunks(
+        response.content,
+        response.toolCalls,
+        completionReq.model,
+        chunkSize,
+        logger,
+      );
+      const interruption = createInterruptionSignal(fixture);
+      const completed = await writeNDJSONStream(res, chunks, {
+        latency,
+        streamingProfile: fixture.streamingProfile,
+        signal: interruption?.signal,
+        onChunkSent: interruption?.tick,
+      });
+      if (!completed) {
+        if (!res.writableEnded) res.destroy();
+        journalEntry.response.interrupted = true;
+        journalEntry.response.interruptReason = interruption?.reason();
+      }
+      interruption?.cleanup();
+    }
     return;
   }
 
@@ -698,7 +839,7 @@ export async function handleOllamaGenerate(
           path: urlPath,
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }
@@ -792,7 +933,29 @@ export async function handleOllamaGenerate(
     return;
   }
 
-  // Tool call responses not supported for /api/generate — fall through to error
+  // Tool call fixtures matched but not supported on /api/generate
+  if (isToolCallResponse(response) || isContentWithToolCallsResponse(response)) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: urlPath,
+      headers: flattenHeaders(req.headers),
+      body: completionReq,
+      response: { status: 400, fixture },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: {
+          message: "Tool call fixtures are not supported on /api/generate — use /api/chat instead",
+          type: "invalid_request_error",
+        },
+      }),
+    );
+    return;
+  }
+
+  // Unknown response type
   journal.add({
     method: req.method ?? "POST",
     path: urlPath,

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -109,7 +109,7 @@ export function ollamaToCompletionRequest(req: OllamaRequest): ChatCompletionReq
   return {
     model: req.model,
     messages,
-    stream: req.stream,
+    stream: req.stream ?? true,
     temperature: req.options?.temperature,
     max_tokens: req.options?.num_predict,
     tools,
@@ -120,7 +120,7 @@ function ollamaGenerateToCompletionRequest(req: OllamaGenerateRequest): ChatComp
   return {
     model: req.model,
     messages: [{ role: "user", content: req.prompt }],
-    stream: req.stream,
+    stream: req.stream ?? true,
     temperature: req.options?.temperature,
     max_tokens: req.options?.num_predict,
   };

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -537,6 +537,11 @@ function buildFixtureResponse(
       const hasToolCalls = Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
       const hasContent = typeof message.content === "string" && message.content.length > 0;
 
+      const openaiReasoning =
+        typeof message.reasoning_content === "string" && message.reasoning_content.length > 0
+          ? message.reasoning_content
+          : undefined;
+
       if (hasToolCalls) {
         const toolCalls: ToolCall[] = (message.tool_calls as Array<Record<string, unknown>>).map(
           (tc) => {
@@ -544,17 +549,25 @@ function buildFixtureResponse(
             return {
               name: String(fn.name),
               arguments: String(fn.arguments),
+              ...(tc.id ? { id: String(tc.id) } : {}),
             };
           },
         );
         if (hasContent) {
-          return { content: message.content as string, toolCalls };
+          return {
+            content: message.content as string,
+            toolCalls,
+            ...(openaiReasoning ? { reasoning: openaiReasoning } : {}),
+          };
         }
         return { toolCalls };
       }
       // Text content only
       if (hasContent) {
-        return { content: message.content as string };
+        return {
+          content: message.content as string,
+          ...(openaiReasoning ? { reasoning: openaiReasoning } : {}),
+        };
       }
     }
   }
@@ -564,21 +577,34 @@ function buildFixtureResponse(
     const blocks = obj.content as Array<Record<string, unknown>>;
     const toolUseBlocks = blocks.filter((b) => b.type === "tool_use");
     const textBlock = blocks.find((b) => b.type === "text");
+    const thinkingBlocks = blocks.filter((b) => b.type === "thinking");
     const hasToolCalls = toolUseBlocks.length > 0;
     const hasContent = textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0;
+    const anthropicReasoning =
+      thinkingBlocks.length > 0
+        ? thinkingBlocks.map((b) => String(b.thinking ?? "")).join("")
+        : undefined;
 
     if (hasToolCalls) {
       const toolCalls: ToolCall[] = toolUseBlocks.map((b) => ({
         name: String(b.name),
         arguments: typeof b.input === "string" ? b.input : JSON.stringify(b.input),
+        ...(b.id ? { id: String(b.id) } : {}),
       }));
       if (hasContent) {
-        return { content: textBlock.text as string, toolCalls };
+        return {
+          content: textBlock.text as string,
+          toolCalls,
+          ...(anthropicReasoning ? { reasoning: anthropicReasoning } : {}),
+        };
       }
       return { toolCalls };
     }
     if (hasContent) {
-      return { content: textBlock.text as string };
+      return {
+        content: textBlock.text as string,
+        ...(anthropicReasoning ? { reasoning: anthropicReasoning } : {}),
+      };
     }
   }
 
@@ -589,9 +615,14 @@ function buildFixtureResponse(
     if (content && Array.isArray(content.parts)) {
       const parts = content.parts as Array<Record<string, unknown>>;
       const fnCallParts = parts.filter((p) => p.functionCall);
-      const textPart = parts.find((p) => typeof p.text === "string");
+      const textPart = parts.find((p) => typeof p.text === "string" && !p.thought);
+      const thoughtParts = parts.filter((p) => p.thought === true && typeof p.text === "string");
       const hasToolCalls = fnCallParts.length > 0;
       const hasContent = textPart && typeof textPart.text === "string" && textPart.text.length > 0;
+      const geminiReasoning =
+        thoughtParts.length > 0
+          ? thoughtParts.map((p) => String(p.text ?? "")).join("")
+          : undefined;
 
       if (hasToolCalls) {
         const toolCalls: ToolCall[] = fnCallParts.map((p) => {
@@ -602,12 +633,19 @@ function buildFixtureResponse(
           };
         });
         if (hasContent) {
-          return { content: textPart.text as string, toolCalls };
+          return {
+            content: textPart.text as string,
+            toolCalls,
+            ...(geminiReasoning ? { reasoning: geminiReasoning } : {}),
+          };
         }
         return { toolCalls };
       }
       if (hasContent) {
-        return { content: textPart.text as string };
+        return {
+          content: textPart.text as string,
+          ...(geminiReasoning ? { reasoning: geminiReasoning } : {}),
+        };
       }
     }
   }
@@ -620,9 +658,20 @@ function buildFixtureResponse(
       const blocks = msg.content as Array<Record<string, unknown>>;
       const toolUseBlocks = blocks.filter((b) => b.toolUse);
       const textBlock = blocks.find((b) => typeof b.text === "string");
+      const reasoningBlocks = blocks.filter((b) => b.reasoningContent);
       const hasToolCalls = toolUseBlocks.length > 0;
       const hasContent =
         textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0;
+      const bedrockReasoning =
+        reasoningBlocks.length > 0
+          ? reasoningBlocks
+              .map((b) => {
+                const rc = b.reasoningContent as Record<string, unknown>;
+                const rt = rc?.reasoningText as Record<string, unknown> | undefined;
+                return String(rt?.text ?? "");
+              })
+              .join("")
+          : undefined;
 
       if (hasToolCalls) {
         const toolCalls: ToolCall[] = toolUseBlocks.map((b) => {
@@ -630,15 +679,23 @@ function buildFixtureResponse(
           return {
             name: String(tu.name ?? ""),
             arguments: typeof tu.input === "string" ? tu.input : JSON.stringify(tu.input),
+            ...(tu.toolUseId ? { id: String(tu.toolUseId) } : {}),
           };
         });
         if (hasContent) {
-          return { content: textBlock.text as string, toolCalls };
+          return {
+            content: textBlock.text as string,
+            toolCalls,
+            ...(bedrockReasoning ? { reasoning: bedrockReasoning } : {}),
+          };
         }
         return { toolCalls };
       }
       if (hasContent) {
-        return { content: textBlock.text as string };
+        return {
+          content: textBlock.text as string,
+          ...(bedrockReasoning ? { reasoning: bedrockReasoning } : {}),
+        };
       }
     }
   }
@@ -674,6 +731,7 @@ function buildFixtureResponse(
               : typeof (b.function as Record<string, unknown>)?.arguments === "string"
                 ? String((b.function as Record<string, unknown>).arguments)
                 : JSON.stringify((b.function as Record<string, unknown>)?.arguments),
+        ...(b.id ? { id: String(b.id) } : {}),
       }));
       if (hasContent) {
         return { content: textBlock.text as string, toolCalls };
@@ -693,6 +751,7 @@ function buildFixtureResponse(
                 : typeof fn?.arguments === "string"
                   ? String(fn.arguments)
                   : JSON.stringify(fn?.arguments),
+          ...(tc.id ? { id: String(tc.id) } : {}),
         };
       });
       if (hasContent) {

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -354,7 +354,7 @@ function makeUpstreamRequest(
           // Stop relaying if the client disconnects mid-stream
           clientRes.on("close", () => {
             clientDisconnected = true;
-            req.destroy();
+            req.destroy(new Error("Client disconnected"));
           });
         }
         const chunks: Buffer[] = [];
@@ -581,10 +581,11 @@ function buildFixtureResponse(
   if (Array.isArray(obj.content) && obj.content.length > 0) {
     const blocks = obj.content as Array<Record<string, unknown>>;
     const toolUseBlocks = blocks.filter((b) => b.type === "tool_use");
-    const textBlock = blocks.find((b) => b.type === "text");
+    const textBlocks = blocks.filter((b) => b.type === "text" && typeof b.text === "string");
     const thinkingBlocks = blocks.filter((b) => b.type === "thinking");
     const hasToolCalls = toolUseBlocks.length > 0;
-    const hasContent = textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0;
+    const joinedText = textBlocks.map((b) => String(b.text ?? "")).join("");
+    const hasContent = joinedText.length > 0;
     const anthropicReasoning =
       thinkingBlocks.length > 0
         ? thinkingBlocks.map((b) => String(b.thinking ?? "")).join("")
@@ -598,7 +599,7 @@ function buildFixtureResponse(
       }));
       if (hasContent) {
         return {
-          content: textBlock.text as string,
+          content: joinedText,
           toolCalls,
           ...(anthropicReasoning ? { reasoning: anthropicReasoning } : {}),
         };
@@ -607,9 +608,13 @@ function buildFixtureResponse(
     }
     if (hasContent) {
       return {
-        content: textBlock.text as string,
+        content: joinedText,
         ...(anthropicReasoning ? { reasoning: anthropicReasoning } : {}),
       };
+    }
+    // Thinking-only response (no text, no tool calls)
+    if (anthropicReasoning) {
+      return { content: "", reasoning: anthropicReasoning };
     }
   }
 
@@ -620,10 +625,11 @@ function buildFixtureResponse(
     if (content && Array.isArray(content.parts)) {
       const parts = content.parts as Array<Record<string, unknown>>;
       const fnCallParts = parts.filter((p) => p.functionCall);
-      const textPart = parts.find((p) => typeof p.text === "string" && !p.thought);
+      const textParts = parts.filter((p) => typeof p.text === "string" && !p.thought);
       const thoughtParts = parts.filter((p) => p.thought === true && typeof p.text === "string");
       const hasToolCalls = fnCallParts.length > 0;
-      const hasContent = textPart && typeof textPart.text === "string" && textPart.text.length > 0;
+      const joinedText = textParts.map((p) => String(p.text ?? "")).join("");
+      const hasContent = joinedText.length > 0;
       const geminiReasoning =
         thoughtParts.length > 0
           ? thoughtParts.map((p) => String(p.text ?? "")).join("")
@@ -639,7 +645,7 @@ function buildFixtureResponse(
         });
         if (hasContent) {
           return {
-            content: textPart.text as string,
+            content: joinedText,
             toolCalls,
             ...(geminiReasoning ? { reasoning: geminiReasoning } : {}),
           };
@@ -648,7 +654,7 @@ function buildFixtureResponse(
       }
       if (hasContent) {
         return {
-          content: textPart.text as string,
+          content: joinedText,
           ...(geminiReasoning ? { reasoning: geminiReasoning } : {}),
         };
       }
@@ -662,11 +668,11 @@ function buildFixtureResponse(
     if (msg && Array.isArray(msg.content)) {
       const blocks = msg.content as Array<Record<string, unknown>>;
       const toolUseBlocks = blocks.filter((b) => b.toolUse);
-      const textBlock = blocks.find((b) => typeof b.text === "string");
+      const textBlocks = blocks.filter((b) => typeof b.text === "string");
       const reasoningBlocks = blocks.filter((b) => b.reasoningContent);
       const hasToolCalls = toolUseBlocks.length > 0;
-      const hasContent =
-        textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0;
+      const joinedText = textBlocks.map((b) => String(b.text ?? "")).join("");
+      const hasContent = joinedText.length > 0;
       const bedrockReasoning =
         reasoningBlocks.length > 0
           ? reasoningBlocks
@@ -689,7 +695,7 @@ function buildFixtureResponse(
         });
         if (hasContent) {
           return {
-            content: textBlock.text as string,
+            content: joinedText,
             toolCalls,
             ...(bedrockReasoning ? { reasoning: bedrockReasoning } : {}),
           };
@@ -698,7 +704,7 @@ function buildFixtureResponse(
       }
       if (hasContent) {
         return {
-          content: textBlock.text as string,
+          content: joinedText,
           ...(bedrockReasoning ? { reasoning: bedrockReasoning } : {}),
         };
       }

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -116,12 +116,17 @@ export async function proxyAndRecord(
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Unknown proxy error";
     defaults.logger.error(`Proxy request failed: ${msg}`);
-    res.writeHead(502, { "Content-Type": "application/json" });
-    res.end(
-      JSON.stringify({
-        error: { message: `Proxy to upstream failed: ${msg}`, type: "proxy_error" },
-      }),
-    );
+    if (!res.headersSent) {
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: { message: `Proxy to upstream failed: ${msg}`, type: "proxy_error" },
+        }),
+      );
+    } else {
+      // SSE headers already sent — gracefully close the connection
+      res.end();
+    }
     return true;
   }
 
@@ -166,11 +171,11 @@ export async function proxyAndRecord(
     }
     if (collapsed.toolCalls && collapsed.toolCalls.length > 0) {
       if (collapsed.content) {
-        defaults.logger.warn(
-          "Collapsed response has both content and toolCalls — preferring toolCalls",
-        );
+        // Both content and toolCalls present — save as ContentWithToolCallsResponse
+        fixtureResponse = { content: collapsed.content, toolCalls: collapsed.toolCalls };
+      } else {
+        fixtureResponse = { toolCalls: collapsed.toolCalls };
       }
-      fixtureResponse = { toolCalls: collapsed.toolCalls };
     } else {
       fixtureResponse = { content: collapsed.content ?? "" };
     }
@@ -186,10 +191,17 @@ export async function proxyAndRecord(
     let encodingFormat: string | undefined;
     try {
       encodingFormat = rawBody ? JSON.parse(rawBody).encoding_format : undefined;
-    } catch {
-      /* not JSON */
+    } catch (err) {
+      defaults.logger.debug(
+        `Could not parse encoding_format from raw body: ${err instanceof Error ? err.message : "unknown error"}`,
+      );
     }
-    fixtureResponse = buildFixtureResponse(parsedResponse, upstreamStatus, encodingFormat);
+    fixtureResponse = buildFixtureResponse(
+      parsedResponse,
+      upstreamStatus,
+      encodingFormat,
+      defaults.logger,
+    );
   }
 
   // Build the match criteria from the (optionally transformed) request
@@ -238,7 +250,11 @@ export async function proxyAndRecord(
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Unknown filesystem error";
       defaults.logger.error(`Failed to save fixture to disk: ${msg}`);
-      res.setHeader("X-LLMock-Record-Error", msg);
+      if (!res.headersSent) {
+        res.setHeader("X-LLMock-Record-Error", msg);
+      } else {
+        defaults.logger.warn(`Cannot set X-LLMock-Record-Error header — headers already sent`);
+      }
     }
 
     if (writtenToDisk) {
@@ -263,7 +279,8 @@ export async function proxyAndRecord(
       relayHeaders["Content-Type"] = ctString;
     }
     res.writeHead(upstreamStatus, relayHeaders);
-    res.end(isBinaryStream ? rawBuffer : upstreamBody);
+    const isAudioRelay = ctString.toLowerCase().startsWith("audio/");
+    res.end(isBinaryStream || isAudioRelay ? rawBuffer : upstreamBody);
   }
 
   return true;
@@ -312,6 +329,7 @@ function makeUpstreamRequest(
         const ctStr = Array.isArray(ct) ? ct.join(", ") : (ct ?? "");
         const isSSE = ctStr.toLowerCase().includes("text/event-stream");
         let streamedToClient = false;
+        let clientDisconnected = false;
         if (isSSE && clientRes && !clientRes.headersSent) {
           const relayHeaders: Record<string, string> = {};
           if (ctStr) relayHeaders["Content-Type"] = ctStr;
@@ -320,16 +338,37 @@ function makeUpstreamRequest(
           // before the first data chunk arrives.
           if (typeof clientRes.flushHeaders === "function") clientRes.flushHeaders();
           streamedToClient = true;
+          // Stop relaying if the client disconnects mid-stream
+          clientRes.on("close", () => {
+            clientDisconnected = true;
+            req.destroy();
+          });
         }
         const chunks: Buffer[] = [];
         res.on("data", (chunk: Buffer) => {
           chunks.push(chunk);
-          if (streamedToClient) clientRes!.write(chunk);
+          if (
+            streamedToClient &&
+            clientRes &&
+            !clientDisconnected &&
+            !clientRes.destroyed &&
+            !clientRes.writableEnded
+          ) {
+            clientRes.write(chunk);
+          }
         });
         res.on("error", reject);
         res.on("end", () => {
           const rawBuffer = Buffer.concat(chunks);
-          if (streamedToClient) clientRes!.end();
+          if (
+            streamedToClient &&
+            clientRes &&
+            !clientDisconnected &&
+            !clientRes.destroyed &&
+            !clientRes.writableEnded
+          ) {
+            clientRes.end();
+          }
           resolve({
             status: res.statusCode ?? 500,
             headers: res.headers,
@@ -361,6 +400,7 @@ function buildFixtureResponse(
   parsed: unknown,
   status: number,
   encodingFormat?: string,
+  logger?: Logger,
 ): FixtureResponse {
   if (parsed === null || parsed === undefined) {
     // Raw / unparseable response — save as error
@@ -396,8 +436,12 @@ function buildFixtureResponse(
         const buf = Buffer.from(first.embedding, "base64");
         const floats = new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4);
         return { embedding: Array.from(floats) };
-      } catch {
-        // Corrupted base64 or non-float32 data — fall through to error
+      } catch (err) {
+        // Corrupted base64 or non-float32 data — may be caused by
+        // Buffer pool byte-offset misalignment with Float32Array.
+        logger?.warn(
+          `Failed to decode base64 embedding (possible byte-alignment issue): ${err instanceof Error ? err.message : "unknown error"}`,
+        );
       }
     }
     // OpenAI image generation: { created, data: [{ url, b64_json, revised_prompt }] }
@@ -475,8 +519,10 @@ function buildFixtureResponse(
     const choice = obj.choices[0] as Record<string, unknown>;
     const message = choice.message as Record<string, unknown> | undefined;
     if (message) {
-      // Tool calls
-      if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+      const hasToolCalls = Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
+      const hasContent = typeof message.content === "string" && message.content.length > 0;
+
+      if (hasToolCalls) {
         const toolCalls: ToolCall[] = (message.tool_calls as Array<Record<string, unknown>>).map(
           (tc) => {
             const fn = tc.function as Record<string, unknown>;
@@ -486,11 +532,14 @@ function buildFixtureResponse(
             };
           },
         );
+        if (hasContent) {
+          return { content: message.content as string, toolCalls };
+        }
         return { toolCalls };
       }
-      // Text content
-      if (typeof message.content === "string") {
-        return { content: message.content };
+      // Text content only
+      if (hasContent) {
+        return { content: message.content as string };
       }
     }
   }
@@ -498,19 +547,23 @@ function buildFixtureResponse(
   // Anthropic: { content: [{ type: "text", text: "..." }] } or tool_use
   if (Array.isArray(obj.content) && obj.content.length > 0) {
     const blocks = obj.content as Array<Record<string, unknown>>;
-    // Check for tool_use blocks first
     const toolUseBlocks = blocks.filter((b) => b.type === "tool_use");
-    if (toolUseBlocks.length > 0) {
+    const textBlock = blocks.find((b) => b.type === "text");
+    const hasToolCalls = toolUseBlocks.length > 0;
+    const hasContent = textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0;
+
+    if (hasToolCalls) {
       const toolCalls: ToolCall[] = toolUseBlocks.map((b) => ({
         name: String(b.name),
         arguments: typeof b.input === "string" ? b.input : JSON.stringify(b.input),
       }));
+      if (hasContent) {
+        return { content: textBlock.text as string, toolCalls };
+      }
       return { toolCalls };
     }
-    // Text blocks
-    const textBlock = blocks.find((b) => b.type === "text");
-    if (textBlock && typeof textBlock.text === "string") {
-      return { content: textBlock.text };
+    if (hasContent) {
+      return { content: textBlock.text as string };
     }
   }
 
@@ -520,9 +573,12 @@ function buildFixtureResponse(
     const content = candidate.content as Record<string, unknown> | undefined;
     if (content && Array.isArray(content.parts)) {
       const parts = content.parts as Array<Record<string, unknown>>;
-      // Tool calls (functionCall)
       const fnCallParts = parts.filter((p) => p.functionCall);
-      if (fnCallParts.length > 0) {
+      const textPart = parts.find((p) => typeof p.text === "string");
+      const hasToolCalls = fnCallParts.length > 0;
+      const hasContent = textPart && typeof textPart.text === "string" && textPart.text.length > 0;
+
+      if (hasToolCalls) {
         const toolCalls: ToolCall[] = fnCallParts.map((p) => {
           const fc = p.functionCall as Record<string, unknown>;
           return {
@@ -530,12 +586,13 @@ function buildFixtureResponse(
             arguments: typeof fc.args === "string" ? fc.args : JSON.stringify(fc.args),
           };
         });
+        if (hasContent) {
+          return { content: textPart.text as string, toolCalls };
+        }
         return { toolCalls };
       }
-      // Text
-      const textPart = parts.find((p) => typeof p.text === "string");
-      if (textPart && typeof textPart.text === "string") {
-        return { content: textPart.text };
+      if (hasContent) {
+        return { content: textPart.text as string };
       }
     }
   }
@@ -547,7 +604,12 @@ function buildFixtureResponse(
     if (msg && Array.isArray(msg.content)) {
       const blocks = msg.content as Array<Record<string, unknown>>;
       const toolUseBlocks = blocks.filter((b) => b.toolUse);
-      if (toolUseBlocks.length > 0) {
+      const textBlock = blocks.find((b) => typeof b.text === "string");
+      const hasToolCalls = toolUseBlocks.length > 0;
+      const hasContent =
+        textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0;
+
+      if (hasToolCalls) {
         const toolCalls: ToolCall[] = toolUseBlocks.map((b) => {
           const tu = b.toolUse as Record<string, unknown>;
           return {
@@ -555,11 +617,13 @@ function buildFixtureResponse(
             arguments: typeof tu.input === "string" ? tu.input : JSON.stringify(tu.input),
           };
         });
+        if (hasContent) {
+          return { content: textBlock.text as string, toolCalls };
+        }
         return { toolCalls };
       }
-      const textBlock = blocks.find((b) => typeof b.text === "string");
-      if (textBlock && typeof textBlock.text === "string") {
-        return { content: textBlock.text };
+      if (hasContent) {
+        return { content: textBlock.text as string };
       }
     }
   }
@@ -567,8 +631,10 @@ function buildFixtureResponse(
   // Ollama: { message: { content: "...", tool_calls: [...] } }
   if (obj.message && typeof obj.message === "object") {
     const msg = obj.message as Record<string, unknown>;
-    // Tool calls (check before content — Ollama sends content: "" alongside tool_calls)
-    if (Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+    const hasOllamaToolCalls = Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0;
+    const hasOllamaContent = typeof msg.content === "string" && msg.content.length > 0;
+
+    if (hasOllamaToolCalls) {
       const toolCalls: ToolCall[] = (msg.tool_calls as Array<Record<string, unknown>>)
         .filter((tc) => tc.function != null)
         .map((tc) => {
@@ -579,10 +645,13 @@ function buildFixtureResponse(
               typeof fn.arguments === "string" ? fn.arguments : JSON.stringify(fn.arguments),
           };
         });
+      if (hasOllamaContent) {
+        return { content: msg.content as string, toolCalls };
+      }
       return { toolCalls };
     }
-    if (typeof msg.content === "string" && msg.content.length > 0) {
-      return { content: msg.content };
+    if (hasOllamaContent) {
+      return { content: msg.content as string };
     }
     // Ollama message with content array (like Cohere)
     if (Array.isArray(msg.content) && msg.content.length > 0) {

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -420,8 +420,13 @@ function buildFixtureResponse(
 
   const obj = parsed as Record<string, unknown>;
 
-  // Error response
-  if (obj.error) {
+  // Error response — only match the actual { error: { message: "..." } } shape
+  // used by OpenAI/Anthropic/etc., not arbitrary truthy `.error` fields.
+  if (
+    typeof obj.error === "object" &&
+    obj.error !== null &&
+    typeof (obj.error as Record<string, unknown>).message === "string"
+  ) {
     const err = obj.error as Record<string, unknown>;
     return {
       error: {
@@ -488,10 +493,19 @@ function buildFixtureResponse(
   }
 
   // OpenAI video generation: { id, status, ... }
+  // Guard against false positives: many API responses have `id` + `status` fields
+  // (e.g. chat completions, Anthropic messages). Reject if the response has fields
+  // that indicate a known non-video format.
   if (
     typeof obj.id === "string" &&
     typeof obj.status === "string" &&
-    (obj.status === "completed" || obj.status === "in_progress" || obj.status === "failed")
+    (obj.status === "completed" || obj.status === "in_progress" || obj.status === "failed") &&
+    !("choices" in obj) &&
+    !("content" in obj) &&
+    !("candidates" in obj) &&
+    !("message" in obj) &&
+    !("data" in obj) &&
+    !("object" in obj)
   ) {
     if (obj.status === "completed" && obj.url) {
       return {
@@ -626,6 +640,42 @@ function buildFixtureResponse(
       if (hasContent) {
         return { content: textBlock.text as string };
       }
+    }
+  }
+
+  // Cohere v2 chat: { finish_reason: "...", message: { content: [{ type: "text", text: "..." }] } }
+  // Must come before Ollama since both have `message`, but Cohere has `finish_reason` at top level
+  // (not nested in `choices`) and `message.content` as an array of typed objects.
+  if (
+    typeof obj.finish_reason === "string" &&
+    obj.message &&
+    typeof obj.message === "object" &&
+    Array.isArray((obj.message as Record<string, unknown>).content)
+  ) {
+    const msg = obj.message as Record<string, unknown>;
+    const contentBlocks = msg.content as Array<Record<string, unknown>>;
+    const textBlock = contentBlocks.find((b) => b.type === "text" && typeof b.text === "string");
+    const toolCallBlocks = contentBlocks.filter((b) => b.type === "tool_call");
+
+    if (toolCallBlocks.length > 0) {
+      const toolCalls: ToolCall[] = toolCallBlocks.map((b) => ({
+        name: String(b.name ?? (b.function as Record<string, unknown>)?.name ?? ""),
+        arguments:
+          typeof b.parameters === "string"
+            ? b.parameters
+            : typeof b.parameters === "object"
+              ? JSON.stringify(b.parameters)
+              : typeof (b.function as Record<string, unknown>)?.arguments === "string"
+                ? String((b.function as Record<string, unknown>).arguments)
+                : JSON.stringify((b.function as Record<string, unknown>)?.arguments),
+      }));
+      if (textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0) {
+        return { content: textBlock.text as string, toolCalls };
+      }
+      return { toolCalls };
+    }
+    if (textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0) {
+      return { content: textBlock.text as string };
     }
   }
 

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -171,15 +171,20 @@ export async function proxyAndRecord(
     if (collapsed.content === "" && (!collapsed.toolCalls || collapsed.toolCalls.length === 0)) {
       defaults.logger.warn("Stream collapse produced empty content — fixture may be incomplete");
     }
+    const reasoningSpread = collapsed.reasoning ? { reasoning: collapsed.reasoning } : {};
     if (collapsed.toolCalls && collapsed.toolCalls.length > 0) {
       if (collapsed.content) {
         // Both content and toolCalls present — save as ContentWithToolCallsResponse
-        fixtureResponse = { content: collapsed.content, toolCalls: collapsed.toolCalls };
+        fixtureResponse = {
+          content: collapsed.content,
+          toolCalls: collapsed.toolCalls,
+          ...reasoningSpread,
+        };
       } else {
-        fixtureResponse = { toolCalls: collapsed.toolCalls };
+        fixtureResponse = { toolCalls: collapsed.toolCalls, ...reasoningSpread };
       }
     } else {
-      fixtureResponse = { content: collapsed.content ?? "" };
+      fixtureResponse = { content: collapsed.content ?? "", ...reasoningSpread };
     }
   } else {
     // Non-streaming — try to parse as JSON
@@ -560,7 +565,7 @@ function buildFixtureResponse(
             ...(openaiReasoning ? { reasoning: openaiReasoning } : {}),
           };
         }
-        return { toolCalls };
+        return { toolCalls, ...(openaiReasoning ? { reasoning: openaiReasoning } : {}) };
       }
       // Text content only
       if (hasContent) {
@@ -598,7 +603,7 @@ function buildFixtureResponse(
           ...(anthropicReasoning ? { reasoning: anthropicReasoning } : {}),
         };
       }
-      return { toolCalls };
+      return { toolCalls, ...(anthropicReasoning ? { reasoning: anthropicReasoning } : {}) };
     }
     if (hasContent) {
       return {
@@ -639,7 +644,7 @@ function buildFixtureResponse(
             ...(geminiReasoning ? { reasoning: geminiReasoning } : {}),
           };
         }
-        return { toolCalls };
+        return { toolCalls, ...(geminiReasoning ? { reasoning: geminiReasoning } : {}) };
       }
       if (hasContent) {
         return {
@@ -689,7 +694,7 @@ function buildFixtureResponse(
             ...(bedrockReasoning ? { reasoning: bedrockReasoning } : {}),
           };
         }
-        return { toolCalls };
+        return { toolCalls, ...(bedrockReasoning ? { reasoning: bedrockReasoning } : {}) };
       }
       if (hasContent) {
         return {

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -739,6 +739,11 @@ function buildFixtureResponse(
     }
   }
 
+  // Ollama /api/generate: { response: "...", done: true/false }
+  if (typeof obj.response === "string" && "done" in obj) {
+    return { content: obj.response };
+  }
+
   // Fallback: unknown format — save as error
   return {
     error: {

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -106,6 +106,7 @@ export async function proxyAndRecord(
   // Track whether we streamed SSE progressively to the client; if so,
   // skip the final res.writeHead/res.end relay at the bottom of this fn.
   let streamedToClient = false;
+  let clientDisconnected = false;
   try {
     const result = await makeUpstreamRequest(target, forwardHeaders, requestBody, res);
     upstreamStatus = result.status;
@@ -113,6 +114,7 @@ export async function proxyAndRecord(
     upstreamBody = result.body;
     rawBuffer = result.rawBuffer;
     streamedToClient = result.streamedToClient;
+    clientDisconnected = result.clientDisconnected;
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Unknown proxy error";
     defaults.logger.error(`Proxy request failed: ${msg}`);
@@ -196,12 +198,17 @@ export async function proxyAndRecord(
         `Could not parse encoding_format from raw body: ${err instanceof Error ? err.message : "unknown error"}`,
       );
     }
-    fixtureResponse = buildFixtureResponse(
-      parsedResponse,
-      upstreamStatus,
-      encodingFormat,
-      defaults.logger,
+    fixtureResponse = buildFixtureResponse(parsedResponse, upstreamStatus, encodingFormat);
+  }
+
+  // If the client disconnected mid-stream, the collected data is likely
+  // truncated.  Saving a partial fixture is worse than saving none — skip
+  // fixture persistence entirely.
+  if (clientDisconnected) {
+    defaults.logger.warn(
+      "Client disconnected mid-stream — skipping fixture save to avoid truncated data",
     );
+    return true;
   }
 
   // Build the match criteria from the (optionally transformed) request
@@ -301,6 +308,7 @@ function makeUpstreamRequest(
   body: string;
   rawBuffer: Buffer;
   streamedToClient: boolean;
+  clientDisconnected: boolean;
 }> {
   return new Promise((resolve, reject) => {
     const transport = target.protocol === "https:" ? https : http;
@@ -375,6 +383,7 @@ function makeUpstreamRequest(
             body: rawBuffer.toString(),
             rawBuffer,
             streamedToClient,
+            clientDisconnected,
           });
         });
       },
@@ -400,7 +409,6 @@ function buildFixtureResponse(
   parsed: unknown,
   status: number,
   encodingFormat?: string,
-  logger?: Logger,
 ): FixtureResponse {
   if (parsed === null || parsed === undefined) {
     // Raw / unparseable response — save as error
@@ -432,17 +440,10 @@ function buildFixtureResponse(
       return { embedding: first.embedding as number[] };
     }
     if (typeof first.embedding === "string" && encodingFormat === "base64") {
-      try {
-        const buf = Buffer.from(first.embedding, "base64");
-        const floats = new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4);
-        return { embedding: Array.from(floats) };
-      } catch (err) {
-        // Corrupted base64 or non-float32 data — may be caused by
-        // Buffer pool byte-offset misalignment with Float32Array.
-        logger?.warn(
-          `Failed to decode base64 embedding (possible byte-alignment issue): ${err instanceof Error ? err.message : "unknown error"}`,
-        );
-      }
+      const buf = Buffer.from(first.embedding, "base64");
+      const aligned = new Uint8Array(buf).buffer; // Always offset 0
+      const floats = new Float32Array(aligned, 0, buf.byteLength / 4);
+      return { embedding: Array.from(floats) };
     }
     // OpenAI image generation: { created, data: [{ url, b64_json, revised_prompt }] }
     if (first.url || first.b64_json) {

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -354,7 +354,7 @@ function makeUpstreamRequest(
           // Stop relaying if the client disconnects mid-stream
           clientRes.on("close", () => {
             clientDisconnected = true;
-            req.destroy(new Error("Client disconnected"));
+            req.destroy();
           });
         }
         const chunks: Buffer[] = [];
@@ -574,6 +574,8 @@ function buildFixtureResponse(
           ...(openaiReasoning ? { reasoning: openaiReasoning } : {}),
         };
       }
+      // Recognized OpenAI shape but empty content (e.g. content filtering, zero max_tokens)
+      return { content: "", ...(openaiReasoning ? { reasoning: openaiReasoning } : {}) };
     }
   }
 
@@ -658,6 +660,8 @@ function buildFixtureResponse(
           ...(geminiReasoning ? { reasoning: geminiReasoning } : {}),
         };
       }
+      // Recognized Gemini shape but empty content
+      return { content: "", ...(geminiReasoning ? { reasoning: geminiReasoning } : {}) };
     }
   }
 
@@ -708,6 +712,8 @@ function buildFixtureResponse(
           ...(bedrockReasoning ? { reasoning: bedrockReasoning } : {}),
         };
       }
+      // Recognized Bedrock Converse shape but empty content
+      return { content: "", ...(bedrockReasoning ? { reasoning: bedrockReasoning } : {}) };
     }
   }
 

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -655,7 +655,13 @@ function buildFixtureResponse(
     const msg = obj.message as Record<string, unknown>;
     const contentBlocks = msg.content as Array<Record<string, unknown>>;
     const textBlock = contentBlocks.find((b) => b.type === "text" && typeof b.text === "string");
+    const hasContent = textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0;
     const toolCallBlocks = contentBlocks.filter((b) => b.type === "tool_call");
+
+    // Also check message-level tool_calls (Cohere v2 puts tool calls here, not in content blocks)
+    const msgToolCalls = Array.isArray(msg.tool_calls)
+      ? (msg.tool_calls as Array<Record<string, unknown>>)
+      : [];
 
     if (toolCallBlocks.length > 0) {
       const toolCalls: ToolCall[] = toolCallBlocks.map((b) => ({
@@ -669,12 +675,32 @@ function buildFixtureResponse(
                 ? String((b.function as Record<string, unknown>).arguments)
                 : JSON.stringify((b.function as Record<string, unknown>)?.arguments),
       }));
-      if (textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0) {
+      if (hasContent) {
         return { content: textBlock.text as string, toolCalls };
       }
       return { toolCalls };
     }
-    if (textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0) {
+    if (msgToolCalls.length > 0) {
+      const toolCalls: ToolCall[] = msgToolCalls.map((tc) => {
+        const fn = tc.function as Record<string, unknown> | undefined;
+        return {
+          name: String(tc.name ?? fn?.name ?? ""),
+          arguments:
+            typeof tc.parameters === "string"
+              ? tc.parameters
+              : typeof tc.parameters === "object"
+                ? JSON.stringify(tc.parameters)
+                : typeof fn?.arguments === "string"
+                  ? String(fn.arguments)
+                  : JSON.stringify(fn?.arguments),
+        };
+      });
+      if (hasContent) {
+        return { content: textBlock.text as string, toolCalls };
+      }
+      return { toolCalls };
+    }
+    if (hasContent) {
       return { content: textBlock.text as string };
     }
   }

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -55,7 +55,7 @@ interface ResponsesContentPart {
 
 interface ResponsesRequest {
   model: string;
-  input: ResponsesInputItem[];
+  input: string | ResponsesInputItem[];
   instructions?: string;
   tools?: ResponsesToolDef[];
   tool_choice?: string | object;
@@ -92,6 +92,13 @@ export function responsesInputToMessages(req: ResponsesRequest): ChatMessage[] {
     messages.push({ role: "system", content: req.instructions });
   }
 
+  // The OpenAI Responses API accepts either a plain string or an array of input items.
+  // When a string is passed, treat it as a single user message.
+  if (typeof req.input === "string") {
+    messages.push({ role: "user", content: req.input });
+    return messages;
+  }
+
   for (const item of req.input) {
     if (item.role === "system" || item.role === "developer") {
       messages.push({ role: "system", content: extractTextContent(item.content) });
@@ -118,8 +125,11 @@ export function responsesInputToMessages(req: ResponsesRequest): ChatMessage[] {
         content: item.output ?? "",
         tool_call_id: item.call_id,
       });
+    } else {
+      // Skip item_reference, local_shell_call, mcp_list_tools, etc. — not needed
+      // for fixture matching. Logging is not threaded into this pure conversion
+      // function; callers can inspect the returned messages if needed.
     }
-    // Skip item_reference, local_shell_call, etc. — not needed for fixture matching
   }
 
   return messages;

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,5 +1,5 @@
 /**
- * OpenAI Responses API support for LLMock.
+ * OpenAI Responses API support for aimock.
  *
  * Translates incoming /v1/responses requests into the ChatCompletionRequest
  * format used by the fixture router, and converts fixture responses back into

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -899,7 +899,7 @@ export async function handleResponses(
           path: req.url ?? "/v1/responses",
           headers: flattenHeaders(req.headers),
           body: completionReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }

--- a/src/router.ts
+++ b/src/router.ts
@@ -83,6 +83,7 @@ export function matchFixture(
           if (!text.includes(match.userMessage)) continue;
         }
       } else {
+        match.userMessage.lastIndex = 0;
         if (!match.userMessage.test(text)) continue;
       }
     }
@@ -112,6 +113,7 @@ export function matchFixture(
           if (!embeddingInput.includes(match.inputText)) continue;
         }
       } else {
+        match.inputText.lastIndex = 0;
         if (!match.inputText.test(embeddingInput)) continue;
       }
     }
@@ -127,6 +129,7 @@ export function matchFixture(
       if (typeof match.model === "string") {
         if (effective.model !== match.model) continue;
       } else {
+        match.model.lastIndex = 0;
         if (!match.model.test(effective.model)) continue;
       }
     }

--- a/src/router.ts
+++ b/src/router.ts
@@ -67,7 +67,11 @@ export function matchFixture(
       if (!compatible) continue;
     }
 
-    // userMessage — match against the last user message content
+    // userMessage — case-sensitive match against the last user message content.
+    // String matching is intentionally case-sensitive so fixture authors can
+    // rely on exact string values. This differs from the case-insensitive
+    // matchesPattern() in helpers.ts, which is used for search/rerank/moderation
+    // where exact casing rarely matters.
     if (match.userMessage !== undefined) {
       const msg = getLastMessageByRole(effective.messages, "user");
       const text = msg ? getTextContent(msg.content) : null;
@@ -96,7 +100,8 @@ export function matchFixture(
       if (!found) continue;
     }
 
-    // inputText — match against the embedding input text (used by embeddings endpoint)
+    // inputText — case-sensitive match against the embedding input text.
+    // Same rationale as userMessage above: fixture authors specify exact strings.
     if (match.inputText !== undefined) {
       const embeddingInput = effective.embeddingInput;
       if (!embeddingInput) continue;

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,7 @@ import { handleEmbeddings } from "./embeddings.js";
 import { handleImages } from "./images.js";
 import { handleSpeech } from "./speech.js";
 import { handleTranscription } from "./transcription.js";
-import { handleVideoCreate, handleVideoStatus, type VideoStateMap } from "./video.js";
+import { handleVideoCreate, handleVideoStatus, VideoStateMap } from "./video.js";
 import { handleOllama, handleOllamaGenerate } from "./ollama.js";
 import { handleCohere } from "./cohere.js";
 import { handleSearch, type SearchFixture } from "./search.js";
@@ -722,7 +722,7 @@ export async function createServer(
     maxEntries: options?.journalMaxEntries ?? 1000,
     fixtureCountsMaxTestIds: options?.fixtureCountsMaxTestIds ?? 500,
   });
-  const videoStates: VideoStateMap = new Map();
+  const videoStates = new VideoStateMap();
 
   // Share journal and metrics registry with mounted services
   if (mounts) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -428,6 +428,28 @@ async function handleCompletions(
     return;
   }
 
+  // Validate messages array
+  if (!Array.isArray(body.messages)) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? COMPLETIONS_PATH,
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 400, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: {
+          message: "Missing required parameter: 'messages'",
+          type: "invalid_request_error",
+        },
+      }),
+    );
+    return;
+  }
+
   // Match fixture
   body._endpointType = "chat";
   const testId = getTestId(req);

--- a/src/server.ts
+++ b/src/server.ts
@@ -102,7 +102,7 @@ const COMPAT_SUFFIXES = [
 function normalizeCompatPath(pathname: string, logger?: Logger): string {
   // Strip /openai/ prefix (Groq/OpenAI-compat alias)
   if (pathname.startsWith("/openai/")) {
-    pathname = pathname.slice(7);
+    pathname = pathname.slice("/openai".length);
   }
 
   // Normalize arbitrary prefixes to /v1/
@@ -157,9 +157,23 @@ function setCorsHeaders(res: http.ServerResponse): void {
   }
 }
 
-async function readBody(req: http.IncomingMessage): Promise<string> {
+const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
+
+async function readBody(
+  req: http.IncomingMessage,
+  maxBytes: number = DEFAULT_MAX_BODY_BYTES,
+): Promise<string> {
   const buffers: Buffer[] = [];
-  for await (const chunk of req) buffers.push(chunk as Buffer);
+  let totalBytes = 0;
+  for await (const chunk of req) {
+    const buf = chunk as Buffer;
+    totalBytes += buf.length;
+    if (totalBytes > maxBytes) {
+      req.destroy();
+      throw new Error(`Request body exceeded size limit of ${maxBytes} bytes`);
+    }
+    buffers.push(buf);
+  }
   return Buffer.concat(buffers).toString();
 }
 
@@ -193,6 +207,7 @@ async function handleControlAPI(
   fixtures: Fixture[],
   journal: Journal,
   videoStates: VideoStateMap,
+  defaults: HandlerDefaults,
 ): Promise<boolean> {
   if (!pathname.startsWith(CONTROL_PREFIX)) return false;
 
@@ -218,18 +233,22 @@ async function handleControlAPI(
     let raw: string;
     try {
       raw = await readBody(req);
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      defaults.logger.error(`POST /__aimock/fixtures: failed to read body: ${msg}`);
       res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Failed to read request body" }));
+      res.end(JSON.stringify({ error: `Failed to read request body: ${msg}` }));
       return true;
     }
 
     let parsed: { fixtures?: FixtureFileEntry[] };
     try {
       parsed = JSON.parse(raw) as { fixtures?: FixtureFileEntry[] };
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      defaults.logger.error(`POST /__aimock/fixtures: invalid JSON: ${msg}`);
       res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Invalid JSON" }));
+      res.end(JSON.stringify({ error: `Invalid JSON: ${msg}` }));
       return true;
     }
 
@@ -249,6 +268,9 @@ async function handleControlAPI(
     }
 
     fixtures.push(...converted);
+    if (defaults.registry) {
+      defaults.registry.setGauge("aimock_fixtures_loaded", {}, fixtures.length);
+    }
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ added: converted.length }));
     return true;
@@ -257,6 +279,9 @@ async function handleControlAPI(
   // DELETE /__aimock/fixtures — clear all fixtures
   if (subPath === "/fixtures" && req.method === "DELETE") {
     fixtures.length = 0;
+    if (defaults.registry) {
+      defaults.registry.setGauge("aimock_fixtures_loaded", {}, fixtures.length);
+    }
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ cleared: true }));
     return true;
@@ -267,6 +292,9 @@ async function handleControlAPI(
     fixtures.length = 0;
     journal.clear();
     videoStates.clear();
+    if (defaults.registry) {
+      defaults.registry.setGauge("aimock_fixtures_loaded", {}, fixtures.length);
+    }
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ reset: true }));
     return true;
@@ -277,18 +305,22 @@ async function handleControlAPI(
     let raw: string;
     try {
       raw = await readBody(req);
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      defaults.logger.error(`POST /__aimock/error: failed to read body: ${msg}`);
       res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Failed to read request body" }));
+      res.end(JSON.stringify({ error: `Failed to read request body: ${msg}` }));
       return true;
     }
 
     let parsed: { status?: number; body?: { message?: string; type?: string; code?: string } };
     try {
       parsed = JSON.parse(raw) as typeof parsed;
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      defaults.logger.error(`POST /__aimock/error: invalid JSON: ${msg}`);
       res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Invalid JSON" }));
+      res.end(JSON.stringify({ error: `Invalid JSON: ${msg}` }));
       return true;
     }
 
@@ -307,15 +339,14 @@ async function handleControlAPI(
     };
     // Insert at front so it matches before everything else
     fixtures.unshift(errorFixture);
-    // Remove after first match
+    // Remove synchronously on first match to prevent race conditions where
+    // two concurrent requests both match before the removal fires.
     const original = errorFixture.match.predicate!;
     errorFixture.match.predicate = (req) => {
       const result = original(req);
       if (result) {
-        queueMicrotask(() => {
-          const idx = fixtures.indexOf(errorFixture);
-          if (idx !== -1) fixtures.splice(idx, 1);
-        });
+        const idx = fixtures.indexOf(errorFixture);
+        if (idx !== -1) fixtures.splice(idx, 1);
       }
       return result;
     };
@@ -794,7 +825,7 @@ export async function createServer(
 
     // Control API — must be checked before mounts and path rewrites
     if (pathname.startsWith(CONTROL_PREFIX)) {
-      await handleControlAPI(req, res, pathname, fixtures, journal, videoStates);
+      await handleControlAPI(req, res, pathname, fixtures, journal, videoStates, defaults);
       return;
     }
 
@@ -926,204 +957,208 @@ export async function createServer(
 
     // POST /v1/responses — OpenAI Responses API
     if (pathname === RESPONSES_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) => handleResponses(req, res, raw, fixtures, journal, defaults, setCorsHeaders))
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            try {
-              res.write(`event: error\ndata: ${JSON.stringify({ error: { message: msg } })}\n\n`);
-            } catch (writeErr) {
-              logger.debug("Failed to write error recovery response:", writeErr);
-            }
-            res.end();
+      try {
+        const raw = await readBody(req);
+        await handleResponses(req, res, raw, fixtures, journal, defaults, setCorsHeaders);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          try {
+            res.write(`event: error\ndata: ${JSON.stringify({ error: { message: msg } })}\n\n`);
+          } catch (writeErr) {
+            logger.debug("Failed to write error recovery response:", writeErr);
           }
-        });
+          res.end();
+        }
+      }
       return;
     }
 
     // POST /v1/messages — Anthropic Claude Messages API
     if (pathname === MESSAGES_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) => handleMessages(req, res, raw, fixtures, journal, defaults, setCorsHeaders))
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            try {
-              res.write(`event: error\ndata: ${JSON.stringify({ error: { message: msg } })}\n\n`);
-            } catch (writeErr) {
-              logger.debug("Failed to write error recovery response:", writeErr);
-            }
-            res.end();
+      try {
+        const raw = await readBody(req);
+        await handleMessages(req, res, raw, fixtures, journal, defaults, setCorsHeaders);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          try {
+            res.write(`event: error\ndata: ${JSON.stringify({ error: { message: msg } })}\n\n`);
+          } catch (writeErr) {
+            logger.debug("Failed to write error recovery response:", writeErr);
           }
-        });
+          res.end();
+        }
+      }
       return;
     }
 
     // POST /v2/chat — Cohere v2 Chat API
     if (pathname === COHERE_CHAT_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) => handleCohere(req, res, raw, fixtures, journal, defaults, setCorsHeaders))
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            try {
-              res.write(`event: error\ndata: ${JSON.stringify({ error: { message: msg } })}\n\n`);
-            } catch (writeErr) {
-              logger.debug("Failed to write error recovery response:", writeErr);
-            }
-            res.end();
+      try {
+        const raw = await readBody(req);
+        await handleCohere(req, res, raw, fixtures, journal, defaults, setCorsHeaders);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          try {
+            res.write(`event: error\ndata: ${JSON.stringify({ error: { message: msg } })}\n\n`);
+          } catch (writeErr) {
+            logger.debug("Failed to write error recovery response:", writeErr);
           }
-        });
+          res.end();
+        }
+      }
       return;
     }
 
     // POST /v1/embeddings — OpenAI Embeddings API
     if (pathname === EMBEDDINGS_PATH && req.method === "POST") {
-      const deploymentId = azureDeploymentId;
-      readBody(req)
-        .then((raw) => {
-          // Azure deployments may omit model from body — use deployment ID as fallback
-          if (deploymentId) {
-            try {
-              const parsed = JSON.parse(raw) as Record<string, unknown>;
-              if (!parsed.model) {
-                parsed.model = deploymentId;
-                return handleEmbeddings(
-                  req,
-                  res,
-                  JSON.stringify(parsed),
-                  fixtures,
-                  journal,
-                  defaults,
-                  setCorsHeaders,
-                );
-              }
-            } catch {
-              // Fall through — let handleEmbeddings report the parse error
+      try {
+        const deploymentId = azureDeploymentId;
+        const embeddingsProvider: RecordProviderKey = azureDeploymentId ? "azure" : "openai";
+        let raw = await readBody(req);
+        // Azure deployments may omit model from body — use deployment ID as fallback
+        if (deploymentId) {
+          try {
+            const parsed = JSON.parse(raw) as Record<string, unknown>;
+            if (!parsed.model) {
+              parsed.model = deploymentId;
+              raw = JSON.stringify(parsed);
             }
+          } catch {
+            // Fall through — let handleEmbeddings report the parse error
           }
-          return handleEmbeddings(req, res, raw, fixtures, journal, defaults, setCorsHeaders);
-        })
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+        }
+        await handleEmbeddings(
+          req,
+          res,
+          raw,
+          fixtures,
+          journal,
+          defaults,
+          setCorsHeaders,
+          embeddingsProvider,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
     // POST /v1/images/generations — OpenAI Image Generation API
     if (pathname === IMAGES_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) => handleImages(req, res, raw, fixtures, journal, defaults, setCorsHeaders))
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+      try {
+        const raw = await readBody(req);
+        await handleImages(req, res, raw, fixtures, journal, defaults, setCorsHeaders);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
     // POST /v1/audio/speech — OpenAI TTS API
     if (pathname === SPEECH_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) => handleSpeech(req, res, raw, fixtures, journal, defaults, setCorsHeaders))
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+      try {
+        const raw = await readBody(req);
+        await handleSpeech(req, res, raw, fixtures, journal, defaults, setCorsHeaders);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
     // POST /v1/audio/transcriptions — OpenAI Transcription API
     if (pathname === TRANSCRIPTIONS_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) =>
-          handleTranscription(req, res, raw, fixtures, journal, defaults, setCorsHeaders),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+      try {
+        const raw = await readBody(req);
+        await handleTranscription(req, res, raw, fixtures, journal, defaults, setCorsHeaders);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
     // POST /v1/videos — Video Generation API
     if (pathname === VIDEOS_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) =>
-          handleVideoCreate(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleVideoCreate(
+          req,
+          res,
+          raw,
+          fixtures,
+          journal,
+          defaults,
+          setCorsHeaders,
+          videoStates,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            fixtures,
-            journal,
-            defaults,
-            setCorsHeaders,
-            videoStates,
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
@@ -1139,32 +1174,31 @@ export async function createServer(
     const geminiPredictMatch = pathname.match(GEMINI_PREDICT_RE);
     if (geminiPredictMatch && req.method === "POST") {
       const predictModel = geminiPredictMatch[1];
-      readBody(req)
-        .then((raw) =>
-          handleImages(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleImages(
+          req,
+          res,
+          raw,
+          fixtures,
+          journal,
+          defaults,
+          setCorsHeaders,
+          "gemini",
+          predictModel,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            fixtures,
-            journal,
-            defaults,
-            setCorsHeaders,
-            "gemini",
-            predictModel,
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
@@ -1173,37 +1207,36 @@ export async function createServer(
     if (geminiMatch && req.method === "POST") {
       const geminiModel = geminiMatch[1];
       const streaming = geminiMatch[2] === "streamGenerateContent";
-      readBody(req)
-        .then((raw) =>
-          handleGemini(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleGemini(
+          req,
+          res,
+          raw,
+          geminiModel,
+          streaming,
+          fixtures,
+          journal,
+          defaults,
+          setCorsHeaders,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            geminiModel,
-            streaming,
-            fixtures,
-            journal,
-            defaults,
-            setCorsHeaders,
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            try {
-              res.write(`data: ${JSON.stringify({ error: { message: msg } })}\n\n`);
-            } catch (writeErr) {
-              logger.debug("Failed to write error recovery response:", writeErr);
-            }
-            res.end();
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          try {
+            res.write(`data: ${JSON.stringify({ error: { message: msg } })}\n\n`);
+          } catch (writeErr) {
+            logger.debug("Failed to write error recovery response:", writeErr);
           }
-        });
+          res.end();
+        }
+      }
       return;
     }
 
@@ -1212,38 +1245,37 @@ export async function createServer(
     if (vertexMatch && req.method === "POST") {
       const vertexModel = vertexMatch[1];
       const streaming = vertexMatch[2] === "streamGenerateContent";
-      readBody(req)
-        .then((raw) =>
-          handleGemini(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleGemini(
+          req,
+          res,
+          raw,
+          vertexModel,
+          streaming,
+          fixtures,
+          journal,
+          defaults,
+          setCorsHeaders,
+          "vertexai",
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            vertexModel,
-            streaming,
-            fixtures,
-            journal,
-            defaults,
-            setCorsHeaders,
-            "vertexai",
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            try {
-              res.write(`data: ${JSON.stringify({ error: { message: msg } })}\n\n`);
-            } catch (writeErr) {
-              logger.debug("Failed to write error recovery response:", writeErr);
-            }
-            res.end();
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          try {
+            res.write(`data: ${JSON.stringify({ error: { message: msg } })}\n\n`);
+          } catch (writeErr) {
+            logger.debug("Failed to write error recovery response:", writeErr);
           }
-        });
+          res.end();
+        }
+      }
       return;
     }
 
@@ -1251,22 +1283,30 @@ export async function createServer(
     const bedrockMatch = pathname.match(BEDROCK_INVOKE_RE);
     if (bedrockMatch && req.method === "POST") {
       const bedrockModelId = bedrockMatch[1];
-      readBody(req)
-        .then((raw) =>
-          handleBedrock(req, res, raw, bedrockModelId, fixtures, journal, defaults, setCorsHeaders),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+      try {
+        const raw = await readBody(req);
+        await handleBedrock(
+          req,
+          res,
+          raw,
+          bedrockModelId,
+          fixtures,
+          journal,
+          defaults,
+          setCorsHeaders,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
@@ -1274,31 +1314,30 @@ export async function createServer(
     const bedrockStreamMatch = pathname.match(BEDROCK_STREAM_RE);
     if (bedrockStreamMatch && req.method === "POST") {
       const bedrockModelId = bedrockStreamMatch[1];
-      readBody(req)
-        .then((raw) =>
-          handleBedrockStream(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleBedrockStream(
+          req,
+          res,
+          raw,
+          bedrockModelId,
+          fixtures,
+          journal,
+          defaults,
+          setCorsHeaders,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            bedrockModelId,
-            fixtures,
-            journal,
-            defaults,
-            setCorsHeaders,
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
@@ -1306,31 +1345,30 @@ export async function createServer(
     const converseMatch = pathname.match(BEDROCK_CONVERSE_RE);
     if (converseMatch && req.method === "POST") {
       const converseModelId = converseMatch[1];
-      readBody(req)
-        .then((raw) =>
-          handleConverse(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleConverse(
+          req,
+          res,
+          raw,
+          converseModelId,
+          fixtures,
+          journal,
+          defaults,
+          setCorsHeaders,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            converseModelId,
-            fixtures,
-            journal,
-            defaults,
-            setCorsHeaders,
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
@@ -1338,71 +1376,70 @@ export async function createServer(
     const converseStreamMatch = pathname.match(BEDROCK_CONVERSE_STREAM_RE);
     if (converseStreamMatch && req.method === "POST") {
       const converseStreamModelId = converseStreamMatch[1];
-      readBody(req)
-        .then((raw) =>
-          handleConverseStream(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleConverseStream(
+          req,
+          res,
+          raw,
+          converseStreamModelId,
+          fixtures,
+          journal,
+          defaults,
+          setCorsHeaders,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            converseStreamModelId,
-            fixtures,
-            journal,
-            defaults,
-            setCorsHeaders,
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
     // POST /api/chat — Ollama Chat API
     if (pathname === OLLAMA_CHAT_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) => handleOllama(req, res, raw, fixtures, journal, defaults, setCorsHeaders))
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+      try {
+        const raw = await readBody(req);
+        await handleOllama(req, res, raw, fixtures, journal, defaults, setCorsHeaders);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
     // POST /api/generate — Ollama Generate API
     if (pathname === OLLAMA_GENERATE_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) =>
-          handleOllamaGenerate(req, res, raw, fixtures, journal, defaults, setCorsHeaders),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+      try {
+        const raw = await readBody(req);
+        await handleOllamaGenerate(req, res, raw, fixtures, journal, defaults, setCorsHeaders);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
@@ -1431,88 +1468,85 @@ export async function createServer(
 
     // POST /search — Web Search API (Tavily-compatible)
     if (pathname === SEARCH_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) =>
-          handleSearch(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleSearch(
+          req,
+          res,
+          raw,
+          serviceFixtures?.search ?? [],
+          journal,
+          defaults,
+          setCorsHeaders,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            serviceFixtures?.search ?? [],
-            journal,
-            defaults,
-            setCorsHeaders,
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
     // POST /v2/rerank — Reranking API (Cohere rerank-compatible)
     if (pathname === RERANK_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) =>
-          handleRerank(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleRerank(
+          req,
+          res,
+          raw,
+          serviceFixtures?.rerank ?? [],
+          journal,
+          defaults,
+          setCorsHeaders,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            serviceFixtures?.rerank ?? [],
-            journal,
-            defaults,
-            setCorsHeaders,
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
     // POST /v1/moderations — Moderation API (OpenAI-compatible)
     if (pathname === MODERATIONS_PATH && req.method === "POST") {
-      readBody(req)
-        .then((raw) =>
-          handleModeration(
-            req,
+      try {
+        const raw = await readBody(req);
+        await handleModeration(
+          req,
+          res,
+          raw,
+          serviceFixtures?.moderation ?? [],
+          journal,
+          defaults,
+          setCorsHeaders,
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
             res,
-            raw,
-            serviceFixtures?.moderation ?? [],
-            journal,
-            defaults,
-            setCorsHeaders,
-          ),
-        )
-        .catch((err: unknown) => {
-          const msg = err instanceof Error ? err.message : "Internal error";
-          if (!res.headersSent) {
-            writeErrorResponse(
-              res,
-              500,
-              JSON.stringify({ error: { message: msg, type: "server_error" } }),
-            );
-          } else if (!res.writableEnded) {
-            res.destroy();
-          }
-        });
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+      }
       return;
     }
 
@@ -1527,15 +1561,17 @@ export async function createServer(
     }
 
     const completionsProvider: RecordProviderKey = azureDeploymentId ? "azure" : "openai";
-    handleCompletions(
-      req,
-      res,
-      fixtures,
-      journal,
-      defaults,
-      azureDeploymentId,
-      completionsProvider,
-    ).catch((err: unknown) => {
+    try {
+      await handleCompletions(
+        req,
+        res,
+        fixtures,
+        journal,
+        defaults,
+        azureDeploymentId,
+        completionsProvider,
+      );
+    } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Internal error";
       if (!res.headersSent) {
         writeErrorResponse(
@@ -1559,7 +1595,7 @@ export async function createServer(
         }
         res.end();
       }
-    });
+    }
   }
 
   // ─── WebSocket upgrade handling ──────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -485,7 +485,7 @@ async function handleCompletions(
           path: req.url ?? COMPLETIONS_PATH,
           headers: flattenHeaders(req.headers),
           body,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }

--- a/src/speech.ts
+++ b/src/speech.ts
@@ -59,6 +59,24 @@ export async function handleSpeech(
     return;
   }
 
+  if (!speechReq.input) {
+    journal.add({
+      method,
+      path,
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 400, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: { message: "Missing required parameter: 'input'", type: "invalid_request_error" },
+      }),
+    );
+    return;
+  }
+
   const syntheticReq: ChatCompletionRequest = {
     model: speechReq.model ?? "tts-1",
     messages: [{ role: "user", content: speechReq.input }],

--- a/src/speech.ts
+++ b/src/speech.ts
@@ -109,7 +109,7 @@ export async function handleSpeech(
           path,
           headers: flattenHeaders(req.headers),
           body: syntheticReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -8,9 +8,12 @@ import { applyChaos } from "./chaos.js";
 import { proxyAndRecord } from "./recorder.js";
 
 /**
- * Extract a named field value from a multipart/form-data body.
- * Lightweight parser — scans for Content-Disposition headers
- * to find simple string field values.
+ * Extract a text field from multipart form data using regex.
+ * NOTE: This runs against the full body including binary audio data.
+ * It works because text metadata fields (model, response_format, etc.)
+ * appear before the binary audio part in standard multipart encoding.
+ * A proper multipart parser would be more robust but is overkill for
+ * the small set of fields we extract.
  */
 function extractFormField(raw: string, fieldName: string): string | undefined {
   const pattern = new RegExp(
@@ -87,7 +90,7 @@ export async function handleTranscription(
           path,
           headers: flattenHeaders(req.headers),
           body: syntheticReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -306,7 +306,6 @@ export interface JournalEntry {
     interrupted?: boolean;
     interruptReason?: string;
     chaosAction?: ChaosAction;
-    source?: string;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -302,6 +302,7 @@ export interface JournalEntry {
   response: {
     status: number;
     fixture: Fixture | null;
+    source?: "proxy";
     interrupted?: boolean;
     interruptReason?: string;
     chaosAction?: ChaosAction;

--- a/src/types.ts
+++ b/src/types.ts
@@ -302,7 +302,7 @@ export interface JournalEntry {
   response: {
     status: number;
     fixture: Fixture | null;
-    source?: "proxy";
+    source?: "fixture" | "proxy";
     interrupted?: boolean;
     interruptReason?: string;
     chaosAction?: ChaosAction;

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,6 +305,7 @@ export interface JournalEntry {
     interrupted?: boolean;
     interruptReason?: string;
     chaosAction?: ChaosAction;
+    source?: string;
   };
 }
 

--- a/src/video.ts
+++ b/src/video.ts
@@ -13,8 +13,60 @@ interface VideoRequest {
   [key: string]: unknown;
 }
 
-/** Stored video state for GET status checks. Key: `${testId}:${videoId}` */
-export type VideoStateMap = Map<string, VideoResponse["video"]>;
+// ─── VideoStateMap with TTL and size bound ────────────────────────────────
+
+const VIDEO_STATE_MAX_ENTRIES = 10_000;
+const VIDEO_STATE_TTL_MS = 3_600_000; // 1 hour
+
+interface VideoStateEntry {
+  video: VideoResponse["video"];
+  createdAt: number;
+}
+
+/**
+ * A Map wrapper for video state that enforces a maximum size and per-entry TTL.
+ * Entries older than VIDEO_STATE_TTL_MS are lazily evicted on `get`.
+ * When the map exceeds VIDEO_STATE_MAX_ENTRIES on `set`, the oldest entries
+ * are removed to stay within bounds.
+ */
+export class VideoStateMap {
+  private readonly entries = new Map<string, VideoStateEntry>();
+
+  get(key: string): VideoResponse["video"] | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (Date.now() - entry.createdAt > VIDEO_STATE_TTL_MS) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    return entry.video;
+  }
+
+  set(key: string, video: VideoResponse["video"]): void {
+    this.entries.set(key, { video, createdAt: Date.now() });
+    // Evict oldest entries if over capacity
+    if (this.entries.size > VIDEO_STATE_MAX_ENTRIES) {
+      const excess = this.entries.size - VIDEO_STATE_MAX_ENTRIES;
+      const iter = this.entries.keys();
+      for (let i = 0; i < excess; i++) {
+        const next = iter.next();
+        if (!next.done) this.entries.delete(next.value);
+      }
+    }
+  }
+
+  delete(key: string): boolean {
+    return this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}
 
 export async function handleVideoCreate(
   req: http.IncomingMessage,
@@ -101,7 +153,7 @@ export async function handleVideoCreate(
           path,
           headers: flattenHeaders(req.headers),
           body: syntheticReq,
-          response: { status: res.statusCode ?? 200, fixture: null },
+          response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
         return;
       }

--- a/src/video.ts
+++ b/src/video.ts
@@ -103,6 +103,24 @@ export async function handleVideoCreate(
     return;
   }
 
+  if (!videoReq.prompt) {
+    journal.add({
+      method,
+      path,
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 400, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: { message: "Missing required parameter: 'prompt'", type: "invalid_request_error" },
+      }),
+    );
+    return;
+  }
+
   const syntheticReq: ChatCompletionRequest = {
     model: videoReq.model ?? "sora-2",
     messages: [{ role: "user", content: videoReq.prompt }],

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -43,6 +43,8 @@ export interface AimockHandle {
  */
 export function useAimock(options: UseAimockOptions = {}): () => AimockHandle {
   let handle: AimockHandle | null = null;
+  let origOpenaiUrl: string | undefined;
+  let origAnthropicUrl: string | undefined;
 
   beforeAll(async () => {
     const { fixtures: fixturePath, patchEnv, ...serverOpts } = options;
@@ -59,6 +61,8 @@ export function useAimock(options: UseAimockOptions = {}): () => AimockHandle {
     const url = await llm.start();
 
     if (patchEnv !== false) {
+      origOpenaiUrl = process.env.OPENAI_BASE_URL;
+      origAnthropicUrl = process.env.ANTHROPIC_BASE_URL;
       process.env.OPENAI_BASE_URL = `${url}/v1`;
       process.env.ANTHROPIC_BASE_URL = `${url}/v1`;
     }
@@ -75,8 +79,10 @@ export function useAimock(options: UseAimockOptions = {}): () => AimockHandle {
   afterAll(async () => {
     if (handle) {
       if (options.patchEnv !== false) {
-        delete process.env.OPENAI_BASE_URL;
-        delete process.env.ANTHROPIC_BASE_URL;
+        if (origOpenaiUrl !== undefined) process.env.OPENAI_BASE_URL = origOpenaiUrl;
+        else delete process.env.OPENAI_BASE_URL;
+        if (origAnthropicUrl !== undefined) process.env.ANTHROPIC_BASE_URL = origAnthropicUrl;
+        else delete process.env.ANTHROPIC_BASE_URL;
       }
       await handle.llm.stop();
       handle = null;

--- a/src/vitest.ts
+++ b/src/vitest.ts
@@ -98,7 +98,10 @@ function loadFixtures(fixturePath: string): Fixture[] {
       return loadFixturesFromDir(fixturePath);
     }
     return loadFixtureFile(fixturePath);
-  } catch {
+  } catch (err) {
+    console.warn(
+      `[aimock] Failed to load fixtures from ${fixturePath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return [];
   }
 }


### PR DESCRIPTION
## Summary

Stacked on PR #133 (omnibus CR follow-up). Addresses bucket (d) items 2 and 3 from the PR #133 CR rounds.

### CI Security Hardening
- Replace `--admin` with `--auto` on fix-drift auto-merge (respects branch protection)
- Move all Slack webhook secrets from shell interpolation to env vars across 5 workflow files
- Add SLACK_WEBHOOK empty-check guards consistently
- Replace `grep -oP` with portable `grep -oE`

### Cohere v2 Complete Parity
- Add reasoning support to all 3 Cohere response builders (text, tool_calls, content+toolCalls) + streaming
- Add webSearches warnings to Cohere + both Bedrock handlers (matching Messages/Responses/Gemini pattern)
- Forward response_format from Cohere requests to ChatCompletionRequest
- Preserve assistant tool_calls during cohereToCompletionRequest conversion

### Bedrock ResponseOverrides
- Wire extractOverrides into all Bedrock and Bedrock Converse response builders
- Apply id, model, finishReason, usage overrides (matching all other providers)

## Test plan
- [ ] 24 new tests (14 Cohere, 10 Bedrock) — all passing
- [ ] 2573/2573 total tests green
- [ ] TSC clean, prettier + eslint clean
- [ ] Merge PR #133 first, then merge this