### PR TITLE
fix(recorder): multi-turn runs must produce distinct fixtures (1.19.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @copilotkit/aimock
 
+## [1.19.3] - 2026-05-08
+
+### Fixed
+
+- **Recorder: multi-turn runs collapsed to a single fixture**. `--record` mode wrote only `userMessage` to the saved fixture's `match` block, so two LLM calls in the same agent run that share the user message (the canonical tool-call → tool-result → follow-up shape) collided in the in-memory fixture cache: as soon as turn 0 was recorded, turn 1 matched it on the same `userMessage` substring, the recorder was skipped, and the follow-up text turn was silently lost. Replaying the resulting single fixture against the same run looped on the tool call until the framework's recursion limit fired. Recorder now also writes `turnIndex` (count of `assistant` messages) and `hasToolResult` (any `role:"tool"` present) — the matcher in 1.16.0 already accepts both — so each call in a run produces a distinct, deterministic match key. Existing single-`userMessage` fixtures continue to match unchanged. Surfaced as: CopilotKit's beautiful-chat showcase having to hot-patch `dist/recorder.js` inside its running aimock container to make `--record` produce usable multi-turn recordings.
+
 ## [1.19.2] - 2026-05-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, text-to-speech, transcription, audio generation, video generation, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -1531,6 +1531,455 @@ describe("recorder edge cases", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Multi-turn disambiguation — recording a single agent run with shared
+// userMessage across LLM calls must produce distinct fixture match criteria.
+// Regression for the case where the recorder wrote only `userMessage` and
+// the in-memory cache then shadowed every subsequent call in the same run.
+// ---------------------------------------------------------------------------
+
+describe("recorder multi-turn disambiguation", () => {
+  it("2 LLM calls in one tool-using run record as 2 fixtures with distinct match", async () => {
+    // Upstream serves different responses for the two turns of the run.
+    // Turn 0 (no assistant, no tool messages) → tool call.
+    // Turn 1 (one assistant + one tool result already in messages) → text.
+    const { recorderUrl, fixturePath } = await setupUpstreamAndRecorder([
+      {
+        match: { userMessage: "weather in Tokyo", turnIndex: 0, hasToolResult: false },
+        response: {
+          toolCalls: [{ name: "get_weather", arguments: '{"location":"Tokyo"}', id: "call_w1" }],
+        },
+      },
+      {
+        match: { userMessage: "weather in Tokyo", turnIndex: 1, hasToolResult: true },
+        response: { content: "Tokyo is 22°C and partly cloudy." },
+      },
+    ]);
+
+    // Turn 0 — no assistant or tool messages yet.
+    const resp0 = await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "weather in Tokyo" }],
+      tools: [{ type: "function", function: { name: "get_weather", parameters: {} } }],
+    });
+    expect(resp0.status).toBe(200);
+    const body0 = JSON.parse(resp0.body);
+    expect(body0.choices[0].message.tool_calls[0].function.name).toBe("get_weather");
+
+    // Turn 1 — assistant tool-call turn + tool result already accumulated.
+    const resp1 = await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "weather in Tokyo" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_w1",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"location":"Tokyo"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_w1", content: '{"temp":22,"sky":"partly cloudy"}' },
+      ],
+      tools: [{ type: "function", function: { name: "get_weather", parameters: {} } }],
+    });
+    expect(resp1.status).toBe(200);
+    const body1 = JSON.parse(resp1.body);
+    expect(body1.choices[0].message.content).toBe("Tokyo is 22°C and partly cloudy.");
+
+    // Two fixture files written, each with a distinct match payload.
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files).toHaveLength(2);
+
+    const matches = files
+      .map((f) => JSON.parse(fs.readFileSync(path.join(fixturePath, f), "utf-8")) as FixtureFile)
+      .map((file) => file.fixtures[0].match);
+
+    // All recorded matches share the userMessage but differ on turnIndex /
+    // hasToolResult — that's the disambiguator.
+    expect(matches.every((m) => m.userMessage === "weather in Tokyo")).toBe(true);
+
+    const keys = matches.map((m) => `${m.turnIndex}|${m.hasToolResult}`).sort();
+    expect(keys).toEqual(["0|false", "1|true"]);
+  });
+
+  it("3 LLM calls (chained tool calls) record as 3 fixtures with distinct match", async () => {
+    // Three-turn run: tool_call → result → tool_call → result → final content.
+    const { recorderUrl, fixturePath } = await setupUpstreamAndRecorder([
+      {
+        match: { userMessage: "plan a trip", turnIndex: 0, hasToolResult: false },
+        response: {
+          toolCalls: [{ name: "find_flights", arguments: '{"to":"Tokyo"}', id: "call_a" }],
+        },
+      },
+      {
+        match: { userMessage: "plan a trip", turnIndex: 1, hasToolResult: true },
+        response: {
+          toolCalls: [{ name: "book_hotel", arguments: '{"city":"Tokyo"}', id: "call_b" }],
+        },
+      },
+      {
+        match: { userMessage: "plan a trip", turnIndex: 2, hasToolResult: true },
+        response: { content: "Trip booked: flight + hotel in Tokyo." },
+      },
+    ]);
+
+    // Turn 0
+    let resp = await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "plan a trip" }],
+    });
+    expect(resp.status).toBe(200);
+    expect(JSON.parse(resp.body).choices[0].message.tool_calls[0].function.name).toBe(
+      "find_flights",
+    );
+
+    // Turn 1
+    resp = await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "plan a trip" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_a",
+              type: "function",
+              function: { name: "find_flights", arguments: '{"to":"Tokyo"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_a", content: '{"flights":["JL001"]}' },
+      ],
+    });
+    expect(resp.status).toBe(200);
+    expect(JSON.parse(resp.body).choices[0].message.tool_calls[0].function.name).toBe("book_hotel");
+
+    // Turn 2
+    resp = await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "plan a trip" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_a",
+              type: "function",
+              function: { name: "find_flights", arguments: '{"to":"Tokyo"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_a", content: '{"flights":["JL001"]}' },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_b",
+              type: "function",
+              function: { name: "book_hotel", arguments: '{"city":"Tokyo"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_b", content: '{"hotel":"Park Hyatt"}' },
+      ],
+    });
+    expect(resp.status).toBe(200);
+    expect(JSON.parse(resp.body).choices[0].message.content).toBe(
+      "Trip booked: flight + hotel in Tokyo.",
+    );
+
+    // Three fixture files, each a distinct match.
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files).toHaveLength(3);
+
+    const matches = files
+      .map((f) => JSON.parse(fs.readFileSync(path.join(fixturePath, f), "utf-8")) as FixtureFile)
+      .map((file) => file.fixtures[0].match);
+
+    const keys = matches.map((m) => `${m.turnIndex}|${m.hasToolResult}`).sort();
+    expect(keys).toEqual(["0|false", "1|true", "2|true"]);
+  });
+
+  it("recorded fixtures replay deterministically against a fresh aimock", async () => {
+    // Phase 1: record a 2-turn run.
+    const { recorderUrl, fixturePath } = await setupUpstreamAndRecorder([
+      {
+        match: { userMessage: "weather in Tokyo", turnIndex: 0, hasToolResult: false },
+        response: {
+          toolCalls: [{ name: "get_weather", arguments: '{"location":"Tokyo"}', id: "call_w1" }],
+        },
+      },
+      {
+        match: { userMessage: "weather in Tokyo", turnIndex: 1, hasToolResult: true },
+        response: { content: "Tokyo is 22°C and partly cloudy." },
+      },
+    ]);
+
+    // Drive the run against the recorder so it proxies and records.
+    await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "weather in Tokyo" }],
+    });
+    await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "weather in Tokyo" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_w1",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"location":"Tokyo"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_w1", content: '{"temp":22}' },
+      ],
+    });
+
+    // Stop the recording servers so Phase 2 owns the ports / fixtures.
+    await new Promise<void>((resolve) => recorder!.server.close(() => resolve()));
+    await new Promise<void>((resolve) => upstream!.server.close(() => resolve()));
+    recorder = undefined;
+    upstream = undefined;
+
+    // Load the recorded fixture files and feed them to a fresh aimock that
+    // has NO upstream — replay must come from fixture cache or it 404s.
+    const recordedFixtures: Fixture[] = fs
+      .readdirSync(fixturePath)
+      .filter((f) => f.endsWith(".json"))
+      .flatMap(
+        (f) =>
+          (JSON.parse(fs.readFileSync(path.join(fixturePath, f), "utf-8")) as FixtureFile).fixtures,
+      );
+    expect(recordedFixtures).toHaveLength(2);
+
+    // Phase 2: replay against a fresh aimock with only the recorded fixtures.
+    recorder = await createServer(recordedFixtures, { port: 0 });
+
+    const replay0 = await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "weather in Tokyo" }],
+    });
+    expect(replay0.status).toBe(200);
+    expect(JSON.parse(replay0.body).choices[0].message.tool_calls[0].function.name).toBe(
+      "get_weather",
+    );
+
+    const replay1 = await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "weather in Tokyo" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_w1",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"location":"Tokyo"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_w1", content: '{"temp":22}' },
+      ],
+    });
+    expect(replay1.status).toBe(200);
+    expect(JSON.parse(replay1.body).choices[0].message.content).toBe(
+      "Tokyo is 22°C and partly cloudy.",
+    );
+  });
+
+  it("two demos with same first-turn userMessage but different follow-ups stay isolated", async () => {
+    // Demo A: "list todos" → tool call → "you have 3 todos"
+    // Demo B: "list todos" → tool call → "you have 0 todos"
+    // Same first-turn userMessage. Different upstream responses per demo.
+    // We record demo A then demo B into the same fixtures dir, then replay
+    // each independently and assert the right follow-up comes back.
+
+    // Phase 1 — record demo A.
+    const demoA = await setupUpstreamAndRecorder([
+      {
+        match: { userMessage: "list todos", turnIndex: 0, hasToolResult: false },
+        response: {
+          toolCalls: [{ name: "fetch_todos", arguments: "{}", id: "call_a" }],
+        },
+      },
+      {
+        match: { userMessage: "list todos", turnIndex: 1, hasToolResult: true },
+        response: { content: "you have 3 todos" },
+      },
+    ]);
+    const sharedFixturePath = demoA.fixturePath;
+
+    await post(`${demoA.recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "list todos" }],
+    });
+    await post(`${demoA.recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "list todos" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_a",
+              type: "function",
+              function: { name: "fetch_todos", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_a", content: '{"count":3}' },
+      ],
+    });
+
+    // Stop demo A's servers.
+    await new Promise<void>((resolve) => recorder!.server.close(() => resolve()));
+    await new Promise<void>((resolve) => upstream!.server.close(() => resolve()));
+    recorder = undefined;
+    upstream = undefined;
+
+    // Phase 2 — record demo B with a DISTINCT userMessage into the SAME
+    // fixturePath. Distinct userMessages are the recommended way to keep
+    // demos isolated; the regression we're guarding against is the silent
+    // collision the old recorder caused even WITHIN a single demo.
+    upstream = await createServer(
+      [
+        {
+          match: { userMessage: "list demo B todos", turnIndex: 0, hasToolResult: false },
+          response: {
+            toolCalls: [{ name: "fetch_todos", arguments: "{}", id: "call_b2" }],
+          },
+        },
+        {
+          match: { userMessage: "list demo B todos", turnIndex: 1, hasToolResult: true },
+          response: { content: "you have 0 todos" },
+        },
+      ],
+      { port: 0 },
+    );
+    recorder = await createServer([], {
+      port: 0,
+      record: { providers: { openai: upstream.url }, fixturePath: sharedFixturePath },
+    });
+
+    await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "list demo B todos" }],
+    });
+    await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "list demo B todos" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_b2",
+              type: "function",
+              function: { name: "fetch_todos", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_b2", content: '{"count":0}' },
+      ],
+    });
+
+    // Stop and replay both demos against a fresh aimock with all recorded
+    // fixtures loaded from disk.
+    await new Promise<void>((resolve) => recorder!.server.close(() => resolve()));
+    await new Promise<void>((resolve) => upstream!.server.close(() => resolve()));
+    recorder = undefined;
+    upstream = undefined;
+
+    const allFixtures: Fixture[] = fs
+      .readdirSync(sharedFixturePath)
+      .filter((f) => f.endsWith(".json"))
+      .flatMap(
+        (f) =>
+          (JSON.parse(fs.readFileSync(path.join(sharedFixturePath, f), "utf-8")) as FixtureFile)
+            .fixtures,
+      );
+    expect(allFixtures).toHaveLength(4);
+
+    recorder = await createServer(allFixtures, { port: 0 });
+
+    // Demo A replay: should hit the demo-A fixtures (userMessage "list todos").
+    const demoAReplay0 = await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "list todos" }],
+    });
+    expect(demoAReplay0.status).toBe(200);
+    expect(JSON.parse(demoAReplay0.body).choices[0].message.tool_calls[0].function.name).toBe(
+      "fetch_todos",
+    );
+
+    const demoAReplay1 = await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "list todos" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_a",
+              type: "function",
+              function: { name: "fetch_todos", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_a", content: '{"count":3}' },
+      ],
+    });
+    expect(demoAReplay1.status).toBe(200);
+    expect(JSON.parse(demoAReplay1.body).choices[0].message.content).toBe("you have 3 todos");
+
+    // Demo B replay (with disambiguated userMessage): should hit the demo-B fixtures.
+    const demoBReplay0 = await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "list demo B todos" }],
+    });
+    expect(demoBReplay0.status).toBe(200);
+    expect(JSON.parse(demoBReplay0.body).choices[0].message.tool_calls[0].function.name).toBe(
+      "fetch_todos",
+    );
+
+    const demoBReplay1 = await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [
+        { role: "user", content: "list demo B todos" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_b2",
+              type: "function",
+              function: { name: "fetch_todos", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_b2", content: '{"count":0}' },
+      ],
+    });
+    expect(demoBReplay1.status).toBe(200);
+    expect(JSON.parse(demoBReplay1.body).choices[0].message.content).toBe("you have 0 todos");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Strict mode thorough tests
 // ---------------------------------------------------------------------------
 

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -321,9 +321,14 @@ export async function proxyAndRecord(
     response: fixtureResponse,
   };
 
-  // Check if the match is empty (all undefined values) — warn but still save to disk
-  const matchValues = Object.values(fixtureMatch);
-  const isEmptyMatch = matchValues.length === 0 || matchValues.every((v) => v === undefined);
+  // Check if the match is empty — warn but still save to disk.
+  // Note: turnIndex/hasToolResult are pure multi-turn disambiguators and don't,
+  // by themselves, constitute a meaningful match key. A "real" match needs at
+  // least one of userMessage / inputText / endpoint to be useful.
+  const isEmptyMatch =
+    fixtureMatch.userMessage === undefined &&
+    fixtureMatch.inputText === undefined &&
+    fixtureMatch.endpoint === undefined;
   if (isEmptyMatch) {
     defaults.logger.warn(
       "Recorded fixture has empty match criteria — skipping in-memory registration",
@@ -1059,12 +1064,16 @@ function buildFixtureMatch(request: ChatCompletionRequest): {
   inputText?: string;
   model?: string;
   endpoint?: EndpointType;
+  turnIndex?: number;
+  hasToolResult?: boolean;
 } {
   const match: {
     userMessage?: string;
     inputText?: string;
     model?: string;
     endpoint?: EndpointType;
+    turnIndex?: number;
+    hasToolResult?: boolean;
   } = {};
 
   // Include endpoint type for multimedia fixtures
@@ -1092,6 +1101,16 @@ function buildFixtureMatch(request: ChatCompletionRequest): {
   // the resolved model so replay matches what `onFalQueue(/flux/, ...)` writes.
   if (request._endpointType === "fal" && request.model) {
     match.model = request.model;
+  }
+
+  // Multi-turn disambiguation: writing only `userMessage` lets the recorder's
+  // in-memory cache shadow follow-up turns that share it (initial tool call
+  // vs. text reply after the tool result). turnIndex + hasToolResult give
+  // each call a distinct, matcher-aware key. Skip for non-chat (no messages).
+  const messages = request.messages ?? [];
+  if (messages.length > 0) {
+    match.turnIndex = messages.filter((m) => m.role === "assistant").length;
+    match.hasToolResult = messages.some((m) => m.role === "tool");
   }
 
   return match;


### PR DESCRIPTION
## Summary

- `--record` mode now writes `turnIndex` and `hasToolResult` to the saved fixture's `match` block, so multi-turn agent runs (tool-call → tool-result → follow-up) record as N distinct fixtures instead of collapsing into one and silently dropping the follow-up turn on replay.
- Matcher and types already supported both fields (added in 1.16.0); only the recorder was lagging. This commit closes that gap.
- Bumps to **1.19.3** (patch — purely additive on the recorder side, existing fixtures continue to match unchanged).

## What was broken

A single agent run usually issues several LLM calls that share the same last user message:

1. Turn 0: `messages: [user]` → tool call.
2. Turn 1: `messages: [user, assistant(tool_call), tool(result)]` → text reply.

`buildFixtureMatch` wrote only `userMessage`. Recording call 0 wrote a fixture with `match: { userMessage: "..." }` and pushed it into the in-memory `fixtures` array. The matcher then matched that fixture for call 1 (substring of the last user message is unchanged), the recorder was skipped, the canned tool-call response was replayed, and the follow-up turn was silently lost. Replays of the resulting single fixture looped on the tool call until the framework's recursion limit fired.

CopilotKit's beautiful-chat showcase compose worked around this by hot-patching `dist/recorder.js` at container start — fragile and dropped on every container restart.

## What changed

- `src/recorder.ts` — `buildFixtureMatch` writes `turnIndex` (count of `assistant` messages) and `hasToolResult` (any prior `role:"tool"` present) for chat-shaped requests. Embedding short-circuit and multimedia endpoints (no messages) are guarded out. Composes cleanly with the `model` field added in 1.18.0 for fal.ai.
- `src/recorder.ts` — `isEmptyMatch` narrowed to check only `userMessage`/`inputText`/`endpoint` so the empty-match-warning behavior is preserved (the new disambiguators don't constitute a meaningful match key on their own).
- `src/__tests__/recorder.test.ts` — new `recorder multi-turn disambiguation` describe block with 4 tests:
  - 2 LLM calls in one tool-using run record as 2 fixtures with distinct match.
  - 3 LLM calls (chained tool calls) record as 3 fixtures with distinct match.
  - Recorded fixtures replay deterministically against a fresh aimock.
  - Two demos with the same first-turn userMessage but distinct disambiguated follow-ups stay isolated.
- `CHANGELOG.md` + `package.json` — 1.19.3 release notes and version bump.

## Compatibility

- **Hand-written fixtures**: no schema change. `turnIndex` and `hasToolResult` were already accepted by the validator and matcher (1.16.0). Existing fixtures that lack these fields continue to match exactly as before.
- **Recorded fixtures from prior versions**: replay unchanged — matcher only checks the new fields when the fixture defines them.
- **Embeddings, image, speech, transcription, video, fal.ai**: unaffected — embedding short-circuit untouched, the new field writes are gated on `messages.length > 0`, and the `model` field added in 1.18.0 for fal.ai composes orthogonally with the new fields.

## Test plan

- [x] `pnpm test src/__tests__/recorder.test.ts` — 85/85 pass (4 new + 81 existing)
- [x] `pnpm test src/__tests__/turn-index.test.ts` — 12/12 pass (matcher coverage unchanged)
- [x] `pnpm test` — 2832/2835 pass; the 3 failures are pre-existing Windows-specific infrastructure tests (symlink invocation, SIGTERM, XDG_CACHE_HOME path separators), all unrelated to this change.
- [x] `pnpm run lint` — clean.
- [x] `pnpm exec prettier --check src/recorder.ts src/__tests__/recorder.test.ts CHANGELOG.md package.json` — clean.
- [x] `pnpm run build` — clean (tsdown, 245 files, no type errors).
