### PR TITLE
fix: remove spurious type field from converse-stream delta and start events (closes #165)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimock",
-  "version": "1.19.2",
+  "version": "1.19.4",
   "description": "Fixture authoring guidance for @copilotkit/aimock — LLM, multimedia, MCP, A2A, AG-UI, vector, and service mocking",
   "author": {
     "name": "CopilotKit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @copilotkit/aimock
 
+## [Unreleased]
+
+### Fixed
+
+- **Converse stream: spurious `type` field in contentBlockDelta and contentBlockStart** — `delta` objects contained a Claude Messages API `type` field (`text_delta`, `thinking_delta`) that is not a member of the Converse API's tagged union. botocore's single-member union parser rejected the extra field with `ResponseParserError`. Also fixed reasoning deltas to use `reasoningContent` (Converse format) instead of `thinking` (Claude format). (Issue #165, reported by @KMiya84377)
+
 ## [1.19.3] - 2026-05-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # @copilotkit/aimock
 
-## [Unreleased]
+## [1.19.4] - 2026-05-08
 
 ### Fixed
 
 - **Converse stream: spurious `type` field in contentBlockDelta and contentBlockStart** — `delta` objects contained a Claude Messages API `type` field (`text_delta`, `thinking_delta`) that is not a member of the Converse API's tagged union. botocore's single-member union parser rejected the extra field with `ResponseParserError`. Also fixed reasoning deltas to use `reasoningContent` (Converse format) instead of `thinking` (Claude format). (Issue #165, reported by @KMiya84377)
+- **Converse: `inferenceConfig.maxTokens` silently dropped** — `converseToCompletionRequest` now forwards `maxTokens` to `max_tokens`
+- **Converse: non-streaming responses missing `metrics`** — Added `metrics: { latencyMs: 0 }` to all 3 non-streaming converse response builders, matching the streaming path and AWS ConverseResponse spec
+
+### Added
+
+- **Bedrock drift test expansion** — invoke-with-response-stream drift test with binary frame parsing and Anthropic-native event shape comparison. Converse-stream SDK shapes for tool call (`toolUse` start/delta) and reasoning (`reasoningContent` start/delta) variants. Three-way triangulate comparisons for all variants.
 
 ## [1.19.3] - 2026-05-08
 

--- a/charts/aimock/Chart.yaml
+++ b/charts/aimock/Chart.yaml
@@ -3,4 +3,4 @@ name: aimock
 description: Mock infrastructure for AI application testing (OpenAI, Anthropic, Gemini, MCP, A2A, vector)
 type: application
 version: 0.1.0
-appVersion: "1.19.2"
+appVersion: "1.19.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.19.3",
+  "version": "1.19.4",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, text-to-speech, transcription, audio generation, video generation, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/src/__tests__/bedrock-stream.test.ts
+++ b/src/__tests__/bedrock-stream.test.ts
@@ -703,6 +703,7 @@ describe("POST /model/{modelId}/converse (non-streaming)", () => {
     expect(body.output.message.content[0].text).toBe("Hi there!");
     expect(body.stopReason).toBe("end_turn");
     expect(body.usage).toEqual({ inputTokens: 0, outputTokens: 0, totalTokens: 0 });
+    expect(typeof body.metrics.latencyMs).toBe("number");
   });
 
   it("returns tool call response in Converse format", async () => {
@@ -719,6 +720,18 @@ describe("POST /model/{modelId}/converse (non-streaming)", () => {
     expect(body.output.message.content[0].toolUse.input).toEqual({ city: "SF" });
     expect(body.output.message.content[0].toolUse.toolUseId).toBeDefined();
     expect(body.stopReason).toBe("tool_use");
+    expect(typeof body.metrics.latencyMs).toBe("number");
+  });
+
+  it("returns metrics field in content+toolCalls response", async () => {
+    instance = await createServer(allFixtures);
+    const res = await post(`${instance.url}/model/${MODEL_ID}/converse`, {
+      messages: [{ role: "user", content: [{ text: "search-and-explain" }] }],
+    });
+
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(typeof body.metrics.latencyMs).toBe("number");
   });
 
   it("returns 404 when no fixture matches", async () => {
@@ -771,8 +784,18 @@ describe("POST /model/{modelId}/converse-stream", () => {
     expect(frames[0].payload).toEqual({ role: "assistant" });
 
     expect(frames[1].eventType).toBe("contentBlockStart");
+    // Text contentBlockStart has an empty start object (no spurious `type` field)
+    const startPayloadText = frames[1].payload as { start: Record<string, unknown> };
+    expect(startPayloadText.start).not.toHaveProperty("type");
+    expect(Object.keys(startPayloadText.start)).toEqual([]);
 
     const deltas = frames.filter((f) => f.eventType === "contentBlockDelta");
+    // Verify no spurious `type` field in any text delta
+    for (const d of deltas) {
+      const delta = (d.payload as { delta: Record<string, unknown> }).delta;
+      expect(delta).not.toHaveProperty("type");
+      expect(Object.keys(delta)).toEqual(["text"]);
+    }
     const fullText = deltas
       .map((f) => (f.payload as { delta: { text: string } }).delta.text)
       .join("");
@@ -881,21 +904,32 @@ describe("POST /model/{modelId}/converse-stream (content + toolCalls)", () => {
     expect(frames[0].eventType).toBe("messageStart");
     expect(frames[0].payload).toEqual({ role: "assistant" });
 
-    // Text contentBlockStart
+    // Text contentBlockStart — start is an empty object (no spurious `type` field)
     const textBlockStart = frames.find(
       (f) =>
         f.eventType === "contentBlockStart" &&
-        (f.payload as { start?: { type?: string } }).start?.type === "text",
+        !(f.payload as { start?: { toolUse?: unknown; reasoningContent?: unknown } }).start
+          ?.toolUse &&
+        !(f.payload as { start?: { toolUse?: unknown; reasoningContent?: unknown } }).start
+          ?.reasoningContent,
     );
     expect(textBlockStart).toBeDefined();
+    const textStart = (textBlockStart!.payload as { start: Record<string, unknown> }).start;
+    expect(textStart).not.toHaveProperty("type");
+    expect(Object.keys(textStart)).toEqual([]);
 
-    // Text deltas
+    // Text deltas — no spurious `type` field in delta
     const textDeltas = frames.filter(
       (f) =>
         f.eventType === "contentBlockDelta" &&
         (f.payload as { delta?: { text?: string } }).delta?.text !== undefined,
     );
     expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+    for (const td of textDeltas) {
+      const delta = (td.payload as { delta: Record<string, unknown> }).delta;
+      expect(delta).not.toHaveProperty("type");
+      expect(Object.keys(delta)).toEqual(["text"]);
+    }
     const fullText = textDeltas
       .map((f) => (f.payload as { delta: { text: string } }).delta.text)
       .join("");
@@ -1055,10 +1089,14 @@ describe("POST /model/{modelId}/converse-stream (contentWithToolCalls full struc
     expect(blockStarts.length).toBe(2); // one text, one tool
 
     // 3. Text content block appears before tool call block
+    //    Text block start has an empty `start` object (no `type` field)
     const textBlockStartIdx = frames.findIndex(
       (f) =>
         f.eventType === "contentBlockStart" &&
-        (f.payload as { start?: { type?: string } }).start?.type === "text",
+        !(f.payload as { start?: { toolUse?: unknown; reasoningContent?: unknown } }).start
+          ?.toolUse &&
+        !(f.payload as { start?: { toolUse?: unknown; reasoningContent?: unknown } }).start
+          ?.reasoningContent,
     );
     const toolBlockStartIdx = frames.findIndex(
       (f) =>
@@ -1146,9 +1184,10 @@ describe("POST /model/{modelId}/converse-stream (contentWithToolCalls full struc
     );
     expect(indices).toEqual([0, 1, 2]);
 
-    // Text block at index 0
-    const textStart = blockStarts[0].payload as { start: { type: string } };
-    expect(textStart.start.type).toBe("text");
+    // Text block at index 0 — start is empty (no `type` field)
+    const textStartPayload = blockStarts[0].payload as { start: Record<string, unknown> };
+    expect(Object.keys(textStartPayload.start)).toEqual([]);
+    expect(textStartPayload.start).not.toHaveProperty("type");
 
     // Tool blocks at indices 1 and 2
     const tool1Start = blockStarts[1].payload as {
@@ -1335,6 +1374,18 @@ describe("converseToCompletionRequest", () => {
     );
 
     expect(result.temperature).toBe(0.7);
+  });
+
+  it("forwards inferenceConfig.maxTokens as max_tokens", () => {
+    const result = converseToCompletionRequest(
+      {
+        messages: [{ role: "user", content: [{ text: "hi" }] }],
+        inferenceConfig: { maxTokens: 100 },
+      },
+      "model-id",
+    );
+
+    expect(result.max_tokens).toBe(100);
   });
 
   it("sets model from modelId parameter", () => {
@@ -1783,6 +1834,7 @@ describe("converseToCompletionRequest (edge cases)", () => {
       "model",
     );
     expect(result.temperature).toBeUndefined();
+    expect(result.max_tokens).toBe(100);
   });
 
   it("handles assistant text blocks with missing text alongside toolUse (text ?? '')", () => {

--- a/src/__tests__/drift/bedrock-stream.drift.ts
+++ b/src/__tests__/drift/bedrock-stream.drift.ts
@@ -7,10 +7,16 @@
 
 import http from "node:http";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import type { ServerInstance } from "../../server.js";
+import { createServer, type ServerInstance } from "../../server.js";
+import type { Fixture } from "../../types.js";
 import { extractShape, triangulate, formatDriftReport, shouldFail } from "./schema.js";
 import { httpPost, startDriftServer, stopDriftServer } from "./helpers.js";
-import { bedrockConverseStreamEventShapes } from "./sdk-shapes.js";
+import {
+  bedrockConverseStreamEventShapes,
+  bedrockConverseStreamToolShapes,
+  bedrockConverseStreamReasoningShapes,
+  bedrockInvokeStreamEventShapes,
+} from "./sdk-shapes.js";
 
 // ---------------------------------------------------------------------------
 // Credentials check
@@ -203,6 +209,65 @@ describe.skipIf(!HAS_CREDENTIALS)("Bedrock drift", () => {
     }
   });
 
+  it("invoke-with-response-stream mock shape matches SDK expectations", async () => {
+    const sdkEvents = bedrockInvokeStreamEventShapes();
+
+    const mockRes = await httpPostBinary(
+      `${instance.url}/model/anthropic.claude-3-haiku-20240307-v1:0/invoke-with-response-stream`,
+      {
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: 10,
+        messages: [{ role: "user", content: "Say hello" }],
+      },
+    );
+
+    expect(mockRes.status).toBe(200);
+    expect(mockRes.headers["content-type"]).toBe("application/vnd.amazon.eventstream");
+
+    const frames = parseFrames(mockRes.body);
+    expect(frames.length).toBeGreaterThanOrEqual(6);
+
+    // All frames should have eventType "chunk" (Bedrock invoke-stream wrapping)
+    for (const frame of frames) {
+      expect(frame.eventType).toBe("chunk");
+    }
+
+    // Extract the Anthropic-native event type from each frame's payload
+    const payloadEvents = frames.map((f) => {
+      const payload = f.payload as Record<string, unknown>;
+      return {
+        type: (payload.type as string) ?? "",
+        dataShape: extractShape(payload),
+      };
+    });
+
+    // Key event types must be present
+    const eventTypes = payloadEvents.map((e) => e.type);
+    for (const expected of [
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]) {
+      expect(eventTypes, `missing event type: ${expected}`).toContain(expected);
+    }
+
+    // Compare each SDK event type against the mock
+    for (const sdkEvent of sdkEvents) {
+      const mockEvent = payloadEvents.find((m) => m.type === sdkEvent.type);
+      if (!mockEvent) continue; // already asserted presence above
+
+      const diffs = triangulate(sdkEvent.dataShape, sdkEvent.dataShape, mockEvent.dataShape);
+      const report = formatDriftReport(`Bedrock InvokeStream:${sdkEvent.type}`, diffs);
+
+      if (shouldFail(diffs)) {
+        expect.soft([], report).toEqual(diffs.filter((d) => d.severity === "critical"));
+      }
+    }
+  });
+
   it("converse mock shape matches SDK expectations", async () => {
     const sdkShape = bedrockConverseResponseShape();
 
@@ -334,6 +399,207 @@ describe.skipIf(!HAS_CREDENTIALS)("Bedrock drift", () => {
       if (shouldFail(diffs)) {
         expect.soft([], report).toEqual(diffs.filter((d) => d.severity === "critical"));
       }
+    }
+  });
+
+  it("converse-stream tool-call event shapes match SDK expectations", async () => {
+    const mockRes = await httpPostBinary(
+      `${instance.url}/model/anthropic.claude-3-haiku-20240307-v1:0/converse-stream`,
+      {
+        messages: [
+          {
+            role: "user",
+            content: [{ text: "Weather in Paris" }],
+          },
+        ],
+        inferenceConfig: { maxTokens: 10 },
+      },
+    );
+
+    expect(mockRes.status).toBe(200);
+    expect(mockRes.headers["content-type"]).toBe("application/vnd.amazon.eventstream");
+
+    const frames = parseFrames(mockRes.body);
+    expect(frames.length).toBeGreaterThanOrEqual(5);
+
+    // ── Tool-specific event types must be present ────────────────────
+    const eventTypes = frames.map((f) => f.eventType);
+    for (const expected of [
+      "messageStart",
+      "contentBlockStart",
+      "contentBlockDelta",
+      "contentBlockStop",
+      "messageStop",
+      "metadata",
+    ]) {
+      expect(eventTypes, `missing event type: ${expected}`).toContain(expected);
+    }
+
+    // ── contentBlockStart must contain toolUse descriptor ────────────
+    const toolStart = frames.find(
+      (f) =>
+        f.eventType === "contentBlockStart" &&
+        (f.payload as { start?: { toolUse?: unknown } }).start?.toolUse !== undefined,
+    );
+    expect(toolStart).toBeDefined();
+    const toolStartPayload = toolStart!.payload as {
+      contentBlockIndex: number;
+      start: { toolUse: { toolUseId: string; name: string } };
+    };
+    expect(toolStartPayload.start.toolUse.name).toBe("get_weather");
+    expect(toolStartPayload.start.toolUse.toolUseId).toBeDefined();
+
+    // ── contentBlockDelta must contain toolUse.input ─────────────────
+    const toolDeltas = frames.filter(
+      (f) =>
+        f.eventType === "contentBlockDelta" &&
+        (f.payload as { delta?: { toolUse?: unknown } }).delta?.toolUse !== undefined,
+    );
+    expect(toolDeltas.length).toBeGreaterThanOrEqual(1);
+    const fullJson = toolDeltas
+      .map((f) => (f.payload as { delta: { toolUse: { input: string } } }).delta.toolUse.input)
+      .join("");
+    expect(JSON.parse(fullJson)).toEqual({ city: "Paris" });
+
+    // ── messageStop must have tool_use stopReason ────────────────────
+    const msgStop = frames.find((f) => f.eventType === "messageStop");
+    expect(msgStop).toBeDefined();
+    expect(msgStop!.payload).toEqual({ stopReason: "tool_use" });
+
+    // ── Shape comparison against SDK tool expectations ───────────────
+    const sdkEvents = bedrockConverseStreamToolShapes();
+    const mockEvents = frames.map((f) => ({
+      type: f.eventType,
+      dataShape: extractShape(f.payload),
+    }));
+
+    for (const sdkEvent of sdkEvents) {
+      const mockEvent = mockEvents.find((m) => m.type === sdkEvent.type);
+      if (!mockEvent) continue;
+
+      const diffs = triangulate(sdkEvent.dataShape, sdkEvent.dataShape, mockEvent.dataShape);
+      const report = formatDriftReport(`Bedrock ConverseStream Tool:${sdkEvent.type}`, diffs);
+
+      if (shouldFail(diffs)) {
+        expect.soft([], report).toEqual(diffs.filter((d) => d.severity === "critical"));
+      }
+    }
+  });
+
+  it("converse-stream reasoning event shapes match SDK expectations", async () => {
+    // Create a dedicated server with a reasoning fixture
+    const reasoningFixture: Fixture = {
+      match: { userMessage: "Think carefully" },
+      response: {
+        content: "The answer is 42.",
+        reasoning: "Let me think step by step...",
+      },
+    };
+    const reasoningInstance = await createServer([reasoningFixture], {
+      port: 0,
+      chunkSize: 100,
+    });
+
+    try {
+      const mockRes = await httpPostBinary(
+        `${reasoningInstance.url}/model/anthropic.claude-3-haiku-20240307-v1:0/converse-stream`,
+        {
+          messages: [
+            {
+              role: "user",
+              content: [{ text: "Think carefully" }],
+            },
+          ],
+          inferenceConfig: { maxTokens: 100 },
+        },
+      );
+
+      expect(mockRes.status).toBe(200);
+      expect(mockRes.headers["content-type"]).toBe("application/vnd.amazon.eventstream");
+
+      const frames = parseFrames(mockRes.body);
+      expect(frames.length).toBeGreaterThanOrEqual(7); // reasoning block + text block + envelope
+
+      // ── Key event types must be present ──────────────────────────────
+      const eventTypes = frames.map((f) => f.eventType);
+      for (const expected of [
+        "messageStart",
+        "contentBlockStart",
+        "contentBlockDelta",
+        "contentBlockStop",
+        "messageStop",
+        "metadata",
+      ]) {
+        expect(eventTypes, `missing event type: ${expected}`).toContain(expected);
+      }
+
+      // ── contentBlockStart must contain reasoningContent descriptor ──
+      const reasoningStart = frames.find(
+        (f) =>
+          f.eventType === "contentBlockStart" &&
+          (f.payload as { start?: { reasoningContent?: unknown } }).start?.reasoningContent !==
+            undefined,
+      );
+      expect(reasoningStart).toBeDefined();
+      const reasoningStartPayload = reasoningStart!.payload as {
+        contentBlockIndex: number;
+        start: { reasoningContent: Record<string, unknown> };
+      };
+      expect(reasoningStartPayload.contentBlockIndex).toBe(0);
+      expect(reasoningStartPayload.start.reasoningContent).toEqual({});
+
+      // ── contentBlockDelta must contain reasoningContent.text ─────────
+      const reasoningDeltas = frames.filter(
+        (f) =>
+          f.eventType === "contentBlockDelta" &&
+          (f.payload as { delta?: { reasoningContent?: unknown } }).delta?.reasoningContent !==
+            undefined,
+      );
+      expect(reasoningDeltas.length).toBeGreaterThanOrEqual(1);
+      const fullReasoning = reasoningDeltas
+        .map(
+          (f) =>
+            (f.payload as { delta: { reasoningContent: { text: string } } }).delta.reasoningContent
+              .text,
+        )
+        .join("");
+      expect(fullReasoning).toBe("Let me think step by step...");
+
+      // ── Text content block follows reasoning block ──────────────────
+      const textDeltas = frames.filter(
+        (f) =>
+          f.eventType === "contentBlockDelta" &&
+          (f.payload as { delta?: { text?: string } }).delta?.text !== undefined,
+      );
+      expect(textDeltas.length).toBeGreaterThanOrEqual(1);
+      const fullText = textDeltas
+        .map((f) => (f.payload as { delta: { text: string } }).delta.text)
+        .join("");
+      expect(fullText).toBe("The answer is 42.");
+
+      // ── Shape comparison against SDK reasoning expectations ─────────
+      const sdkEvents = bedrockConverseStreamReasoningShapes();
+      const mockEvents = frames.map((f) => ({
+        type: f.eventType,
+        dataShape: extractShape(f.payload),
+      }));
+
+      for (const sdkEvent of sdkEvents) {
+        const mockEvent = mockEvents.find((m) => m.type === sdkEvent.type);
+        if (!mockEvent) continue;
+
+        const diffs = triangulate(sdkEvent.dataShape, sdkEvent.dataShape, mockEvent.dataShape);
+        const report = formatDriftReport(
+          `Bedrock ConverseStream Reasoning:${sdkEvent.type}`,
+          diffs,
+        );
+
+        if (shouldFail(diffs)) {
+          expect.soft([], report).toEqual(diffs.filter((d) => d.severity === "critical"));
+        }
+      }
+    } finally {
+      await new Promise<void>((r) => reasoningInstance.server.close(() => r()));
     }
   });
 });

--- a/src/__tests__/drift/sdk-shapes.ts
+++ b/src/__tests__/drift/sdk-shapes.ts
@@ -746,14 +746,14 @@ export function bedrockConverseStreamEventShapes(): SSEEventShape[] {
       type: "contentBlockStart",
       dataShape: extractShape({
         contentBlockIndex: 0,
-        start: { type: "text" },
+        start: {},
       }),
     },
     {
       type: "contentBlockDelta",
       dataShape: extractShape({
         contentBlockIndex: 0,
-        delta: { type: "text_delta", text: "Hello" },
+        delta: { text: "Hello" },
       }),
     },
     {
@@ -773,6 +773,177 @@ export function bedrockConverseStreamEventShapes(): SSEEventShape[] {
       dataShape: extractShape({
         usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
         metrics: { latencyMs: 0 },
+      }),
+    },
+  ];
+}
+
+/**
+ * Expected event shapes for Bedrock ConverseStream tool call responses.
+ *
+ * Tool calls use `contentBlockStart` with a `toolUse` start descriptor
+ * and `contentBlockDelta` with `toolUse.input` string chunks.
+ */
+export function bedrockConverseStreamToolShapes(): SSEEventShape[] {
+  return [
+    {
+      type: "messageStart",
+      dataShape: extractShape({
+        role: "assistant",
+      }),
+    },
+    {
+      type: "contentBlockStart",
+      dataShape: extractShape({
+        contentBlockIndex: 0,
+        start: { toolUse: { toolUseId: "toolu_test", name: "get_weather" } },
+      }),
+    },
+    {
+      type: "contentBlockDelta",
+      dataShape: extractShape({
+        contentBlockIndex: 0,
+        delta: { toolUse: { input: '{"city":' } },
+      }),
+    },
+    {
+      type: "contentBlockStop",
+      dataShape: extractShape({
+        contentBlockIndex: 0,
+      }),
+    },
+    {
+      type: "messageStop",
+      dataShape: extractShape({
+        stopReason: "tool_use",
+      }),
+    },
+    {
+      type: "metadata",
+      dataShape: extractShape({
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        metrics: { latencyMs: 0 },
+      }),
+    },
+  ];
+}
+
+/**
+ * Expected event shapes for Bedrock ConverseStream reasoning responses.
+ *
+ * Reasoning content uses `contentBlockStart` with a `reasoningContent`
+ * start descriptor and `contentBlockDelta` with `reasoningContent.text`
+ * string chunks, followed by the regular text content block.
+ */
+export function bedrockConverseStreamReasoningShapes(): SSEEventShape[] {
+  return [
+    {
+      type: "messageStart",
+      dataShape: extractShape({
+        role: "assistant",
+      }),
+    },
+    {
+      type: "contentBlockStart",
+      dataShape: extractShape({
+        contentBlockIndex: 0,
+        start: { reasoningContent: {} },
+      }),
+    },
+    {
+      type: "contentBlockDelta",
+      dataShape: extractShape({
+        contentBlockIndex: 0,
+        delta: { reasoningContent: { text: "Let me think..." } },
+      }),
+    },
+    {
+      type: "contentBlockStop",
+      dataShape: extractShape({
+        contentBlockIndex: 0,
+      }),
+    },
+    {
+      type: "messageStop",
+      dataShape: extractShape({
+        stopReason: "end_turn",
+      }),
+    },
+    {
+      type: "metadata",
+      dataShape: extractShape({
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        metrics: { latencyMs: 0 },
+      }),
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// AWS Bedrock Invoke-with-Response-Stream (Anthropic native inside EventStream)
+// ---------------------------------------------------------------------------
+
+/**
+ * Expected event shapes for Bedrock invoke-with-response-stream responses.
+ *
+ * Unlike ConverseStream (which uses Bedrock-native camelCase payloads),
+ * invoke-with-response-stream wraps Anthropic-native streaming events inside
+ * AWS binary Event Stream frames. Every frame has `:event-type` = "chunk"
+ * and the JSON payload is the raw Anthropic SSE event object.
+ */
+export function bedrockInvokeStreamEventShapes(): SSEEventShape[] {
+  return [
+    {
+      type: "message_start",
+      dataShape: extractShape({
+        type: "message_start",
+        message: {
+          id: "msg_abc123",
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "anthropic.claude-3-haiku",
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      }),
+    },
+    {
+      type: "content_block_start",
+      dataShape: extractShape({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+    },
+    {
+      type: "content_block_delta",
+      dataShape: extractShape({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello" },
+      }),
+    },
+    {
+      type: "content_block_stop",
+      dataShape: extractShape({
+        type: "content_block_stop",
+        index: 0,
+      }),
+    },
+    {
+      type: "message_delta",
+      dataShape: extractShape({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 0 },
+      }),
+    },
+    {
+      type: "message_stop",
+      dataShape: extractShape({
+        type: "message_stop",
       }),
     },
   ];

--- a/src/__tests__/reasoning-all-providers.test.ts
+++ b/src/__tests__/reasoning-all-providers.test.ts
@@ -519,29 +519,58 @@ describe("POST /model/{id}/converse-stream (reasoning streaming)", () => {
 
     expect(eventTypes[0]).toBe("messageStart");
 
-    // Find thinking and text block starts — payloads are flat (not double-wrapped)
+    // Find reasoning and text block starts — payloads are flat (not double-wrapped)
+    // Reasoning block uses `start: { reasoningContent: {} }` (Converse format)
     const thinkingStartIdx = frames.findIndex(
       (f) =>
         f.eventType === "contentBlockStart" &&
-        (f.payload as { start?: { type?: string } }).start?.type === "thinking",
+        (f.payload as { start?: { reasoningContent?: unknown } }).start?.reasoningContent !==
+          undefined,
     );
+    // Text block uses `start: {}` (empty object, no `type` field)
     const textStartIdx = frames.findIndex(
       (f) =>
         f.eventType === "contentBlockStart" &&
-        (f.payload as { start?: { type?: string } }).start?.type === "text",
+        !(f.payload as { start?: { reasoningContent?: unknown; toolUse?: unknown } }).start
+          ?.reasoningContent &&
+        !(f.payload as { start?: { reasoningContent?: unknown; toolUse?: unknown } }).start
+          ?.toolUse,
     );
 
     expect(thinkingStartIdx).toBeGreaterThan(0);
     expect(textStartIdx).toBeGreaterThan(thinkingStartIdx);
 
+    // Verify start payloads have no spurious `type` field
+    const thinkingStartPayload = (
+      frames[thinkingStartIdx].payload as { start: Record<string, unknown> }
+    ).start;
+    expect(thinkingStartPayload).toHaveProperty("reasoningContent");
+    expect(thinkingStartPayload).not.toHaveProperty("type");
+    const textStartPayload = (frames[textStartIdx].payload as { start: Record<string, unknown> })
+      .start;
+    expect(textStartPayload).not.toHaveProperty("type");
+    expect(Object.keys(textStartPayload)).toEqual([]);
+
     // Verify reasoning content appears in the stream — flat payloads
+    // Reasoning deltas use `delta: { reasoningContent: { text: "..." } }` (Converse format)
     const thinkingDeltas = frames.filter(
       (f) =>
         f.eventType === "contentBlockDelta" &&
-        (f.payload as { delta?: { type?: string } }).delta?.type === "thinking_delta",
+        (f.payload as { delta?: { reasoningContent?: unknown } }).delta?.reasoningContent !==
+          undefined,
     );
+    for (const td of thinkingDeltas) {
+      const delta = (td.payload as { delta: Record<string, unknown> }).delta;
+      expect(delta).toHaveProperty("reasoningContent");
+      expect(delta).not.toHaveProperty("type");
+      expect(delta).not.toHaveProperty("thinking");
+    }
     const fullThinking = thinkingDeltas
-      .map((f) => (f.payload as { delta: { thinking: string } }).delta.thinking)
+      .map(
+        (f) =>
+          (f.payload as { delta: { reasoningContent: { text: string } } }).delta.reasoningContent
+            .text,
+      )
       .join("");
     expect(fullThinking).toBe("Let me think step by step about this problem.");
 
@@ -561,7 +590,8 @@ describe("POST /model/{id}/converse-stream (reasoning streaming)", () => {
     const thinkingDeltas = frames.filter(
       (f) =>
         f.eventType === "contentBlockDelta" &&
-        (f.payload as { delta?: { type?: string } }).delta?.type === "thinking_delta",
+        (f.payload as { delta?: { reasoningContent?: unknown } }).delta?.reasoningContent !==
+          undefined,
     );
     expect(thinkingDeltas).toHaveLength(0);
   });

--- a/src/bedrock-converse.ts
+++ b/src/bedrock-converse.ts
@@ -121,14 +121,14 @@ function buildBedrockStreamTextEvents(
     const blockIndex = 0;
     events.push({
       eventType: "contentBlockStart",
-      payload: { contentBlockIndex: blockIndex, start: { type: "thinking" } },
+      payload: { contentBlockIndex: blockIndex, start: { reasoningContent: {} } },
     });
     for (let i = 0; i < reasoning.length; i += chunkSize) {
       events.push({
         eventType: "contentBlockDelta",
         payload: {
           contentBlockIndex: blockIndex,
-          delta: { type: "thinking_delta", thinking: reasoning.slice(i, i + chunkSize) },
+          delta: { reasoningContent: { text: reasoning.slice(i, i + chunkSize) } },
         },
       });
     }
@@ -141,14 +141,14 @@ function buildBedrockStreamTextEvents(
   const textBlockIndex = reasoning ? 1 : 0;
   events.push({
     eventType: "contentBlockStart",
-    payload: { contentBlockIndex: textBlockIndex, start: { type: "text" } },
+    payload: { contentBlockIndex: textBlockIndex, start: {} },
   });
   for (let i = 0; i < content.length; i += chunkSize) {
     events.push({
       eventType: "contentBlockDelta",
       payload: {
         contentBlockIndex: textBlockIndex,
-        delta: { type: "text_delta", text: content.slice(i, i + chunkSize) },
+        delta: { text: content.slice(i, i + chunkSize) },
       },
     });
   }
@@ -375,6 +375,7 @@ export function converseToCompletionRequest(
     messages,
     stream: false,
     temperature: req.inferenceConfig?.temperature,
+    max_tokens: req.inferenceConfig?.maxTokens,
     tools,
   };
 }
@@ -403,6 +404,7 @@ function buildConverseTextResponse(
     },
     stopReason: converseStopReason(overrides?.finishReason, "end_turn"),
     usage: converseUsage(overrides),
+    metrics: { latencyMs: 0 },
   };
 }
 
@@ -437,6 +439,7 @@ function buildConverseToolCallResponse(
     },
     stopReason: converseStopReason(overrides?.finishReason, "tool_use"),
     usage: converseUsage(overrides),
+    metrics: { latencyMs: 0 },
   };
 }
 
@@ -482,6 +485,7 @@ function buildConverseContentWithToolCallsResponse(
     },
     stopReason: converseStopReason(overrides?.finishReason, "tool_use"),
     usage: converseUsage(overrides),
+    metrics: { latencyMs: 0 },
   };
 }
 


### PR DESCRIPTION
## Summary

Converse-stream spec conformance fixes — same class of bugs as #162 (Claude Messages API format leaking into Converse API handlers). Full 10-agent Bedrock conformance audit completed; all other Bedrock endpoints are clean.

### Fixes

1. **contentBlockDelta spurious `type` field** — `delta` objects contained Claude Messages API `type` fields (`text_delta`, `thinking_delta`) not valid in the Converse API's tagged union. botocore's single-member parser rejected the extra field with `ResponseParserError`. (Closes #165)

2. **Reasoning events used Claude format** — `contentBlockStart` used `start: { type: "thinking" }` and deltas used `delta: { thinking: "..." }`. Now uses Converse format: `start: { reasoningContent: {} }` and `delta: { reasoningContent: { text: "..." } }`.

3. **Text contentBlockStart had spurious `type`** — `start: { type: "text" }` changed to `start: {}` (Converse text blocks have empty start).

4. **`inferenceConfig.maxTokens` silently dropped** — `converseToCompletionRequest` now forwards `maxTokens` to `max_tokens`.

5. **Non-streaming converse missing `metrics`** — Added `metrics: { latencyMs: 0 }` to all 3 non-streaming response builders, matching the streaming path and AWS ConverseResponse spec.

### New drift tests

- **invoke-with-response-stream** drift test with binary frame parsing and Anthropic-native event shape comparison
- **converse-stream tool call** shapes — `toolUse` start/delta SDK shapes + triangulate
- **converse-stream reasoning** shapes — `reasoningContent` start/delta SDK shapes + triangulate

### Audit scope

10-agent MSAL covering: invoke non-streaming, invoke-stream binary framing, invoke-stream Claude events, converse non-streaming, converse-stream text/tool/reasoning, converse request conversion, invoke request conversion, drift test + SDK shape coverage. All clean except the 5 issues above.

Closes #165 — reported by @KMiya84377

## Test plan

- [x] `pnpm test` — 2837 passed
- [x] `npx tsc --noEmit` — clean
- [x] Negative assertions on all delta and start payloads
- [x] SDK drift shapes updated for all 3 converse-stream variants (text, tool, reasoning)
- [x] invoke-with-response-stream drift test added
- [x] Full codebase audit: zero Claude format contamination in other providers