### PR TITLE
docs: add MCP server page

### DIFF
--- a/docs/mcp/index.html
+++ b/docs/mcp/index.html
@@ -73,7 +73,9 @@
           <tbody>
             <tr>
               <td><code>search-docs</code></td>
-              <td>Semantic search over aimock documentation — guides, API references, provider configs</td>
+              <td>
+                Semantic search over aimock documentation — guides, API references, provider configs
+              </td>
             </tr>
             <tr>
               <td><code>search-code</code></td>
@@ -99,16 +101,12 @@
         <h3>Claude Code</h3>
         <p>Add via the CLI:</p>
         <div class="code-block">
-          <div class="code-block-header">
-            Terminal <span class="lang-tag">bash</span>
-          </div>
+          <div class="code-block-header">Terminal <span class="lang-tag">bash</span></div>
           <pre><code>claude mcp add aimock-docs --transport http https://mcp.aimock.copilotkit.dev/mcp</code></pre>
         </div>
         <p>Or add to <code>~/.claude/mcp.json</code>:</p>
         <div class="code-block">
-          <div class="code-block-header">
-            ~/.claude/mcp.json <span class="lang-tag">json</span>
-          </div>
+          <div class="code-block-header">~/.claude/mcp.json <span class="lang-tag">json</span></div>
           <pre><code>{
   <span class="prop">"mcp-servers"</span>: {
     <span class="prop">"aimock-docs"</span>: {
@@ -137,9 +135,7 @@
 
         <h3>Cursor</h3>
         <div class="code-block">
-          <div class="code-block-header">
-            .cursor/mcp.json <span class="lang-tag">json</span>
-          </div>
+          <div class="code-block-header">.cursor/mcp.json <span class="lang-tag">json</span></div>
           <pre><code>{
   <span class="prop">"mcpServers"</span>: {
     <span class="prop">"aimock-docs"</span>: {
@@ -152,9 +148,7 @@
 
         <h3>OpenAI Codex</h3>
         <div class="code-block">
-          <div class="code-block-header">
-            codex-mcp.json <span class="lang-tag">json</span>
-          </div>
+          <div class="code-block-header">codex-mcp.json <span class="lang-tag">json</span></div>
           <pre><code>{
   <span class="prop">"mcpServers"</span>: {
     <span class="prop">"aimock-docs"</span>: {
@@ -187,17 +181,17 @@
         <h3>Generic (Streamable HTTP)</h3>
         <p>Any MCP-compatible client can connect via Streamable HTTP:</p>
         <div class="code-block">
-          <div class="code-block-header">
-            Endpoint <span class="lang-tag">text</span>
-          </div>
+          <div class="code-block-header">Endpoint <span class="lang-tag">text</span></div>
           <pre><code>URL:       https://mcp.aimock.copilotkit.dev/mcp
 Transport: Streamable HTTP
 Method:    POST</code></pre>
         </div>
 
         <h2>What Gets Indexed</h2>
-        <p>The MCP server indexes two sources from the
-          <a href="https://github.com/CopilotKit/aimock" target="_blank">aimock repository</a>:</p>
+        <p>
+          The MCP server indexes two sources from the
+          <a href="https://github.com/CopilotKit/aimock" target="_blank">aimock repository</a>:
+        </p>
         <ul>
           <li>
             <strong>Documentation</strong> — all HTML pages from <code>docs/</code>, chunked for

--- a/docs/mcp/index.html
+++ b/docs/mcp/index.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MCP Server — aimock</title>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+    <meta
+      name="description"
+      content="Connect AI agents to aimock documentation via MCP — Claude Code, Claude Desktop, Cursor, Codex, and any Streamable HTTP client."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <nav class="top-nav">
+      <div class="nav-inner">
+        <div style="display: flex; align-items: center; gap: 1rem">
+          <button
+            class="sidebar-toggle"
+            onclick="document.querySelector('.sidebar').classList.toggle('open')"
+            aria-label="Toggle sidebar"
+          >
+            &#9776;
+          </button>
+          <a href="/" class="nav-brand"> <span class="prompt">$</span> aimock </a>
+        </div>
+        <ul class="nav-links">
+          <li><a href="/">Home</a></li>
+          <li><a href="/docs" style="color: var(--accent)">Docs</a></li>
+          <li>
+            <a href="https://github.com/CopilotKit/aimock" class="gh-link" target="_blank"
+              ><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+              GitHub</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="docs-layout">
+      <aside class="sidebar" id="sidebar"></aside>
+
+      <main class="docs-content">
+        <h1>MCP Server</h1>
+        <p class="lead">
+          aimock's documentation and source code are indexed by a
+          <a href="https://github.com/CopilotKit/pathfinder" target="_blank">Pathfinder</a>
+          instance, giving AI agents semantic search and file exploration via MCP.
+        </p>
+
+        <h2>Available Tools</h2>
+        <p>
+          The MCP server exposes five tools that agents can use to find information about aimock:
+        </p>
+
+        <table class="endpoint-table">
+          <thead>
+            <tr>
+              <th>Tool</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>search-docs</code></td>
+              <td>Semantic search over aimock documentation — guides, API references, provider configs</td>
+            </tr>
+            <tr>
+              <td><code>search-code</code></td>
+              <td>Semantic search over aimock's TypeScript source — routers, handlers, builders</td>
+            </tr>
+            <tr>
+              <td><code>explore-docs</code></td>
+              <td>Browse documentation files with bash commands (find, grep, cat, ls, head)</td>
+            </tr>
+            <tr>
+              <td><code>explore-code</code></td>
+              <td>Browse source code files with bash commands</td>
+            </tr>
+            <tr>
+              <td><code>submit-feedback</code></td>
+              <td>Report whether search results were helpful to improve quality</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2>Connect Your Agent</h2>
+
+        <h3>Claude Code</h3>
+        <p>Add via the CLI:</p>
+        <div class="code-block">
+          <div class="code-block-header">
+            Terminal <span class="lang-tag">bash</span>
+          </div>
+          <pre><code>claude mcp add aimock-docs --transport http https://mcp.aimock.copilotkit.dev/mcp</code></pre>
+        </div>
+        <p>Or add to <code>~/.claude/mcp.json</code>:</p>
+        <div class="code-block">
+          <div class="code-block-header">
+            ~/.claude/mcp.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"mcp-servers"</span>: {
+    <span class="prop">"aimock-docs"</span>: {
+      <span class="prop">"type"</span>: <span class="str">"http"</span>,
+      <span class="prop">"url"</span>: <span class="str">"https://mcp.aimock.copilotkit.dev/mcp"</span>
+    }
+  }
+}</code></pre>
+        </div>
+
+        <h3>Claude Desktop</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            ~/Library/Application Support/Claude/claude_desktop_config.json
+            <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"mcpServers"</span>: {
+    <span class="prop">"aimock-docs"</span>: {
+      <span class="prop">"type"</span>: <span class="str">"http"</span>,
+      <span class="prop">"url"</span>: <span class="str">"https://mcp.aimock.copilotkit.dev/mcp"</span>
+    }
+  }
+}</code></pre>
+        </div>
+
+        <h3>Cursor</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            .cursor/mcp.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"mcpServers"</span>: {
+    <span class="prop">"aimock-docs"</span>: {
+      <span class="prop">"type"</span>: <span class="str">"http"</span>,
+      <span class="prop">"url"</span>: <span class="str">"https://mcp.aimock.copilotkit.dev/mcp"</span>
+    }
+  }
+}</code></pre>
+        </div>
+
+        <h3>OpenAI Codex</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            codex-mcp.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"mcpServers"</span>: {
+    <span class="prop">"aimock-docs"</span>: {
+      <span class="prop">"type"</span>: <span class="str">"http"</span>,
+      <span class="prop">"url"</span>: <span class="str">"https://mcp.aimock.copilotkit.dev/mcp"</span>
+    }
+  }
+}</code></pre>
+        </div>
+        <p>Then run: <code>codex --mcp-config codex-mcp.json</code></p>
+
+        <h3>VS Code (Continue)</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            ~/.continue/config.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"mcpServers"</span>: [
+    {
+      <span class="prop">"name"</span>: <span class="str">"aimock-docs"</span>,
+      <span class="prop">"transport"</span>: {
+        <span class="prop">"type"</span>: <span class="str">"http"</span>,
+        <span class="prop">"url"</span>: <span class="str">"https://mcp.aimock.copilotkit.dev/mcp"</span>
+      }
+    }
+  ]
+}</code></pre>
+        </div>
+
+        <h3>Generic (Streamable HTTP)</h3>
+        <p>Any MCP-compatible client can connect via Streamable HTTP:</p>
+        <div class="code-block">
+          <div class="code-block-header">
+            Endpoint <span class="lang-tag">text</span>
+          </div>
+          <pre><code>URL:       https://mcp.aimock.copilotkit.dev/mcp
+Transport: Streamable HTTP
+Method:    POST</code></pre>
+        </div>
+
+        <h2>What Gets Indexed</h2>
+        <p>The MCP server indexes two sources from the
+          <a href="https://github.com/CopilotKit/aimock" target="_blank">aimock repository</a>:</p>
+        <ul>
+          <li>
+            <strong>Documentation</strong> — all HTML pages from <code>docs/</code>, chunked for
+            semantic search with source URLs back to
+            <a href="https://aimock.copilotkit.dev">aimock.copilotkit.dev</a>
+          </li>
+          <li>
+            <strong>Source code</strong> — TypeScript files from <code>src/</code>, excluding tests,
+            chunked by logical code blocks
+          </li>
+        </ul>
+        <p>
+          The index auto-refreshes daily and on push via GitHub webhooks, so agents always search
+          against the latest content.
+        </p>
+
+        <h2>Verifying the Connection</h2>
+        <p>
+          Once connected, your agent should see the aimock tools in its available tools list. Try
+          asking your agent:
+        </p>
+        <ul>
+          <li><em>"Search aimock docs for how to mock streaming responses"</em></li>
+          <li><em>"Explore the aimock source code for the router implementation"</em></li>
+          <li><em>"How do I use fixtures with aimock?"</em></li>
+        </ul>
+      </main>
+      <aside class="page-toc" id="page-toc"></aside>
+    </div>
+    <footer class="docs-footer">
+      <div class="footer-inner">
+        <div class="footer-left"><span>$</span> aimock &middot; MIT License</div>
+        <ul class="footer-links">
+          <li><a href="https://github.com/CopilotKit/aimock" target="_blank">GitHub</a></li>
+          <li>
+            <a href="https://www.npmjs.com/package/@copilotkit/aimock" target="_blank">npm</a>
+          </li>
+        </ul>
+      </div>
+    </footer>
+    <script src="../sidebar.js"></script>
+    <script src="../cli-tabs.js"></script>
+  </body>
+</html>

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -10,6 +10,7 @@
         { label: "Quick Start: LLM", href: "/chat-completions" },
         { label: "Quick Start: aimock", href: "/aimock-cli" },
         { label: "Examples", href: "/examples" },
+        { label: "MCP Server", href: "/mcp" },
       ],
     },
     {


### PR DESCRIPTION
## Summary
- Add `docs/mcp/index.html` — documents the Pathfinder-powered MCP server for aimock docs and source code
- Covers available tools (search-docs, search-code, explore-docs, explore-code, submit-feedback)
- Client setup configs for Claude Code, Claude Desktop, Cursor, Codex, VS Code (Continue), and generic HTTP
- Add "MCP Server" link to sidebar under Getting Started

## Test plan
- [x] Verify page renders at `/mcp` on the docs site
- [x] Confirm sidebar link highlights correctly
- [x] Test MCP connection with `claude mcp add aimock-docs --transport http https://mcp.aimock.copilotkit.dev/mcp`