### PR TITLE
feat: add fal.ai as a first-class provider (record + replay)

### DIFF
--- a/src/__tests__/fal.test.ts
+++ b/src/__tests__/fal.test.ts
@@ -1,0 +1,314 @@
+import { describe, test, expect, afterEach } from "vitest";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { LLMock } from "../llmock.js";
+
+// Spin up a tiny stub upstream that responds with whatever JSON the test
+// hands it; lets us exercise the record-and-replay path without depending on
+// fal.ai itself.
+function startStubUpstream(
+  handler: (req: http.IncomingMessage, body: string) => { status?: number; body: unknown },
+): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString();
+        const result = handler(req, body);
+        res.writeHead(result.status ?? 200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result.body));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () =>
+          new Promise<void>((r) => {
+            server.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+describe("fal.ai general handler — fixture lookup", () => {
+  let mock: LLMock;
+
+  afterEach(async () => {
+    await mock?.stop();
+  });
+
+  test("onFalQueue: submit returns envelope, status returns COMPLETED, result returns JSON", async () => {
+    mock = new LLMock({ port: 0 });
+    mock.onFalQueue(/flux/, { images: [{ url: "https://example.com/cat.png" }] });
+    await mock.start();
+
+    const submit = await fetch(`${mock.url}/fal/fal-ai/flux/dev`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "queue.fal.run" },
+      body: JSON.stringify({ input: { prompt: "a cat" } }),
+    });
+    expect(submit.status).toBe(200);
+    const envelope = await submit.json();
+    expect(envelope.request_id).toBeDefined();
+    expect(envelope.status_url).toContain(envelope.request_id);
+    expect(envelope.response_url).toContain(envelope.request_id);
+    expect(envelope.cancel_url).toContain(envelope.request_id);
+
+    const status = await fetch(
+      `${mock.url}/fal/fal-ai/flux/dev/requests/${envelope.request_id}/status`,
+      { headers: { "x-fal-target-host": "queue.fal.run" } },
+    );
+    expect(status.status).toBe(200);
+    const statusBody = await status.json();
+    expect(statusBody.status).toBe("COMPLETED");
+    expect(statusBody.request_id).toBe(envelope.request_id);
+
+    const result = await fetch(`${mock.url}/fal/fal-ai/flux/dev/requests/${envelope.request_id}`, {
+      headers: { "x-fal-target-host": "queue.fal.run" },
+    });
+    expect(result.status).toBe(200);
+    const resultBody = await result.json();
+    expect(resultBody).toEqual({ images: [{ url: "https://example.com/cat.png" }] });
+  });
+
+  test("body extraction handles input.prompt nesting (fal-client default shape)", async () => {
+    mock = new LLMock({ port: 0 });
+    mock.onFalQueue(/flux/, { images: [{ url: "https://example.com/x.png" }] });
+    await mock.start();
+
+    const submit = await fetch(`${mock.url}/fal/fal-ai/flux/dev`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "queue.fal.run" },
+      body: JSON.stringify({ input: { prompt: "a cat", image_size: "square_hd" }, logs: false }),
+    });
+    expect(submit.status).toBe(200);
+  });
+
+  test("sync run returns JSON directly via x-fal-target-host: fal.run", async () => {
+    mock = new LLMock({ port: 0 });
+    mock.onFalRun(/flux/, { images: [{ url: "https://example.com/sync.png" }] });
+    await mock.start();
+
+    const res = await fetch(`${mock.url}/fal/fal-ai/flux/dev`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "fal.run" },
+      body: JSON.stringify({ prompt: "a cat" }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ images: [{ url: "https://example.com/sync.png" }] });
+    expect(data.request_id).toBeUndefined();
+  });
+
+  test("cancel returns ALREADY_COMPLETED for stored job", async () => {
+    mock = new LLMock({ port: 0 });
+    mock.onFalQueue(/kling/, { video: { url: "https://example.com/v.mp4" } });
+    await mock.start();
+
+    const submit = await fetch(`${mock.url}/fal/fal-ai/kling/v1`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "queue.fal.run" },
+      body: JSON.stringify({ input: { prompt: "river" } }),
+    });
+    const envelope = await submit.json();
+
+    const cancel = await fetch(
+      `${mock.url}/fal/fal-ai/kling/v1/requests/${envelope.request_id}/cancel`,
+      { method: "PUT", headers: { "x-fal-target-host": "queue.fal.run" } },
+    );
+    expect(cancel.status).toBe(400);
+    const body = await cancel.json();
+    expect(body.status).toBe("ALREADY_COMPLETED");
+  });
+
+  test("status for unknown request_id returns 404", async () => {
+    mock = new LLMock({ port: 0 });
+    await mock.start();
+
+    const res = await fetch(`${mock.url}/fal/fal-ai/flux/dev/requests/missing/status`, {
+      headers: { "x-fal-target-host": "queue.fal.run" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("no fixture match returns 404 in non-strict mode", async () => {
+    mock = new LLMock({ port: 0 });
+    mock.onFalQueue(/flux/, { images: [] });
+    await mock.start();
+
+    const res = await fetch(`${mock.url}/fal/fal-ai/different-model/v1`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "queue.fal.run" },
+      body: JSON.stringify({ input: { prompt: "x" } }),
+    });
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error.code).toBe("no_fixture_match");
+  });
+
+  test("error fixture returns the configured status", async () => {
+    mock = new LLMock({ port: 0 });
+    mock.addFixture({
+      match: { model: /kling/, endpoint: "fal" },
+      response: { error: { message: "rate limited", type: "rate_limit_error" }, status: 429 },
+    });
+    await mock.start();
+
+    const res = await fetch(`${mock.url}/fal/fal-ai/kling/v1`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "queue.fal.run" },
+      body: JSON.stringify({ input: { prompt: "river" } }),
+    });
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error.message).toBe("rate limited");
+  });
+
+  test("storage upload initiate returns synthesised envelope", async () => {
+    mock = new LLMock({ port: 0 });
+    await mock.start();
+
+    const res = await fetch(`${mock.url}/fal/storage/upload/initiate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "rest.alpha.fal.ai" },
+      body: JSON.stringify({ filename: "cat.png" }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.upload_url).toContain("rest.alpha.fal.ai");
+    expect(data.file_url).toContain("cat.png");
+  });
+
+  test("X-Test-Id isolation across queue jobs", async () => {
+    mock = new LLMock({ port: 0 });
+    mock.onFalQueue(/flux/, { images: [{ url: "https://example.com/iso.png" }] });
+    await mock.start();
+
+    const submitA = await fetch(`${mock.url}/fal/fal-ai/flux/dev`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-fal-target-host": "queue.fal.run",
+        "X-Test-Id": "A",
+      },
+      body: JSON.stringify({ input: { prompt: "a" } }),
+    });
+    const envelopeA = await submitA.json();
+
+    const cross = await fetch(
+      `${mock.url}/fal/fal-ai/flux/dev/requests/${envelopeA.request_id}/status`,
+      {
+        headers: { "x-fal-target-host": "queue.fal.run", "X-Test-Id": "B" },
+      },
+    );
+    expect(cross.status).toBe(404);
+
+    const same = await fetch(
+      `${mock.url}/fal/fal-ai/flux/dev/requests/${envelopeA.request_id}/status`,
+      {
+        headers: { "x-fal-target-host": "queue.fal.run", "X-Test-Id": "A" },
+      },
+    );
+    expect(same.status).toBe(200);
+  });
+
+  test("legacy /fal/queue/submit/{model} path still works for audio fixtures", async () => {
+    mock = new LLMock({ port: 0 });
+    mock.onFalAudio("drum", { audio: "SGVsbG8=", format: "mp3" });
+    await mock.start();
+
+    const submit = await fetch(`${mock.url}/fal/queue/submit/fal-ai/stable-audio`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "drum" }),
+    });
+    expect(submit.status).toBe(200);
+  });
+});
+
+describe("fal.ai general handler — record and replay", () => {
+  let mock: LLMock;
+  let upstream: { url: string; close: () => Promise<void> } | undefined;
+  let tmpDir: string | undefined;
+
+  afterEach(async () => {
+    await mock?.stop();
+    await upstream?.close();
+    upstream = undefined;
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  test("proxies unmatched fal request to upstream and saves fixture", async () => {
+    upstream = await startStubUpstream(() => ({
+      body: { images: [{ url: "https://example.com/recorded.png" }] },
+    }));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-fal-record-"));
+
+    mock = new LLMock({
+      port: 0,
+      record: { providers: { fal: upstream.url }, fixturePath: tmpDir },
+    });
+    await mock.start();
+
+    // In record mode the proxy is transparent — what upstream says is what
+    // the client gets. Queue envelope synthesis only happens in fixture mode.
+    const res = await fetch(`${mock.url}/fal/fal-ai/flux/dev`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "queue.fal.run" },
+      body: JSON.stringify({ input: { prompt: "a cat" } }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ images: [{ url: "https://example.com/recorded.png" }] });
+
+    const files = fs.readdirSync(tmpDir);
+    const falFixtures = files.filter((f) => f.startsWith("fal-") && f.endsWith(".json"));
+    expect(falFixtures.length).toBeGreaterThanOrEqual(1);
+
+    const recorded = JSON.parse(fs.readFileSync(path.join(tmpDir, falFixtures[0]), "utf-8"));
+    expect(recorded.fixtures[0].match.endpoint).toBe("fal");
+    expect(recorded.fixtures[0].response.json).toEqual({
+      images: [{ url: "https://example.com/recorded.png" }],
+    });
+  });
+
+  test("replays from in-memory fixture on second identical request (no second proxy)", async () => {
+    let upstreamCalls = 0;
+    upstream = await startStubUpstream(() => {
+      upstreamCalls++;
+      return { body: { images: [{ url: "https://example.com/replay.png" }] } };
+    });
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-fal-replay-"));
+
+    mock = new LLMock({
+      port: 0,
+      record: { providers: { fal: upstream.url }, fixturePath: tmpDir },
+    });
+    await mock.start();
+
+    // First call — hits upstream
+    await fetch(`${mock.url}/fal/fal-ai/flux/dev`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "queue.fal.run" },
+      body: JSON.stringify({ input: { prompt: "a cat" } }),
+    });
+    expect(upstreamCalls).toBe(1);
+
+    // Second call — should match recorded fixture, no upstream hit
+    const res2 = await fetch(`${mock.url}/fal/fal-ai/flux/dev`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-fal-target-host": "queue.fal.run" },
+      body: JSON.stringify({ input: { prompt: "a cat" } }),
+    });
+    expect(res2.status).toBe(200);
+    expect(upstreamCalls).toBe(1);
+  });
+});

--- a/src/fal-audio.ts
+++ b/src/fal-audio.ts
@@ -74,7 +74,7 @@ export const falJobs = new FalJobMap();
 
 // ─── Audio response translation ──────────────────────────────────────────
 
-function audioToFalFile(response: AudioResponse): Record<string, unknown> {
+export function audioToFalFile(response: AudioResponse): Record<string, unknown> {
   let contentType: string;
   let data: string;
 

--- a/src/fal.ts
+++ b/src/fal.ts
@@ -1,0 +1,514 @@
+import type http from "node:http";
+import crypto from "node:crypto";
+import type { ChatCompletionRequest, Fixture, HandlerDefaults, RawJSONResponse } from "./types.js";
+import {
+  isAudioResponse,
+  isErrorResponse,
+  isJSONResponse,
+  flattenHeaders,
+  getTestId,
+} from "./helpers.js";
+import { matchFixture } from "./router.js";
+import { proxyAndRecord } from "./recorder.js";
+import type { Journal } from "./journal.js";
+import { audioToFalFile } from "./fal-audio.js";
+
+// ─── FalQueueState (TTL + bounded) ───────────────────────────────────────
+
+const FAL_QUEUE_MAX_ENTRIES = 10_000;
+const FAL_QUEUE_TTL_MS = 3_600_000; // 1 hour
+
+interface FalQueueJob {
+  requestId: string;
+  modelId: string;
+  status: "IN_QUEUE" | "IN_PROGRESS" | "COMPLETED";
+  result: unknown;
+  createdAt: number;
+}
+
+interface FalQueueEntry {
+  job: FalQueueJob;
+  createdAt: number;
+}
+
+/**
+ * Per-testId queue state for the general fal handler. Mirrors FalJobMap from
+ * fal-audio.ts but stores arbitrary JSON payloads instead of audio file
+ * objects, so it can serve any fal model (image, video, motion, music, etc.).
+ */
+export class FalQueueStateMap {
+  private readonly entries = new Map<string, FalQueueEntry>();
+
+  get(key: string): FalQueueJob | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (Date.now() - entry.createdAt > FAL_QUEUE_TTL_MS) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    return entry.job;
+  }
+
+  set(key: string, job: FalQueueJob): void {
+    this.entries.set(key, { job, createdAt: Date.now() });
+    if (this.entries.size > FAL_QUEUE_MAX_ENTRIES) {
+      const excess = this.entries.size - FAL_QUEUE_MAX_ENTRIES;
+      const iter = this.entries.keys();
+      for (let i = 0; i < excess; i++) {
+        const next = iter.next();
+        if (!next.done) this.entries.delete(next.value);
+      }
+    }
+  }
+
+  delete(key: string): boolean {
+    return this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+export const falQueueStates = new FalQueueStateMap();
+
+// ─── Hosts and routing ──────────────────────────────────────────────────
+
+const FAL_HOSTS = {
+  queue: "queue.fal.run",
+  sync: "fal.run",
+  storage: "rest.fal.ai",
+  storageAlpha: "rest.alpha.fal.ai",
+  gateway: "gateway.fal.ai",
+} as const;
+
+const QUEUE_REQUESTS_RE = /^(.+)\/requests\/([^/]+)(\/status|\/cancel)?$/;
+const STORAGE_INITIATE_PATH = "/storage/upload/initiate";
+
+function stripFalPrefix(pathname: string): string {
+  const stripped = pathname.replace(/^\/fal/, "");
+  return stripped.length > 0 ? stripped : "/";
+}
+
+function extractPromptFromBody(body: unknown): string {
+  if (!body || typeof body !== "object") return "";
+  const obj = body as Record<string, unknown>;
+  if (typeof obj.prompt === "string") return obj.prompt;
+  if (typeof obj.text === "string") return obj.text;
+  const input = obj.input;
+  if (input && typeof input === "object") {
+    const inputObj = input as Record<string, unknown>;
+    if (typeof inputObj.prompt === "string") return inputObj.prompt;
+    if (typeof inputObj.text === "string") return inputObj.text;
+  }
+  return "";
+}
+
+interface ParsedFalPath {
+  modelId: string;
+  requestId?: string;
+  action?: "status" | "cancel" | "result";
+}
+
+function parseFalPath(stripped: string): ParsedFalPath | null {
+  if (!stripped.startsWith("/")) return null;
+  const trimmed = stripped.replace(/^\/+/, "");
+  if (!trimmed) return null;
+
+  const m = QUEUE_REQUESTS_RE.exec(`/${trimmed}`);
+  if (m) {
+    const modelId = m[1].replace(/^\/+/, "");
+    const action = m[3] === "/status" ? "status" : m[3] === "/cancel" ? "cancel" : "result";
+    return { modelId, requestId: m[2], action };
+  }
+  return { modelId: trimmed };
+}
+
+export type HandleFalOutcome = "handled" | "passthrough";
+
+interface FalRouteInfo {
+  kind: "queue-submit" | "queue-status" | "queue-result" | "queue-cancel" | "sync-run" | "storage";
+  modelId?: string;
+  requestId?: string;
+  targetHost: string;
+}
+
+function classifyRoute(
+  req: http.IncomingMessage,
+  pathname: string,
+  targetHost: string,
+): FalRouteInfo | null {
+  const stripped = stripFalPrefix(pathname);
+
+  if (targetHost === FAL_HOSTS.storage || targetHost === FAL_HOSTS.storageAlpha) {
+    if (req.method === "POST" && stripped === STORAGE_INITIATE_PATH) {
+      return { kind: "storage", targetHost };
+    }
+    return null;
+  }
+
+  const parsed = parseFalPath(stripped);
+  if (!parsed) return null;
+
+  if (targetHost === FAL_HOSTS.queue) {
+    if (parsed.requestId) {
+      if (parsed.action === "status" && req.method === "GET") {
+        return {
+          kind: "queue-status",
+          modelId: parsed.modelId,
+          requestId: parsed.requestId,
+          targetHost,
+        };
+      }
+      if (parsed.action === "cancel" && req.method === "PUT") {
+        return {
+          kind: "queue-cancel",
+          modelId: parsed.modelId,
+          requestId: parsed.requestId,
+          targetHost,
+        };
+      }
+      if (parsed.action === "result" && req.method === "GET") {
+        return {
+          kind: "queue-result",
+          modelId: parsed.modelId,
+          requestId: parsed.requestId,
+          targetHost,
+        };
+      }
+      return null;
+    }
+    if (req.method === "POST") {
+      return { kind: "queue-submit", modelId: parsed.modelId, targetHost };
+    }
+    return null;
+  }
+
+  if (targetHost === FAL_HOSTS.sync) {
+    if (req.method === "POST" && parsed.modelId) {
+      return { kind: "sync-run", modelId: parsed.modelId, targetHost };
+    }
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * General fal.ai handler. Routes by `x-fal-target-host` header (the convention
+ * used by `@fal-ai/client`'s server-side requestMiddleware workaround for the
+ * fact that `proxyUrl` is browser-only).
+ *
+ * Returns `"passthrough"` when the request does not look like a host-mirrored
+ * fal call, so the caller can fall back to the legacy `/fal/queue/...` and
+ * `/fal/run/...` audio routes.
+ */
+export async function handleFal(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  body: string,
+  pathname: string,
+  fixtures: Fixture[],
+  defaults: HandlerDefaults,
+  journal: Journal,
+): Promise<HandleFalOutcome> {
+  const targetHostHeader = req.headers["x-fal-target-host"];
+  const targetHost = Array.isArray(targetHostHeader) ? targetHostHeader[0] : targetHostHeader;
+  if (!targetHost) return "passthrough";
+
+  const route = classifyRoute(req, pathname, targetHost);
+  if (!route) return "passthrough";
+
+  const testId = getTestId(req);
+  const stateKey = (id: string) => `${testId}:${id}`;
+
+  switch (route.kind) {
+    case "queue-status": {
+      const job = falQueueStates.get(stateKey(route.requestId!));
+      if (!job) {
+        respondNotFound(req, res, pathname, journal, route.requestId!);
+        return "handled";
+      }
+      const responseBody = {
+        status: job.status,
+        request_id: job.requestId,
+        response_url: `https://${FAL_HOSTS.queue}/${job.modelId}/requests/${job.requestId}`,
+      };
+      writeJson(req, res, 200, responseBody, pathname, journal);
+      return "handled";
+    }
+
+    case "queue-result": {
+      const job = falQueueStates.get(stateKey(route.requestId!));
+      if (!job) {
+        respondNotFound(req, res, pathname, journal, route.requestId!);
+        return "handled";
+      }
+      writeJson(req, res, 200, job.result, pathname, journal);
+      return "handled";
+    }
+
+    case "queue-cancel": {
+      const job = falQueueStates.get(stateKey(route.requestId!));
+      if (!job) {
+        journal.add({
+          method: req.method ?? "PUT",
+          path: pathname,
+          headers: flattenHeaders(req.headers),
+          body: null,
+          response: { status: 404, fixture: null },
+        });
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "NOT_FOUND" }));
+        return "handled";
+      }
+      journal.add({
+        method: req.method ?? "PUT",
+        path: pathname,
+        headers: flattenHeaders(req.headers),
+        body: null,
+        response: { status: 400, fixture: null },
+      });
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ALREADY_COMPLETED" }));
+      return "handled";
+    }
+
+    case "storage": {
+      let filename = "upload.bin";
+      try {
+        const parsed = body ? (JSON.parse(body) as Record<string, unknown>) : {};
+        if (typeof parsed.filename === "string") filename = parsed.filename;
+        if (typeof parsed.file_name === "string") filename = parsed.file_name;
+      } catch {
+        // ignore — stub doesn't require a structured body
+      }
+      const fileId = crypto.randomUUID();
+      const responseBody = {
+        upload_url: `https://${route.targetHost}/storage/upload/${fileId}`,
+        file_url: `https://${route.targetHost}/files/${fileId}/${filename}`,
+      };
+      writeJson(req, res, 200, responseBody, pathname, journal);
+      return "handled";
+    }
+
+    case "queue-submit":
+    case "sync-run": {
+      const modelId = route.modelId!;
+      const parsedBody = parseBody(body);
+      const prompt = extractPromptFromBody(parsedBody);
+      const syntheticReq: ChatCompletionRequest = {
+        model: modelId,
+        messages: [{ role: "user", content: prompt || JSON.stringify(parsedBody ?? {}) }],
+        _endpointType: "fal",
+      };
+
+      const matchCounts = journal.getFixtureMatchCountsForTest(testId);
+      const fixture = matchFixture(fixtures, syntheticReq, matchCounts, defaults.requestTransform);
+
+      if (!fixture) {
+        if (defaults.record) {
+          const effectiveDefaults = withFalUpstream(defaults, route.targetHost);
+          const outcome = await proxyAndRecord(
+            req,
+            res,
+            syntheticReq,
+            "fal",
+            stripFalPrefix(pathname),
+            fixtures,
+            effectiveDefaults,
+            body,
+          );
+          if (outcome === "handled_by_hook") return "handled";
+          if (outcome === "relayed") {
+            journal.add({
+              method: req.method ?? "POST",
+              path: pathname,
+              headers: flattenHeaders(req.headers),
+              body: syntheticReq,
+              response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
+            });
+            return "handled";
+          }
+        }
+
+        const strictStatus = defaults.strict ? 503 : 404;
+        const strictMessage = defaults.strict
+          ? "Strict mode: no fixture matched"
+          : "No fixture matched";
+        journal.add({
+          method: req.method ?? "POST",
+          path: pathname,
+          headers: flattenHeaders(req.headers),
+          body: syntheticReq,
+          response: { status: strictStatus, fixture: null },
+        });
+        res.writeHead(strictStatus, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: {
+              message: strictMessage,
+              type: "invalid_request_error",
+              code: "no_fixture_match",
+            },
+          }),
+        );
+        return "handled";
+      }
+
+      journal.incrementFixtureMatchCount(fixture, fixtures, testId);
+      const response = fixture.response;
+
+      if (isErrorResponse(response)) {
+        const status = response.status ?? 500;
+        journal.add({
+          method: req.method ?? "POST",
+          path: pathname,
+          headers: flattenHeaders(req.headers),
+          body: syntheticReq,
+          response: { status, fixture },
+        });
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(response));
+        return "handled";
+      }
+
+      let payload: unknown;
+      if (isJSONResponse(response)) {
+        payload = (response as RawJSONResponse).json;
+      } else if (isAudioResponse(response)) {
+        payload = audioToFalFile(response);
+      } else {
+        journal.add({
+          method: req.method ?? "POST",
+          path: pathname,
+          headers: flattenHeaders(req.headers),
+          body: syntheticReq,
+          response: { status: 500, fixture },
+        });
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: {
+              message: "Fixture response is not JSON or audio for fal endpoint",
+              type: "server_error",
+            },
+          }),
+        );
+        return "handled";
+      }
+
+      if (route.kind === "sync-run") {
+        journal.add({
+          method: req.method ?? "POST",
+          path: pathname,
+          headers: flattenHeaders(req.headers),
+          body: syntheticReq,
+          response: { status: 200, fixture },
+        });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(payload));
+        return "handled";
+      }
+
+      const requestId = crypto.randomUUID();
+      falQueueStates.set(stateKey(requestId), {
+        requestId,
+        modelId,
+        status: "COMPLETED",
+        result: payload,
+        createdAt: Date.now(),
+      });
+      const envelope = {
+        request_id: requestId,
+        response_url: `https://${FAL_HOSTS.queue}/${modelId}/requests/${requestId}`,
+        status_url: `https://${FAL_HOSTS.queue}/${modelId}/requests/${requestId}/status`,
+        cancel_url: `https://${FAL_HOSTS.queue}/${modelId}/requests/${requestId}/cancel`,
+        queue_position: 0,
+      };
+      journal.add({
+        method: req.method ?? "POST",
+        path: pathname,
+        headers: flattenHeaders(req.headers),
+        body: syntheticReq,
+        response: { status: 200, fixture },
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(envelope));
+      return "handled";
+    }
+  }
+}
+
+function parseBody(raw: string): Record<string, unknown> | null {
+  if (!raw.trim()) return null;
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function withFalUpstream(defaults: HandlerDefaults, targetHost: string): HandlerDefaults {
+  if (!defaults.record) return defaults;
+  // Respect an explicit record.providers.fal — tests and dev configs need to
+  // point at a stub upstream. Only synthesise from the header when the user
+  // didn't configure one (the "or omit upstream URL — it's in the request
+  // hostname" mode from the issue).
+  if (defaults.record.providers.fal) return defaults;
+  return {
+    ...defaults,
+    record: {
+      ...defaults.record,
+      providers: {
+        ...defaults.record.providers,
+        fal: `https://${targetHost}`,
+      },
+    },
+  };
+}
+
+function writeJson(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  status: number,
+  payload: unknown,
+  pathname: string,
+  journal: Journal,
+): void {
+  journal.add({
+    method: req.method ?? "GET",
+    path: pathname,
+    headers: flattenHeaders(req.headers),
+    body: null,
+    response: { status, fixture: null },
+  });
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function respondNotFound(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  pathname: string,
+  journal: Journal,
+  requestId: string,
+): void {
+  journal.add({
+    method: req.method ?? "GET",
+    path: pathname,
+    headers: flattenHeaders(req.headers),
+    body: null,
+    response: { status: 404, fixture: null },
+  });
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      error: { message: `Request ${requestId} not found`, type: "not_found" },
+    }),
+  );
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -11,6 +11,7 @@ import type {
   AudioResponse,
   TranscriptionResponse,
   VideoResponse,
+  RawJSONResponse,
   SSEChunk,
   ToolCall,
   ChatCompletion,
@@ -131,6 +132,10 @@ export function isVideoResponse(r: FixtureResponse): r is VideoResponse {
     (r as VideoResponse).video != null &&
     typeof (r as VideoResponse).video === "object"
   );
+}
+
+export function isJSONResponse(r: FixtureResponse): r is RawJSONResponse {
+  return "json" in r && (r as RawJSONResponse).json !== undefined;
 }
 
 export function extractOverrides(

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ export { handleTranscription } from "./transcription.js";
 export { handleVideoCreate, handleVideoStatus, VideoStateMap } from "./video.js";
 export { handleElevenLabsAudio } from "./elevenlabs-audio.js";
 export { handleFalQueue } from "./fal-audio.js";
+export { handleFal, FalQueueStateMap } from "./fal.js";
 
 // Helpers
 export {
@@ -335,6 +336,7 @@ export type {
   AudioResponse,
   TranscriptionResponse,
   VideoResponse,
+  RawJSONResponse,
   ResponseOverrides,
   ContentWithToolCallsResponse,
   FixtureFileResponse,

--- a/src/llmock.ts
+++ b/src/llmock.ts
@@ -28,6 +28,7 @@ import type { SearchFixture, SearchResult } from "./search.js";
 import type { RerankFixture, RerankResult } from "./rerank.js";
 import type { ModerationFixture, ModerationResult } from "./moderation.js";
 import { falJobs } from "./fal-audio.js";
+import { falQueueStates } from "./fal.js";
 
 export class LLMock {
   private fixtures: Fixture[] = [];
@@ -193,6 +194,19 @@ export class LLMock {
     });
   }
 
+  // fal.queue.* is the dominant client API; onFalRun is a sync alias.
+  onFalQueue(modelOrPrompt: string | RegExp, response: unknown, opts?: FixtureOpts): this {
+    return this.addFixture({
+      match: { model: modelOrPrompt, endpoint: "fal" },
+      response: { json: response },
+      ...opts,
+    });
+  }
+
+  onFalRun(modelOrPrompt: string | RegExp, response: unknown, opts?: FixtureOpts): this {
+    return this.onFalQueue(modelOrPrompt, response, opts);
+  }
+
   // ---- Service mock convenience methods ----
 
   onSearch(pattern: string | RegExp, results: SearchResult[]): this {
@@ -318,6 +332,7 @@ export class LLMock {
     this.rerankFixtures.length = 0;
     this.moderationFixtures.length = 0;
     falJobs.clear();
+    falQueueStates.clear();
     if (this.serverInstance) {
       this.serverInstance.journal.clear();
       this.serverInstance.videoStates.clear();

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -265,15 +265,39 @@ export async function proxyAndRecord(
       // Not JSON — could be an unknown format
       defaults.logger.warn("Upstream response is not valid JSON — saving as error fixture");
     }
-    let encodingFormat: string | undefined;
-    try {
-      encodingFormat = rawBody ? JSON.parse(rawBody).encoding_format : undefined;
-    } catch (err) {
-      defaults.logger.debug(
-        `Could not parse encoding_format from raw body: ${err instanceof Error ? err.message : "unknown error"}`,
-      );
+    // fal.ai returns arbitrary, model-specific JSON shapes (images, video URLs,
+    // audio file objects, etc.). Round-trip the payload verbatim instead of
+    // letting buildFixtureResponse mis-classify it as ImageResponse / VideoResponse.
+    if (request._endpointType === "fal" && parsedResponse !== null) {
+      const obj = parsedResponse as Record<string, unknown>;
+      const isErrorShape =
+        typeof obj.error === "object" &&
+        obj.error !== null &&
+        typeof (obj.error as Record<string, unknown>).message === "string";
+      if (isErrorShape) {
+        const err = obj.error as Record<string, unknown>;
+        fixtureResponse = {
+          error: {
+            message: String(err.message ?? "Unknown error"),
+            type: String(err.type ?? "api_error"),
+            code: err.code ? String(err.code) : undefined,
+          },
+          status: upstreamStatus,
+        };
+      } else {
+        fixtureResponse = { json: parsedResponse, status: upstreamStatus };
+      }
+    } else {
+      let encodingFormat: string | undefined;
+      try {
+        encodingFormat = rawBody ? JSON.parse(rawBody).encoding_format : undefined;
+      } catch (err) {
+        defaults.logger.debug(
+          `Could not parse encoding_format from raw body: ${err instanceof Error ? err.message : "unknown error"}`,
+        );
+      }
+      fixtureResponse = buildFixtureResponse(parsedResponse, upstreamStatus, encodingFormat);
     }
-    fixtureResponse = buildFixtureResponse(parsedResponse, upstreamStatus, encodingFormat);
   }
 
   // If the client disconnected mid-stream, the collected data is likely
@@ -986,14 +1010,21 @@ type EndpointType =
   | "video"
   | "embedding"
   | "audio-gen"
-  | "fal-audio";
+  | "fal-audio"
+  | "fal";
 
 function buildFixtureMatch(request: ChatCompletionRequest): {
   userMessage?: string;
   inputText?: string;
+  model?: string;
   endpoint?: EndpointType;
 } {
-  const match: { userMessage?: string; inputText?: string; endpoint?: EndpointType } = {};
+  const match: {
+    userMessage?: string;
+    inputText?: string;
+    model?: string;
+    endpoint?: EndpointType;
+  } = {};
 
   // Include endpoint type for multimedia fixtures
   if (request._endpointType && request._endpointType !== "chat") {
@@ -1013,6 +1044,13 @@ function buildFixtureMatch(request: ChatCompletionRequest): {
     if (text) {
       match.userMessage = text;
     }
+  }
+
+  // fal.ai fixtures are typically authored against the model id (e.g.
+  // /flux/, /kling/) since the request body is opaque per-model JSON. Persist
+  // the resolved model so replay matches what `onFalQueue(/flux/, ...)` writes.
+  if (request._endpointType === "fal" && request.model) {
+    match.model = request.model;
   }
 
   return match;

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,6 +4,8 @@ import {
   isAudioResponse,
   isTranscriptionResponse,
   isVideoResponse,
+  isJSONResponse,
+  isErrorResponse,
 } from "./helpers.js";
 
 export function getLastMessageByRole(messages: ChatMessage[], role: string): ChatMessage | null {
@@ -64,6 +66,7 @@ export function matchFixture(
         (reqEndpoint === "speech" && isAudioResponse(r)) ||
         (reqEndpoint === "audio-gen" && isAudioResponse(r)) ||
         (reqEndpoint === "fal-audio" && isAudioResponse(r)) ||
+        (reqEndpoint === "fal" && (isJSONResponse(r) || isErrorResponse(r))) ||
         (reqEndpoint === "transcription" && isTranscriptionResponse(r)) ||
         (reqEndpoint === "video" && isVideoResponse(r));
       if (!compatible) continue;

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,7 @@ import { handleTranscription } from "./transcription.js";
 import { handleVideoCreate, handleVideoStatus, VideoStateMap } from "./video.js";
 import { handleElevenLabsAudio } from "./elevenlabs-audio.js";
 import { handleFalQueue, falJobs } from "./fal-audio.js";
+import { handleFal, falQueueStates } from "./fal.js";
 import { handleOllama, handleOllamaGenerate } from "./ollama.js";
 import { handleCohere } from "./cohere.js";
 import { handleSearch, type SearchFixture } from "./search.js";
@@ -86,6 +87,7 @@ const ELEVENLABS_MUSIC_RE = /^\/v1\/music(?:\/(.+))?$/;
 const FAL_QUEUE_SUBMIT_RE = /^\/fal\/queue\/submit\/(.+)$/;
 const FAL_QUEUE_REQUESTS_RE = /^\/fal\/queue\/requests\/(.+)$/;
 const FAL_RUN_RE = /^\/fal\/run\/(.+)$/;
+const FAL_PREFIX_RE = /^\/fal(?:\/.*)?$/;
 const DEFAULT_CHUNK_SIZE = 20;
 
 // OpenAI-compatible endpoint suffixes for path prefix normalization.
@@ -303,6 +305,7 @@ async function handleControlAPI(
     journal.clear();
     videoStates.clear();
     falJobs.clear();
+    falQueueStates.clear();
     if (defaults.registry) {
       defaults.registry.setGauge("aimock_fixtures_loaded", {}, fixtures.length);
     }
@@ -1782,6 +1785,50 @@ export async function createServer(
         }
       }
       return;
+    }
+
+    // /fal/* with `x-fal-target-host` header — general fal.ai routing
+    // (queue.fal.run, fal.run, rest.fal.ai, rest.alpha.fal.ai).
+    // Matches the requestMiddleware path-mirror convention used by
+    // @fal-ai/client when proxyUrl can't be honoured server-side.
+    if (FAL_PREFIX_RE.test(pathname) && req.headers["x-fal-target-host"]) {
+      setCorsHeaders(res);
+      try {
+        const raw = req.method === "POST" || req.method === "PUT" ? await readBody(req) : "";
+        const chaosAction = evaluateChaos(null, defaults.chaos, req.headers, defaults.logger);
+        if (chaosAction) {
+          applyChaosAction(
+            chaosAction,
+            res,
+            null,
+            journal,
+            {
+              method: req.method ?? "GET",
+              path: pathname,
+              headers: flattenHeaders(req.headers),
+              body: { model: "", messages: [] },
+            },
+            "fixture",
+            defaults.registry,
+          );
+          return;
+        }
+        const outcome = await handleFal(req, res, raw, pathname, fixtures, defaults, journal);
+        if (outcome === "handled") return;
+        // passthrough: fall through to legacy fal-audio routes below
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : "Internal error";
+        if (!res.headersSent) {
+          writeErrorResponse(
+            res,
+            500,
+            JSON.stringify({ error: { message: msg, type: "server_error" } }),
+          );
+        } else if (!res.writableEnded) {
+          res.destroy();
+        }
+        return;
+      }
     }
 
     // POST /fal/queue/submit/{model} — fal.ai Queue Submit

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,8 @@ export interface FixtureMatch {
     | "video"
     | "embedding"
     | "audio-gen"
-    | "fal-audio";
+    | "fal-audio"
+    | "fal";
 }
 
 // Fixture response types
@@ -187,6 +188,16 @@ export interface VideoResponse {
   };
 }
 
+/**
+ * Pass-through JSON response. Used by handlers (e.g. fal.ai) that record
+ * arbitrary upstream JSON payloads and replay them verbatim, without the
+ * provider-specific shape coercion the other response types impose.
+ */
+export interface RawJSONResponse extends ResponseOverrides {
+  json: unknown;
+  status?: number;
+}
+
 export type FixtureResponse =
   | TextResponse
   | ToolCallResponse
@@ -196,7 +207,8 @@ export type FixtureResponse =
   | ImageResponse
   | AudioResponse
   | TranscriptionResponse
-  | VideoResponse;
+  | VideoResponse
+  | RawJSONResponse;
 
 // Streaming physics
 
@@ -281,7 +293,8 @@ export type FixtureFileResponse =
   | ImageResponse
   | AudioResponse
   | TranscriptionResponse
-  | VideoResponse;
+  | VideoResponse
+  | RawJSONResponse;
 
 export interface FixtureFile {
   fixtures: FixtureFileEntry[];
@@ -306,7 +319,8 @@ export interface FixtureFileEntry {
       | "video"
       | "embedding"
       | "audio-gen"
-      | "fal-audio";
+      | "fal-audio"
+      | "fal";
     // predicate not supported in JSON files
   };
   response: FixtureFileResponse;


### PR DESCRIPTION
## Summary

- Adds a general fal.ai handler (`src/fal.ts`) supporting arbitrary JSON request/response payloads — image, video, motion, music, etc. — alongside the existing audio-only `src/fal-audio.ts`.
- Routes by `x-fal-target-host` header to mirror the `@fal-ai/client` server-side `requestMiddleware` convention (since `proxyUrl` is browser-only). Falls through to the legacy `/fal/queue/...` and `/fal/run/...` paths for back-compat.
- Adds `mock.onFalQueue(/model/, payload)` (primary) and `mock.onFalRun(/model/, payload)` (sync alias) to `LLMock`. Queue submit auto-mints a request_id and returns the standard envelope; status/result lookups go through a per-testId TTL+bounded `FalQueueStateMap` (mirrors the `FalJobMap` pattern from `fal-audio.ts` and the `VideoStateMap` from `video.ts`).
- Adds a `RawJSONResponse` (`{ json: unknown }`) variant to `FixtureResponse` so the recorder can save fal payloads verbatim instead of mis-classifying them as `ImageResponse` / `VideoResponse`.

Closes #152.

## Surface

| Method | Path | x-fal-target-host | Behaviour |
| --- | --- | --- | --- |
| POST | `/fal/{owner}/{model}` | `queue.fal.run` | queue submit (auto-mints request_id, returns envelope) |
| GET | `/fal/{owner}/{model}/requests/{id}/status` | `queue.fal.run` | queue status (`COMPLETED`) |
| GET | `/fal/{owner}/{model}/requests/{id}` | `queue.fal.run` | queue result (the matched JSON payload) |
| PUT | `/fal/{owner}/{model}/requests/{id}/cancel` | `queue.fal.run` | `ALREADY_COMPLETED` |
| POST | `/fal/{owner}/{model}` | `fal.run` | sync run (returns JSON directly, no envelope) |
| POST | `/fal/storage/upload/initiate` | `rest.fal.ai` / `rest.alpha.fal.ai` | synthesised upload envelope stub |
| _legacy_ | `/fal/queue/submit/{model}`, `/fal/queue/requests/{id}/...`, `/fal/run/{model}` | _(none)_ | unchanged — `fal-audio.ts` |

## Usage

```ts
const mock = await LLMock.create({ port: 4010 });
mock.onFalQueue(/flux/, { images: [{ url: 'https://example.com/cat.png' }] });
mock.onFalQueue(/kling/, { video: { url: 'https://example.com/v.mp4' } });

// In your app:
fal.config({
  requestMiddleware: async (req) => {
    const original = new URL(req.url);
    if (!FAL_HOSTS.has(original.hostname)) return req;
    const rewritten = new URL('http://localhost:4010/fal');
    rewritten.pathname += original.pathname;
    rewritten.search = original.search;
    return {
      ...req,
      url: rewritten.toString(),
      headers: { ...req.headers, 'x-fal-target-host': original.hostname },
    };
  },
});

await fal.queue.submit('fal-ai/flux/dev', { input: { prompt: 'a cat' } });
// → returns { request_id, status_url, response_url, cancel_url, queue_position: 0 }
```

In record mode (`record.providers.fal: 'https://queue.fal.run'`, or omit and let the header drive it), unmatched requests proxy through to fal.ai and are saved as `endpoint: "fal"` fixtures with the verbatim JSON payload.

## Test plan

- [x] `pnpm test` — 2751 passed, 36 skipped, 78 test files
- [x] `pnpm run lint`, `pnpm run format:check` (the only formatting warning is in pre-existing `.claude/settings.local.json`)
- [x] New `src/__tests__/fal.test.ts` (12 tests): queue lifecycle, host-mirror routing, sync run, cancel, error fixtures, storage stub, testId isolation, legacy back-compat, record + replay
- [x] Existing `src/__tests__/fal-audio.test.ts` still green
- [x] Existing `src/__tests__/recorder.test.ts` still green
- [ ] Smoke test against real `@fal-ai/client` in a downstream app (TanStack Start)

## Notes

- `recorder.ts` already tees SSE streams progressively (added in a prior commit), so the streaming-relay concern raised in the issue's first comment is no longer a blocker for fal.
- The new helpers expose `onFalQueue` as the primary entry point and `onFalRun` as a thin alias, since `fal.queue.*` is how clients actually call fal in modern code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)