### PR TITLE
Progressively relay NDJSON/Bedrock streams, add SSE anti-buffering headers

### DIFF
--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -4192,4 +4192,323 @@ describe("recorder SSE progressive streaming", () => {
     // slack for scheduler jitter but require clearly more than "all at once".
     expect(span).toBeGreaterThanOrEqual(100);
   });
+
+  it("includes Cache-Control, Connection, and X-Accel-Buffering headers on SSE relay", async () => {
+    // Upstream returns SSE — recorder must set standard anti-buffering headers
+    // so reverse proxies (nginx, Cloudflare, CDN, Bun.serve) do not buffer.
+    rawServer = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.write('data: {"chunk":0}\n\n');
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+    await new Promise<void>((resolve) => rawServer!.listen(0, "127.0.0.1", resolve));
+    const rawAddr = rawServer!.address() as { port: number };
+    const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-sse-hdrs-"));
+    recorder = await createServer([], {
+      port: 0,
+      record: { providers: { openai: rawUrl }, fixturePath: tmpDir, proxyOnly: true },
+    });
+
+    const resp = await post(`${recorder.url}/v1/chat/completions`, {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "sse headers" }],
+      stream: true,
+    });
+
+    expect(resp.headers["cache-control"]).toBe("no-cache, no-transform");
+    expect(resp.headers["connection"]).toBe("keep-alive");
+    expect(resp.headers["x-accel-buffering"]).toBe("no");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NDJSON progressive streaming — recorder must tee upstream chunks to the
+// client as they arrive, not buffer and replay in a single write.
+// ---------------------------------------------------------------------------
+
+describe("recorder NDJSON progressive streaming", () => {
+  let rawServer: http.Server | undefined;
+
+  afterEach(async () => {
+    if (rawServer) {
+      await new Promise<void>((resolve) => rawServer!.close(() => resolve()));
+      rawServer = undefined;
+    }
+  });
+
+  it("streams NDJSON lines progressively to the client (not buffered)", async () => {
+    // Raw upstream that emits 5 NDJSON lines spaced by 50ms each.
+    // The recorder must relay each chunk as it arrives; if it buffers
+    // and replays via a single res.end(), the client observes all lines
+    // within microseconds of each other.
+    const FRAME_DELAY_MS = 50;
+    const NUM_FRAMES = 5;
+    rawServer = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "application/x-ndjson",
+      });
+      let i = 0;
+      const emit = () => {
+        if (i < NUM_FRAMES) {
+          const line = JSON.stringify({
+            model: "llama3",
+            message: { role: "assistant", content: `chunk-${i}` },
+            done: false,
+          });
+          res.write(line + "\n");
+          i++;
+          setTimeout(emit, FRAME_DELAY_MS);
+        } else {
+          const doneLine = JSON.stringify({
+            model: "llama3",
+            message: { role: "assistant", content: "" },
+            done: true,
+          });
+          res.write(doneLine + "\n");
+          res.end();
+        }
+      };
+      setTimeout(emit, FRAME_DELAY_MS);
+    });
+    await new Promise<void>((resolve) => rawServer!.listen(0, "127.0.0.1", resolve));
+    const rawAddr = rawServer!.address() as { port: number };
+    const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-ndjson-"));
+    recorder = await createServer([], {
+      port: 0,
+      record: { providers: { ollama: rawUrl }, fixturePath: tmpDir, proxyOnly: true },
+    });
+
+    // Issue request and capture the wall-clock arrival time of each
+    // client-visible data event.
+    const arrivalTimes: number[] = [];
+    const body = JSON.stringify({
+      model: "llama3",
+      messages: [{ role: "user", content: "stream me" }],
+      stream: true,
+    });
+    const parsedUrl = new URL(recorder.url);
+    await new Promise<void>((resolve, reject) => {
+      const clientReq = http.request(
+        {
+          hostname: parsedUrl.hostname,
+          port: parsedUrl.port,
+          path: "/api/chat",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          res.on("data", () => {
+            arrivalTimes.push(Date.now());
+          });
+          res.on("end", () => resolve());
+          res.on("error", reject);
+        },
+      );
+      clientReq.on("error", reject);
+      clientReq.write(body);
+      clientReq.end();
+    });
+
+    // We should observe multiple client-visible data events, and the span
+    // between first and last should reflect the upstream frame spacing.
+    expect(arrivalTimes.length).toBeGreaterThanOrEqual(2);
+    const span = arrivalTimes[arrivalTimes.length - 1] - arrivalTimes[0];
+    expect(span).toBeGreaterThanOrEqual(100);
+  });
+
+  it("preserves application/x-ndjson content-type in client response", async () => {
+    rawServer = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/x-ndjson" });
+      res.write(
+        JSON.stringify({
+          model: "llama3",
+          message: { role: "assistant", content: "hi" },
+          done: true,
+        }) + "\n",
+      );
+      res.end();
+    });
+    await new Promise<void>((resolve) => rawServer!.listen(0, "127.0.0.1", resolve));
+    const rawAddr = rawServer!.address() as { port: number };
+    const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-ndjson-ct-"));
+    recorder = await createServer([], {
+      port: 0,
+      record: { providers: { ollama: rawUrl }, fixturePath: tmpDir, proxyOnly: true },
+    });
+
+    const body = JSON.stringify({
+      model: "llama3",
+      messages: [{ role: "user", content: "hi" }],
+      stream: true,
+    });
+    const parsedUrl = new URL(recorder.url);
+    const clientCT = await new Promise<string>((resolve, reject) => {
+      const clientReq = http.request(
+        {
+          hostname: parsedUrl.hostname,
+          port: parsedUrl.port,
+          path: "/api/chat",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          const ct = res.headers["content-type"] ?? "";
+          res.on("data", () => {});
+          res.on("end", () => resolve(ct));
+          res.on("error", reject);
+        },
+      );
+      clientReq.on("error", reject);
+      clientReq.write(body);
+      clientReq.end();
+    });
+
+    expect(clientCT.toLowerCase()).toContain("application/x-ndjson");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bedrock binary event stream progressive streaming — recorder must tee
+// upstream chunks to the client as they arrive, not buffer and replay.
+// ---------------------------------------------------------------------------
+
+describe("recorder Bedrock binary event stream progressive streaming", () => {
+  let rawServer: http.Server | undefined;
+
+  afterEach(async () => {
+    if (rawServer) {
+      await new Promise<void>((resolve) => rawServer!.close(() => resolve()));
+      rawServer = undefined;
+    }
+  });
+
+  it("streams Bedrock event stream frames progressively to the client (not buffered)", async () => {
+    const FRAME_DELAY_MS = 50;
+    const NUM_FRAMES = 5;
+    rawServer = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "application/vnd.amazon.eventstream",
+      });
+      let i = 0;
+      const emit = () => {
+        if (i < NUM_FRAMES) {
+          // Emit a minimal binary payload that looks like Bedrock event data.
+          // We don't need valid CRC framing here — the test verifies progressive
+          // relay timing, not parse correctness.
+          const payload = Buffer.from(`bedrock-chunk-${i}`);
+          res.write(payload);
+          i++;
+          setTimeout(emit, FRAME_DELAY_MS);
+        } else {
+          res.end();
+        }
+      };
+      setTimeout(emit, FRAME_DELAY_MS);
+    });
+    await new Promise<void>((resolve) => rawServer!.listen(0, "127.0.0.1", resolve));
+    const rawAddr = rawServer!.address() as { port: number };
+    const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-bedrock-"));
+    recorder = await createServer([], {
+      port: 0,
+      record: { providers: { bedrock: rawUrl }, fixturePath: tmpDir, proxyOnly: true },
+    });
+
+    const arrivalTimes: number[] = [];
+    const body = JSON.stringify({
+      messages: [{ role: "user", content: [{ text: "stream me" }] }],
+      modelId: "anthropic.claude-3-sonnet",
+    });
+    const parsedUrl = new URL(recorder.url);
+    await new Promise<void>((resolve, reject) => {
+      const clientReq = http.request(
+        {
+          hostname: parsedUrl.hostname,
+          port: parsedUrl.port,
+          path: "/model/anthropic.claude-3-sonnet/converse-stream",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          res.on("data", () => {
+            arrivalTimes.push(Date.now());
+          });
+          res.on("end", () => resolve());
+          res.on("error", reject);
+        },
+      );
+      clientReq.on("error", reject);
+      clientReq.write(body);
+      clientReq.end();
+    });
+
+    expect(arrivalTimes.length).toBeGreaterThanOrEqual(2);
+    const span = arrivalTimes[arrivalTimes.length - 1] - arrivalTimes[0];
+    expect(span).toBeGreaterThanOrEqual(100);
+  });
+
+  it("preserves application/vnd.amazon.eventstream content-type in client response", async () => {
+    rawServer = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/vnd.amazon.eventstream" });
+      res.write(Buffer.from("bedrock-data"));
+      res.end();
+    });
+    await new Promise<void>((resolve) => rawServer!.listen(0, "127.0.0.1", resolve));
+    const rawAddr = rawServer!.address() as { port: number };
+    const rawUrl = `http://127.0.0.1:${rawAddr.port}`;
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-bedrock-ct-"));
+    recorder = await createServer([], {
+      port: 0,
+      record: { providers: { bedrock: rawUrl }, fixturePath: tmpDir, proxyOnly: true },
+    });
+
+    const body = JSON.stringify({
+      messages: [{ role: "user", content: [{ text: "hi" }] }],
+      modelId: "anthropic.claude-3-sonnet",
+    });
+    const parsedUrl = new URL(recorder.url);
+    const clientCT = await new Promise<string>((resolve, reject) => {
+      const clientReq = http.request(
+        {
+          hostname: parsedUrl.hostname,
+          port: parsedUrl.port,
+          path: "/model/anthropic.claude-3-sonnet/converse-stream",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(body),
+          },
+        },
+        (res) => {
+          const ct = res.headers["content-type"] ?? "";
+          res.on("data", () => {});
+          res.on("end", () => resolve(ct));
+          res.on("error", reject);
+        },
+      );
+      clientReq.on("error", reject);
+      clientReq.write(body);
+      clientReq.end();
+    });
+
+    expect(clientCT.toLowerCase()).toContain("application/vnd.amazon.eventstream");
+  });
 });

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -61,7 +61,8 @@ export interface ProxyOptions {
    * unwritten.
    *
    * NOT invoked when the upstream response was streamed progressively to the
-   * client (SSE) — the bytes are already on the wire and can't be mutated.
+   * client (SSE, NDJSON, or binary event streams) — the bytes are already on
+   * the wire and can't be mutated.
    * Callers that need to observe the bypass should pass `onHookBypassed`.
    */
   beforeWriteResponse?: (response: ProxyCapturedResponse) => boolean | Promise<boolean>;
@@ -72,7 +73,7 @@ export interface ProxyOptions {
    * Intended for observability (log/metric/journal annotation) — proxyAndRecord
    * still returns `"relayed"`.
    */
-  onHookBypassed?: (reason: "sse_streamed") => void;
+  onHookBypassed?: (reason: "sse_streamed" | "ndjson_streamed" | "binary_streamed") => void;
 }
 
 /**
@@ -428,15 +429,20 @@ export async function proxyAndRecord(
     defaults.logger.info(`Proxied ${providerKey} request (proxy-only mode)`);
   }
 
-  // Relay upstream response to client (skip when SSE was already streamed
-  // progressively by makeUpstreamRequest — headers and body are already on
-  // the wire).
+  // Relay upstream response to client (skip when the response was already
+  // streamed progressively by makeUpstreamRequest — headers and body are
+  // already on the wire).
   if (streamedToClient) {
-    // SSE: the hook can't run because the body is already on the wire. Surface
+    // The hook can't run because the body is already on the wire. Surface
     // the bypass so the caller (typically the chaos layer) can record it —
-    // otherwise a configured chaos action silently no-ops on SSE traffic.
+    // otherwise a configured chaos action silently no-ops on streamed traffic.
     if (options?.beforeWriteResponse && options.onHookBypassed) {
-      options.onHookBypassed("sse_streamed");
+      const bypassReason: "sse_streamed" | "ndjson_streamed" | "binary_streamed" = isBinaryStream
+        ? "binary_streamed"
+        : ctString.toLowerCase().includes("application/x-ndjson")
+          ? "ndjson_streamed"
+          : "sse_streamed";
+      options.onHookBypassed(bypassReason);
     }
   } else {
     // Give the caller a chance to mutate or replace the response before relay.
@@ -502,18 +508,27 @@ function makeUpstreamRequest(
         res.setTimeout(BODY_TIMEOUT_MS, () => {
           req.destroy(new Error(`Upstream response timed out after ${BODY_TIMEOUT_MS / 1000}s`));
         });
-        // Detect Server-Sent Events so we can tee upstream chunks to the
+        // Detect streaming content types so we can tee upstream chunks to the
         // client as they arrive rather than buffering the entire stream and
         // replaying it in a single res.end() at the bottom of proxyAndRecord.
-        // Buffering collapses every SSE frame into one client-visible write,
-        // which defeats progressive rendering in downstream consumers.
+        // Buffering collapses every frame into one client-visible write,
+        // which defeats progressive rendering in downstream consumers and
+        // can trip HTTP idle timeouts on slow calls.
         const ct = res.headers["content-type"];
         const ctStr = Array.isArray(ct) ? ct.join(", ") : (ct ?? "");
-        const isSSE = ctStr.toLowerCase().includes("text/event-stream");
+        const ctLower = ctStr.toLowerCase();
+        const isSSE = ctLower.includes("text/event-stream");
+        const isNDJSON = ctLower.includes("application/x-ndjson");
+        const isBinaryEventStream = ctLower.includes("application/vnd.amazon.eventstream");
+        const isProgressiveStream = isSSE || isNDJSON || isBinaryEventStream;
         let streamedToClient = false;
         let clientDisconnected = false;
-        if (isSSE && clientRes && !clientRes.headersSent) {
-          const relayHeaders: Record<string, string> = {};
+        if (isProgressiveStream && clientRes && !clientRes.headersSent) {
+          const relayHeaders: Record<string, string> = {
+            "Cache-Control": "no-cache, no-transform",
+            Connection: "keep-alive",
+            "X-Accel-Buffering": "no",
+          };
           if (ctStr) relayHeaders["Content-Type"] = ctStr;
           // Normalize status codes for the client: aimock acts as a gateway,
           // so upstream provider details should not leak.

--- a/src/server.ts
+++ b/src/server.ts
@@ -562,13 +562,12 @@ async function handleCompletions(
                 );
                 return true;
               },
-              // SSE can't be mutated post-facto (bytes already on the wire).
-              // Record the bypass so the rolled action isn't invisible in
-              // logs / Prometheus — otherwise malformedRate: 1.0 on SSE
-              // traffic silently means 0%.
-              onHookBypassed: (reason: "sse_streamed") => {
+              // Streaming responses can't be mutated post-facto (bytes already
+              // on the wire). Record the bypass so the rolled action isn't
+              // invisible in logs / Prometheus.
+              onHookBypassed: (reason: "sse_streamed" | "ndjson_streamed" | "binary_streamed") => {
                 defaults.logger.warn(
-                  `[chaos] malformed bypassed on proxy: upstream returned SSE (${reason})`,
+                  `[chaos] malformed bypassed on proxy: upstream returned streaming response (${reason})`,
                 );
                 defaults.registry?.incrementCounter("aimock_chaos_bypassed_total", {
                   action: "malformed",


### PR DESCRIPTION
## Summary

- Extend progressive streaming relay to cover `application/x-ndjson` (Ollama) and `application/vnd.amazon.eventstream` (Bedrock) — previously these were fully buffered before relay, triggering downstream HTTP idle timeouts on slow calls
- Add standard anti-buffering headers (`Cache-Control: no-cache, no-transform`, `Connection: keep-alive`, `X-Accel-Buffering: no`) to all progressive stream relay paths, preventing reverse proxies from buffering SSE/NDJSON/Bedrock responses
- Widen `onHookBypassed` reason type to distinguish SSE, NDJSON, and binary stream bypasses

Addresses #172

## Test plan

- [x] 2872 tests pass (79 files, 37 skipped)
- [x] TypeScript typecheck clean
- [x] Prettier + ESLint clean
- [x] 7-agent CR Round 1: 0 bucket (a) findings
- [x] 5 new tests: NDJSON progressive timing, NDJSON content-type preservation, Bedrock progressive timing, Bedrock content-type preservation, SSE anti-buffering headers