### PR TITLE
Codebase hardening: bucket (c) sweep from dual-context header CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Helper utilities and error serialization** — hardened helper functions and error serialization paths for correctness and robustness
+- **Journal and fixture-loader correctness** — fixed journal entry handling and fixture-loader edge cases
+- **WebSocket handler consistency and strict-mode journal** — aligned WebSocket handler behavior and ensured strict-mode journal entries are recorded correctly
+- **Provider handler consistency and proxy outcomes** — unified provider handler error paths and proxy outcome reporting
+- **Media handler hardening and chaos injection** — strengthened media handler validation and chaos injection reliability
+
+### Tests
+
+- **Bedrock mock consistency and CLI help text** — corrected Bedrock mock test assertions and CLI `--help` output coverage
+
 ## [1.22.0] - 2026-05-11
 
 ### Added

--- a/src/__tests__/bedrock-stream.test.ts
+++ b/src/__tests__/bedrock-stream.test.ts
@@ -187,9 +187,6 @@ function postPartialBinary(
         res.on("error", () => {
           aborted = true;
         });
-        res.on("aborted", () => {
-          aborted = true;
-        });
         res.on("close", () => {
           safeResolve({ body: Buffer.concat(chunks), aborted });
         });
@@ -1747,7 +1744,7 @@ describe("converseToCompletionRequest (edge cases)", () => {
       },
       "model",
     );
-    expect(result.messages[0]).toEqual({ role: "assistant", content: "" });
+    expect(result.messages[0]).toEqual({ role: "assistant", content: null });
   });
 
   it("handles user tool result with missing text in content items (text ?? '' fallback)", () => {
@@ -1859,8 +1856,8 @@ describe("converseToCompletionRequest (edge cases)", () => {
       "model",
     );
     expect(result.messages[0].tool_calls).toHaveLength(1);
-    // Empty text → content is "" (nullish coalescing preserves empty string)
-    expect(result.messages[0].content).toBe("");
+    // Empty text → content is null (|| coerces empty string to null)
+    expect(result.messages[0].content).toBe(null);
   });
 });
 

--- a/src/__tests__/bedrock.test.ts
+++ b/src/__tests__/bedrock.test.ts
@@ -751,8 +751,8 @@ describe("bedrockToCompletionRequest (edge cases)", () => {
       },
       "model",
     );
-    // Empty array → no tool_use blocks, textContent is "" → preserved as "" (not coerced to null via ??)
-    expect(result.messages[0]).toEqual({ role: "assistant", content: "" });
+    // Empty array → no tool_use blocks, textContent is "" → coerced to null via ||
+    expect(result.messages[0]).toEqual({ role: "assistant", content: null });
   });
 
   it("handles user message with content blocks but no tool_results (text extraction)", () => {
@@ -1650,31 +1650,8 @@ describe("Bedrock webSearches warning", () => {
       response: { content: "Result.", webSearches: ["test"] },
     };
     const journal = new Journal();
-    const req = {
-      method: undefined,
-      url: undefined,
-      headers: {},
-    } as unknown as http.IncomingMessage;
-    const res = {
-      _written: "",
-      writableEnded: false,
-      statusCode: 0,
-      writeHead(s: number) {
-        this.statusCode = s;
-      },
-      setHeader() {},
-      write(d: string) {
-        this._written += d;
-        return true;
-      },
-      end(d?: string) {
-        if (d) this._written += d;
-        this.writableEnded = true;
-      },
-      destroy() {
-        this.writableEnded = true;
-      },
-    } as unknown as http.ServerResponse;
+    const req = createMockReq();
+    const res = createMockRes();
 
     await handleBedrock(
       req,

--- a/src/bedrock-converse.ts
+++ b/src/bedrock-converse.ts
@@ -180,8 +180,12 @@ function buildBedrockStreamContentWithToolCallsEvents(
 ): Array<{ eventType: string; payload: object }> {
   const events = buildBedrockStreamTextEvents(content, chunkSize, reasoning, overrides);
   // Remove trailing metadata + messageStop events — we re-emit them after tool blocks
-  events.pop(); // metadata
-  events.pop(); // messageStop
+  for (let i = events.length - 1; i >= 0; i--) {
+    const et = (events[i] as { eventType: string }).eventType;
+    if (et === "metadata" || et === "messageStop") {
+      events.splice(i, 1);
+    }
+  }
   let blockIndex = reasoning ? 2 : 1;
 
   for (const tc of toolCalls) {
@@ -336,7 +340,7 @@ export function converseToCompletionRequest(
       if (toolUseBlocks.length > 0) {
         messages.push({
           role: "assistant",
-          content: textContent ?? null,
+          content: textContent || null,
           tool_calls: toolUseBlocks.map((b) => ({
             id: b.toolUse!.toolUseId,
             type: "function" as const,
@@ -347,7 +351,7 @@ export function converseToCompletionRequest(
           })),
         });
       } else {
-        messages.push({ role: "assistant", content: textContent ?? null });
+        messages.push({ role: "assistant", content: textContent || null });
       }
     } else {
       const warnMsg = `Unexpected message role "${msg.role}" in Converse request — skipping`;
@@ -607,6 +611,7 @@ export async function handleConverse(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -723,7 +728,7 @@ export async function handleConverse(
 
   // Tool call response
   if (isToolCallResponse(response)) {
-    if ("webSearches" in response) {
+    if (response.webSearches?.length) {
       logger.warn(
         "webSearches in fixture response are not supported for Bedrock Converse API — ignoring",
       );
@@ -877,6 +882,7 @@ export async function handleConverseStream(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -1023,7 +1029,7 @@ export async function handleConverseStream(
 
   // Tool call response — stream as Event Stream
   if (isToolCallResponse(response)) {
-    if ("webSearches" in response) {
+    if (response.webSearches?.length) {
       logger.warn(
         "webSearches in fixture response are not supported for Bedrock Converse API — ignoring",
       );

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -207,7 +207,7 @@ export function bedrockToCompletionRequest(
         if (toolUseBlocks.length > 0) {
           messages.push({
             role: "assistant",
-            content: textContent ?? null,
+            content: textContent || null,
             tool_calls: toolUseBlocks.map((b, index) => {
               if (!b.id && logger) {
                 logger.warn(
@@ -225,7 +225,7 @@ export function bedrockToCompletionRequest(
             }),
           });
         } else {
-          messages.push({ role: "assistant", content: textContent ?? null });
+          messages.push({ role: "assistant", content: textContent || null });
         }
       } else {
         messages.push({ role: "assistant", content: null });
@@ -257,6 +257,7 @@ export function bedrockToCompletionRequest(
     messages,
     stream: false,
     temperature: req.temperature,
+    max_tokens: req.max_tokens,
     tools,
   };
 }
@@ -438,6 +439,7 @@ export async function handleBedrock(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -571,7 +573,7 @@ export async function handleBedrock(
 
   // Tool call response
   if (isToolCallResponse(response)) {
-    if ("webSearches" in response) {
+    if (response.webSearches?.length) {
       logger.warn("webSearches in fixture response are not supported for Bedrock API — ignoring");
     }
     const overrides = extractOverrides(response);
@@ -1058,6 +1060,7 @@ export async function handleBedrockStream(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -1204,7 +1207,7 @@ export async function handleBedrockStream(
 
   // Tool call response — stream as Event Stream
   if (isToolCallResponse(response)) {
-    if ("webSearches" in response) {
+    if (response.webSearches?.length) {
       logger.warn("webSearches in fixture response are not supported for Bedrock API — ignoring");
     }
     const overrides = extractOverrides(response);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ Options:
   -l, --latency <ms>        Latency in ms between SSE chunks (default: 0)
   -c, --chunk-size <chars>  Chunk size in characters (default: 20)
   -w, --watch               Watch fixture path for changes and reload
-      --log-level <level>   Log verbosity: silent, info, debug (default: info)
+      --log-level <level>   Log verbosity: silent, warn, info, debug (default: info)
       --validate-on-load    Validate fixture schemas at startup
       --metrics             Enable Prometheus metrics at GET /metrics
       --record              Record mode: proxy unmatched requests and save fixtures

--- a/src/cohere.ts
+++ b/src/cohere.ts
@@ -28,6 +28,7 @@ import {
   isToolCallResponse,
   isContentWithToolCallsResponse,
   isErrorResponse,
+  serializeErrorResponse,
   flattenHeaders,
   getTestId,
   resolveResponse,
@@ -874,6 +875,7 @@ export async function handleCohere(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -933,7 +935,7 @@ export async function handleCohere(
       body: completionReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 
@@ -1033,6 +1035,11 @@ export async function handleCohere(
 
   // Tool call response
   if (isToolCallResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn(
+        "webSearches in fixture response are not supported for Cohere v2 Chat API — ignoring",
+      );
+    }
     const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+/** Sentinel testId used when no explicit test scope is provided. */
+export const DEFAULT_TEST_ID = "__default__";

--- a/src/elevenlabs-audio.ts
+++ b/src/elevenlabs-audio.ts
@@ -4,6 +4,8 @@ import {
   isAudioResponse,
   isTextResponse,
   isErrorResponse,
+  serializeErrorResponse,
+  flattenHeaders,
   FORMAT_TO_CONTENT_TYPE,
   getTestId,
   resolveResponse,
@@ -14,6 +16,7 @@ import { matchFixture } from "./router.js";
 import { writeErrorResponse } from "./sse-writer.js";
 import { proxyAndRecord } from "./recorder.js";
 import type { Journal } from "./journal.js";
+import { applyChaos } from "./chaos.js";
 
 export async function handleElevenLabsAudio(
   req: http.IncomingMessage,
@@ -36,7 +39,7 @@ export async function handleElevenLabsAudio(
     journal.add({
       method,
       path,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: null,
       response: { status: 400, fixture: null },
     });
@@ -87,7 +90,7 @@ export async function handleElevenLabsAudio(
     journal.add({
       method,
       path,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: { status: 400, fixture: null },
     });
@@ -113,6 +116,21 @@ export async function handleElevenLabsAudio(
     journal.incrementFixtureMatchCount(fixture, fixtures, testId);
   }
 
+  if (
+    applyChaos(
+      res,
+      fixture,
+      defaults.chaos,
+      req.headers,
+      journal,
+      { method, path, headers: flattenHeaders(req.headers), body: syntheticReq },
+      fixture ? "fixture" : "proxy",
+      defaults.registry,
+      defaults.logger,
+    )
+  )
+    return;
+
   // No fixture match
   if (!fixture) {
     if (defaults.record) {
@@ -127,11 +145,11 @@ export async function handleElevenLabsAudio(
         body,
       );
       if (outcome === "handled_by_hook") return;
-      if (outcome === "relayed") {
+      if (outcome !== "not_configured") {
         journal.add({
           method,
           path,
-          headers: {},
+          headers: flattenHeaders(req.headers),
           body: syntheticReq,
           response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
@@ -147,7 +165,7 @@ export async function handleElevenLabsAudio(
     journal.add({
       method,
       path,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: {
         status: strictStatus,
@@ -173,11 +191,11 @@ export async function handleElevenLabsAudio(
     journal.add({
       method,
       path,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 
@@ -187,7 +205,7 @@ export async function handleElevenLabsAudio(
       journal.add({
         method,
         path,
-        headers: {},
+        headers: flattenHeaders(req.headers),
         body: syntheticReq,
         response: { status: 500, fixture },
       });
@@ -206,7 +224,7 @@ export async function handleElevenLabsAudio(
     journal.add({
       method,
       path,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: { status: 200, fixture },
     });
@@ -220,7 +238,7 @@ export async function handleElevenLabsAudio(
     journal.add({
       method,
       path,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: { status: 500, fixture },
     });
@@ -257,7 +275,7 @@ export async function handleElevenLabsAudio(
     journal.add({
       method,
       path,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: { status: 200, fixture },
     });
@@ -273,7 +291,7 @@ export async function handleElevenLabsAudio(
   journal.add({
     method,
     path,
-    headers: {},
+    headers: flattenHeaders(req.headers),
     body: syntheticReq,
     response: { status: 200, fixture },
   });

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -16,6 +16,7 @@ import type {
 import {
   isEmbeddingResponse,
   isErrorResponse,
+  serializeErrorResponse,
   generateDeterministicEmbedding,
   buildEmbeddingResponse,
   flattenHeaders,
@@ -168,7 +169,7 @@ export async function handleEmbeddings(
         body: syntheticReq,
         response: { status, fixture },
       });
-      writeErrorResponse(res, status, JSON.stringify(response));
+      writeErrorResponse(res, status, serializeErrorResponse(response));
       return;
     }
 
@@ -222,6 +223,7 @@ export async function handleEmbeddings(
       defaults,
       raw,
     );
+    if (outcome === "handled_by_hook") return;
     if (outcome !== "not_configured") {
       journal.add({
         method: req.method ?? "POST",

--- a/src/fal-audio.ts
+++ b/src/fal-audio.ts
@@ -4,15 +4,19 @@ import type { AudioResponse, ChatCompletionRequest, Fixture, HandlerDefaults } f
 import {
   isAudioResponse,
   isErrorResponse,
+  serializeErrorResponse,
+  flattenHeaders,
   FORMAT_TO_CONTENT_TYPE,
   getTestId,
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
 } from "./helpers.js";
+import { writeErrorResponse } from "./sse-writer.js";
 import { matchFixture } from "./router.js";
 import { proxyAndRecord } from "./recorder.js";
 import type { Journal } from "./journal.js";
+import { applyChaos } from "./chaos.js";
 
 // ─── FalJobMap with TTL and size bound ───────────────────────────────────
 
@@ -24,7 +28,6 @@ interface FalJob {
   modelId: string;
   status: "IN_QUEUE" | "IN_PROGRESS" | "COMPLETED";
   result: Record<string, unknown> | null;
-  createdAt: number;
 }
 
 interface FalJobEntry {
@@ -37,9 +40,40 @@ interface FalJobEntry {
  * Entries older than FAL_JOB_TTL_MS are lazily evicted on `get`.
  * When the map exceeds FAL_JOB_MAX_ENTRIES on `set`, the oldest entries
  * are removed to stay within bounds.
+ * A background sweep runs every 60 s to proactively evict expired entries.
  */
 export class FalJobMap {
   private readonly entries = new Map<string, FalJobEntry>();
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.startSweep();
+  }
+
+  /** Start the proactive TTL sweep (every 60 s). */
+  startSweep(): void {
+    if (this.sweepTimer) return;
+    this.sweepTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [key, entry] of this.entries) {
+        if (now - entry.createdAt > FAL_JOB_TTL_MS) {
+          this.entries.delete(key);
+        }
+      }
+    }, 60_000);
+    // Allow the process to exit even if the timer is still active
+    if (this.sweepTimer && typeof this.sweepTimer === "object" && "unref" in this.sweepTimer) {
+      this.sweepTimer.unref();
+    }
+  }
+
+  /** Stop the proactive TTL sweep. */
+  stopSweep(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+  }
 
   get(key: string): FalJob | undefined {
     const entry = this.entries.get(key);
@@ -69,6 +103,11 @@ export class FalJobMap {
   }
 
   clear(): void {
+    this.entries.clear();
+  }
+
+  destroy(): void {
+    this.stopSweep();
     this.entries.clear();
   }
 
@@ -196,7 +235,7 @@ export async function handleFalQueue(
   journal.add({
     method: req.method ?? "GET",
     path: pathname,
-    headers: {},
+    headers: flattenHeaders(req.headers),
     body: null,
     response: { status: 404, fixture: null },
   });
@@ -227,7 +266,7 @@ async function handleQueueSubmit(
       journal.add({
         method: req.method ?? "POST",
         path: pathname,
-        headers: {},
+        headers: flattenHeaders(req.headers),
         body: null,
         response: { status: 400, fixture: null },
       });
@@ -254,6 +293,30 @@ async function handleQueueSubmit(
 
   const fixture = matchFixture(fixtures, syntheticReq, matchCounts, defaults.requestTransform);
 
+  if (fixture) {
+    journal.incrementFixtureMatchCount(fixture, fixtures, testId);
+  }
+
+  if (
+    applyChaos(
+      res,
+      fixture,
+      defaults.chaos,
+      req.headers,
+      journal,
+      {
+        method: req.method ?? "POST",
+        path: pathname,
+        headers: flattenHeaders(req.headers),
+        body: syntheticReq,
+      },
+      fixture ? "fixture" : "proxy",
+      defaults.registry,
+      defaults.logger,
+    )
+  )
+    return;
+
   if (!fixture) {
     if (defaults.record) {
       const outcome = await proxyAndRecord(
@@ -267,11 +330,11 @@ async function handleQueueSubmit(
         body,
       );
       if (outcome === "handled_by_hook") return;
-      if (outcome === "relayed") {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: pathname,
-          headers: {},
+          headers: flattenHeaders(req.headers),
           body: syntheticReq,
           response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
@@ -287,7 +350,7 @@ async function handleQueueSubmit(
     journal.add({
       method: req.method ?? "POST",
       path: pathname,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: {
         status: strictStatus,
@@ -308,7 +371,6 @@ async function handleQueueSubmit(
     return;
   }
 
-  journal.incrementFixtureMatchCount(fixture, fixtures, testId);
   const response = await resolveResponse(fixture, syntheticReq);
 
   if (isErrorResponse(response)) {
@@ -316,12 +378,12 @@ async function handleQueueSubmit(
     journal.add({
       method: req.method ?? "POST",
       path: pathname,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: { status, fixture },
     });
     res.writeHead(status, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(response));
+    res.end(serializeErrorResponse(response));
     return;
   }
 
@@ -329,7 +391,7 @@ async function handleQueueSubmit(
     journal.add({
       method: req.method ?? "POST",
       path: pathname,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: { status: 500, fixture },
     });
@@ -350,7 +412,6 @@ async function handleQueueSubmit(
     modelId,
     status: "COMPLETED",
     result,
-    createdAt: Date.now(),
   };
 
   const stateKey = `${testId}:${requestId}`;
@@ -359,7 +420,7 @@ async function handleQueueSubmit(
   journal.add({
     method: req.method ?? "POST",
     path: pathname,
-    headers: {},
+    headers: flattenHeaders(req.headers),
     body: syntheticReq,
     response: { status: 200, fixture },
   });
@@ -390,7 +451,7 @@ function handleQueueStatus(
     journal.add({
       method: req.method ?? "GET",
       path: pathname,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: null,
       response: { status: 404, fixture: null },
     });
@@ -406,7 +467,7 @@ function handleQueueStatus(
   journal.add({
     method: req.method ?? "GET",
     path: pathname,
-    headers: {},
+    headers: flattenHeaders(req.headers),
     body: null,
     response: { status: 200, fixture: null },
   });
@@ -435,7 +496,7 @@ function handleQueueResult(
     journal.add({
       method: req.method ?? "GET",
       path: pathname,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: null,
       response: { status: 404, fixture: null },
     });
@@ -448,10 +509,28 @@ function handleQueueResult(
     return;
   }
 
+  if (job.result === null) {
+    journal.add({
+      method: req.method ?? "GET",
+      path: pathname,
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 409, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      409,
+      JSON.stringify({
+        error: { message: "Job result not yet available", type: "not_ready" },
+      }),
+    );
+    return;
+  }
+
   journal.add({
     method: req.method ?? "GET",
     path: pathname,
-    headers: {},
+    headers: flattenHeaders(req.headers),
     body: null,
     response: { status: 200, fixture: null },
   });
@@ -474,7 +553,7 @@ function handleQueueCancel(
     journal.add({
       method: req.method ?? "DELETE",
       path: pathname,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: null,
       response: { status: 404, fixture: null },
     });
@@ -487,7 +566,7 @@ function handleQueueCancel(
   journal.add({
     method: req.method ?? "DELETE",
     path: pathname,
-    headers: {},
+    headers: flattenHeaders(req.headers),
     body: null,
     response: { status: 400, fixture: null },
   });
@@ -515,7 +594,7 @@ async function handleSyncRun(
       journal.add({
         method: req.method ?? "POST",
         path: pathname,
-        headers: {},
+        headers: flattenHeaders(req.headers),
         body: null,
         response: { status: 400, fixture: null },
       });
@@ -542,6 +621,30 @@ async function handleSyncRun(
 
   const fixture = matchFixture(fixtures, syntheticReq, matchCounts, defaults.requestTransform);
 
+  if (fixture) {
+    journal.incrementFixtureMatchCount(fixture, fixtures, getTestId(req));
+  }
+
+  if (
+    applyChaos(
+      res,
+      fixture,
+      defaults.chaos,
+      req.headers,
+      journal,
+      {
+        method: req.method ?? "POST",
+        path: pathname,
+        headers: flattenHeaders(req.headers),
+        body: syntheticReq,
+      },
+      fixture ? "fixture" : "proxy",
+      defaults.registry,
+      defaults.logger,
+    )
+  )
+    return;
+
   if (!fixture) {
     if (defaults.record) {
       const outcome = await proxyAndRecord(
@@ -555,11 +658,11 @@ async function handleSyncRun(
         body,
       );
       if (outcome === "handled_by_hook") return;
-      if (outcome === "relayed") {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: pathname,
-          headers: {},
+          headers: flattenHeaders(req.headers),
           body: syntheticReq,
           response: { status: res.statusCode ?? 200, fixture: null, source: "proxy" },
         });
@@ -575,7 +678,7 @@ async function handleSyncRun(
     journal.add({
       method: req.method ?? "POST",
       path: pathname,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: {
         status: strictStatus,
@@ -596,7 +699,6 @@ async function handleSyncRun(
     return;
   }
 
-  journal.incrementFixtureMatchCount(fixture, fixtures, getTestId(req));
   const response = await resolveResponse(fixture, syntheticReq);
 
   if (isErrorResponse(response)) {
@@ -604,12 +706,12 @@ async function handleSyncRun(
     journal.add({
       method: req.method ?? "POST",
       path: pathname,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: { status, fixture },
     });
     res.writeHead(status, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(response));
+    res.end(serializeErrorResponse(response));
     return;
   }
 
@@ -617,7 +719,7 @@ async function handleSyncRun(
     journal.add({
       method: req.method ?? "POST",
       path: pathname,
-      headers: {},
+      headers: flattenHeaders(req.headers),
       body: syntheticReq,
       response: { status: 500, fixture },
     });
@@ -635,7 +737,7 @@ async function handleSyncRun(
   journal.add({
     method: req.method ?? "POST",
     path: pathname,
-    headers: {},
+    headers: flattenHeaders(req.headers),
     body: syntheticReq,
     response: { status: 200, fixture },
   });

--- a/src/fal.ts
+++ b/src/fal.ts
@@ -4,6 +4,7 @@ import type { ChatCompletionRequest, Fixture, HandlerDefaults, RawJSONResponse }
 import {
   isAudioResponse,
   isErrorResponse,
+  serializeErrorResponse,
   isJSONResponse,
   flattenHeaders,
   getTestId,
@@ -327,7 +328,7 @@ export async function handleFal(
             body,
           );
           if (outcome === "handled_by_hook") return "handled";
-          if (outcome === "relayed") {
+          if (outcome !== "not_configured") {
             journal.add({
               method: req.method ?? "POST",
               path: pathname,
@@ -381,7 +382,7 @@ export async function handleFal(
           response: { status, fixture },
         });
         res.writeHead(status, { "Content-Type": "application/json" });
-        res.end(JSON.stringify(response));
+        res.end(serializeErrorResponse(response));
         return "handled";
       }
 

--- a/src/fixture-loader.ts
+++ b/src/fixture-loader.ts
@@ -387,6 +387,7 @@ export function validateFixtures(fixtures: Fixture[]): ValidationResult[] {
             });
           }
         }
+        validateWebSearches(response, i, results);
       }
 
       // Error response checks
@@ -612,6 +613,19 @@ export function validateFixtures(fixtures: Fixture[]): ValidationResult[] {
         });
       }
     }
+    if (f.match.sequenceIndex !== undefined) {
+      if (
+        typeof f.match.sequenceIndex !== "number" ||
+        f.match.sequenceIndex < 0 ||
+        !Number.isInteger(f.match.sequenceIndex)
+      ) {
+        results.push({
+          severity: "error",
+          fixtureIndex: i,
+          message: "match.sequenceIndex must be a non-negative integer",
+        });
+      }
+    }
     if (f.match.hasToolResult !== undefined && typeof f.match.hasToolResult !== "boolean") {
       results.push({
         severity: "error",
@@ -683,6 +697,7 @@ export function validateFixtures(fixtures: Fixture[]): ValidationResult[] {
       match.model !== undefined ||
       match.predicate !== undefined ||
       match.turnIndex !== undefined ||
+      match.sequenceIndex !== undefined ||
       match.hasToolResult !== undefined;
 
     if (!hasDiscriminator && i < fixtures.length - 1) {

--- a/src/gemini-interactions.ts
+++ b/src/gemini-interactions.ts
@@ -713,7 +713,7 @@ export async function handleGeminiInteractions(
         raw,
       );
       if (outcome === "handled_by_hook") return;
-      if (outcome === "relayed") {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: urlPath,

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -109,15 +109,26 @@ export function geminiToCompletionRequest(
         const textParts = content.parts.filter((p) => p.text !== undefined && !p.thought);
 
         if (funcResponses.length > 0) {
-          // functionResponse → tool message
+          // functionResponse → tool message; match IDs from the preceding assistant's tool_calls
+          const lastAssistant = [...messages]
+            .reverse()
+            .find((m) => m.role === "assistant" && m.tool_calls);
+          const matchedToolCallIds = new Set<string>();
           for (const part of funcResponses) {
+            const matchingCall = lastAssistant?.tool_calls?.find(
+              (tc) =>
+                tc.function.name === part.functionResponse!.name && !matchedToolCallIds.has(tc.id),
+            );
+            if (matchingCall) matchedToolCallIds.add(matchingCall.id);
+            const toolCallId =
+              matchingCall?.id ?? `call_gemini_${part.functionResponse!.name}_${callCounter++}`;
             messages.push({
               role: "tool",
               content:
                 typeof part.functionResponse!.response === "string"
                   ? part.functionResponse!.response
                   : JSON.stringify(part.functionResponse!.response),
-              tool_call_id: `call_gemini_${part.functionResponse!.name}_${callCounter++}`,
+              tool_call_id: toolCallId,
             });
           }
           // Any text parts alongside → user message
@@ -142,8 +153,8 @@ export function geminiToCompletionRequest(
           messages.push({
             role: "assistant",
             content: text || null,
-            tool_calls: funcCalls.map((fc) => ({
-              id: `call_gemini_${fc.functionCall!.name}_${callCounter++}`,
+            tool_calls: funcCalls.map((fc, i) => ({
+              id: `call_gemini_${fc.functionCall!.name}_${i}`,
               type: "function" as const,
               function: {
                 name: fc.functionCall!.name,
@@ -209,8 +220,16 @@ function geminiUsageMetadata(overrides?: ResponseOverrides): {
 } {
   if (!overrides?.usage)
     return { promptTokenCount: 0, candidatesTokenCount: 0, totalTokenCount: 0 };
-  const prompt = overrides.usage.promptTokenCount ?? 0;
-  const candidates = overrides.usage.candidatesTokenCount ?? 0;
+  const prompt =
+    overrides.usage.promptTokenCount ??
+    overrides.usage.prompt_tokens ??
+    overrides.usage.input_tokens ??
+    0;
+  const candidates =
+    overrides.usage.candidatesTokenCount ??
+    overrides.usage.completion_tokens ??
+    overrides.usage.output_tokens ??
+    0;
   const total = overrides.usage.totalTokenCount ?? prompt + candidates;
   return {
     promptTokenCount: prompt,
@@ -643,6 +662,7 @@ export async function handleGemini(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -837,6 +857,9 @@ export async function handleGemini(
 
   // Tool call response
   if (isToolCallResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn("webSearches in fixture response are not supported for Gemini API — ignoring");
+    }
     const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import type * as http from "node:http";
 import type { IncomingHttpHeaders } from "node:http";
+import { DEFAULT_TEST_ID } from "./constants.js";
 import type {
   ChatCompletionRequest,
   Fixture,
@@ -85,8 +86,13 @@ export async function resolveResponse(
   request: ChatCompletionRequest,
 ): Promise<FixtureResponse> {
   if (typeof fixture.response === "function") {
-    const raw = await fixture.response(request);
-    return normalizeFactoryResponse(raw);
+    try {
+      const raw = await fixture.response(request);
+      return normalizeFactoryResponse(raw);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Response factory threw: ${msg}`);
+    }
   }
   return fixture.response;
 }
@@ -101,7 +107,7 @@ function normalizeFactoryResponse(raw: FixtureResponse): FixtureResponse {
       if (typeof tc.arguments === "object" && tc.arguments !== null) {
         return { ...tc, arguments: JSON.stringify(tc.arguments) };
       }
-      return tc;
+      return { ...tc };
     });
   }
   return r as unknown as FixtureResponse;
@@ -150,8 +156,25 @@ export function isErrorResponse(r: FixtureResponse): r is ErrorResponse {
   return (
     "error" in r &&
     (r as ErrorResponse).error !== null &&
-    typeof (r as ErrorResponse).error === "object"
+    typeof (r as ErrorResponse).error === "object" &&
+    "message" in ((r as ErrorResponse).error as Record<string, unknown>) &&
+    typeof ((r as ErrorResponse).error as Record<string, unknown>).message === "string"
   );
+}
+
+/**
+ * Serialize an ErrorResponse to JSON, stripping the internal-only `status`
+ * field that controls the HTTP status code but should never appear in the
+ * response body.  Real LLM APIs don't include it.
+ */
+export function serializeErrorResponse(response: ErrorResponse): string {
+  return JSON.stringify({
+    error: {
+      message: response.error.message,
+      type: response.error.type ?? "server_error",
+      code: response.error.code ?? null,
+    },
+  });
 }
 
 export function isEmbeddingResponse(r: FixtureResponse): r is EmbeddingResponse {
@@ -675,12 +698,39 @@ export function buildContentWithToolCallsCompletion(
 
 // ─── HTTP helpers ─────────────────────────────────────────────────────────
 
-export function readBody(req: http.IncomingMessage): Promise<string> {
+const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export function readBody(
+  req: http.IncomingMessage,
+  maxBytes: number = DEFAULT_MAX_BODY_BYTES,
+): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => resolve(Buffer.concat(chunks).toString()));
-    req.on("error", reject);
+    let totalBytes = 0;
+    let settled = false;
+    req.on("data", (chunk: Buffer) => {
+      if (settled) return;
+      totalBytes += chunk.length;
+      if (totalBytes > maxBytes) {
+        settled = true;
+        req.destroy();
+        reject(new Error(`Request body exceeded size limit of ${maxBytes} bytes`));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (!settled) {
+        settled = true;
+        resolve(Buffer.concat(chunks).toString());
+      }
+    });
+    req.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
   });
 }
 
@@ -699,6 +749,7 @@ export function matchesPattern(text: string, pattern: string | RegExp): boolean 
   if (typeof pattern === "string") {
     return text.toLowerCase().includes(pattern.toLowerCase());
   }
+  pattern.lastIndex = 0;
   return pattern.test(text);
 }
 
@@ -718,9 +769,7 @@ export function getTestId(req: http.IncomingMessage): string {
     if (queryValue) return queryValue;
   }
 
-  // Duplicated from journal.ts DEFAULT_TEST_ID — importing it here would create
-  // a circular dependency (journal.ts imports from helpers.ts).
-  return "__default__";
+  return DEFAULT_TEST_ID;
 }
 
 // ─── Snapshot recording helpers ──────────────────────────────────────────────

--- a/src/images.ts
+++ b/src/images.ts
@@ -3,6 +3,7 @@ import type { ChatCompletionRequest, Fixture, HandlerDefaults } from "./types.js
 import {
   isImageResponse,
   isErrorResponse,
+  serializeErrorResponse,
   flattenHeaders,
   getTestId,
   resolveResponse,
@@ -151,6 +152,7 @@ export async function handleImages(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method,
@@ -200,7 +202,7 @@ export async function handleImages(
       body: syntheticReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -1,8 +1,7 @@
 import { generateId } from "./helpers.js";
 import type { Fixture, FixtureMatch, JournalEntry } from "./types.js";
-
-/** Sentinel testId used when no explicit test scope is provided. */
-export const DEFAULT_TEST_ID = "__default__";
+import { DEFAULT_TEST_ID } from "./constants.js";
+export { DEFAULT_TEST_ID } from "./constants.js";
 
 /**
  * Compare two field values, handling RegExp by source+flags rather than reference.
@@ -14,12 +13,31 @@ function fieldEqual(a: unknown, b: unknown): boolean {
 }
 
 /**
+ * Compare two systemMessage values. Handles string, string[], and RegExp.
+ * Both-undefined is treated as equal.
+ */
+function systemMessageEqual(
+  a: string | string[] | RegExp | undefined,
+  b: string | string[] | RegExp | undefined,
+): boolean {
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  if (typeof a === "string" && typeof b === "string") return a === b;
+  if (Array.isArray(a) && Array.isArray(b))
+    return a.length === b.length && a.every((v, i) => v === b[i]);
+  if (a instanceof RegExp && b instanceof RegExp)
+    return a.source === b.source && a.flags === b.flags;
+  return false;
+}
+
+/**
  * Check whether two fixture match objects have the same criteria
  * (ignoring sequenceIndex). Used to group sequenced fixtures.
  */
 function matchCriteriaEqual(a: FixtureMatch, b: FixtureMatch): boolean {
   return (
     fieldEqual(a.userMessage, b.userMessage) &&
+    systemMessageEqual(a.systemMessage, b.systemMessage) &&
     fieldEqual(a.inputText, b.inputText) &&
     fieldEqual(a.toolCallId, b.toolCallId) &&
     fieldEqual(a.toolName, b.toolName) &&

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -190,7 +190,9 @@ export function claudeToCompletionRequest(req: ClaudeRequest): ChatCompletionReq
     messages,
     stream: req.stream,
     temperature: req.temperature,
+    max_tokens: req.max_tokens,
     tools,
+    _endpointType: "chat",
   };
 }
 
@@ -210,8 +212,8 @@ function claudeUsage(overrides?: ResponseOverrides): {
 } {
   if (!overrides?.usage) return { input_tokens: 0, output_tokens: 0 };
   return {
-    input_tokens: overrides.usage.input_tokens ?? 0,
-    output_tokens: overrides.usage.output_tokens ?? 0,
+    input_tokens: overrides.usage.input_tokens ?? overrides.usage.prompt_tokens ?? 0,
+    output_tokens: overrides.usage.output_tokens ?? overrides.usage.completion_tokens ?? 0,
   };
 }
 
@@ -741,7 +743,6 @@ export async function handleMessages(
 
   // Convert to ChatCompletionRequest for fixture matching
   const completionReq = claudeToCompletionRequest(claudeReq);
-  completionReq._endpointType = "chat";
 
   const testId = getTestId(req);
   const fixture = matchFixture(
@@ -795,6 +796,7 @@ export async function handleMessages(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -970,6 +972,11 @@ export async function handleMessages(
 
   // Tool call response
   if (isToolCallResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn(
+        "webSearches in fixture response are not supported for Claude Messages API — ignoring",
+      );
+    }
     const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -26,6 +26,7 @@ import {
   isToolCallResponse,
   isContentWithToolCallsResponse,
   isErrorResponse,
+  serializeErrorResponse,
   flattenHeaders,
   getTestId,
   resolveResponse,
@@ -583,6 +584,7 @@ export async function handleOllama(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -643,12 +645,15 @@ export async function handleOllama(
       body: completionReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 
   // Content + tool calls response (must be checked before text/tool-only branches)
   if (isContentWithToolCallsResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn("webSearches in fixture response are not supported for Ollama API -- ignoring");
+    }
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -692,6 +697,9 @@ export async function handleOllama(
 
   // Text response
   if (isTextResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn("webSearches in fixture response are not supported for Ollama API -- ignoring");
+    }
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -733,6 +741,9 @@ export async function handleOllama(
 
   // Tool call response
   if (isToolCallResponse(response)) {
+    if (response.webSearches?.length) {
+      logger.warn("webSearches in fixture response are not supported for Ollama API — ignoring");
+    }
     const journalEntry = journal.add({
       method: req.method ?? "POST",
       path: urlPath,
@@ -895,6 +906,7 @@ export async function handleOllamaGenerate(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -955,7 +967,7 @@ export async function handleOllamaGenerate(
       body: completionReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -17,6 +17,7 @@ import { collapseStreamingResponse } from "./stream-collapse.js";
 import { writeErrorResponse } from "./sse-writer.js";
 import { resolveUpstreamUrl } from "./url.js";
 import { getTestId, slugifyTestId } from "./helpers.js";
+import { DEFAULT_TEST_ID } from "./constants.js";
 
 /** Headers to strip when proxying — hop-by-hop (RFC 2616 §13.5.1) + client-set. */
 const STRIP_HEADERS = new Set([
@@ -165,7 +166,14 @@ export async function proxyAndRecord(
   let streamedToClient = false;
   let clientDisconnected = false;
   try {
-    const result = await makeUpstreamRequest(target, forwardHeaders, requestBody, res, req.method);
+    const result = await makeUpstreamRequest(
+      target,
+      forwardHeaders,
+      requestBody,
+      res,
+      req.method,
+      defaults.logger,
+    );
     upstreamStatus = result.status;
     upstreamHeaders = result.headers;
     upstreamBody = result.body;
@@ -350,7 +358,7 @@ export async function proxyAndRecord(
   if (!defaults.record?.proxyOnly) {
     // Determine file path: snapshot-style (by testId) or legacy timestamp
     const testId = getTestId(req);
-    let isSnapshotMode = testId !== "__default__";
+    let isSnapshotMode = testId !== DEFAULT_TEST_ID;
 
     let filepath!: string;
     let mergeExisting = false;
@@ -431,9 +439,9 @@ export async function proxyAndRecord(
       const msg = err instanceof Error ? err.message : "Unknown filesystem error";
       defaults.logger.error(`Failed to save fixture to disk: ${msg}`);
       if (!res.headersSent) {
-        res.setHeader("X-LLMock-Record-Error", msg);
+        res.setHeader("X-AIMock-Record-Error", msg);
       } else {
-        defaults.logger.warn(`Cannot set X-LLMock-Record-Error header — headers already sent`);
+        defaults.logger.warn(`Cannot set X-AIMock-Record-Error header — headers already sent`);
       }
     }
 
@@ -523,6 +531,7 @@ function makeUpstreamRequest(
   body: string,
   clientRes?: http.ServerResponse,
   method: string = "POST",
+  logger?: Logger,
 ): Promise<{
   status: number;
   headers: http.IncomingHttpHeaders;
@@ -603,8 +612,10 @@ function makeUpstreamRequest(
           ) {
             try {
               clientRes.write(chunk);
-            } catch {
-              // Client socket errored (disconnect, reset, etc.) — stop relaying.
+            } catch (writeErr) {
+              logger?.debug(
+                `Failed to relay chunk to client: ${writeErr instanceof Error ? writeErr.message : "unknown"}`,
+              );
               clientDisconnected = true;
             }
           }
@@ -622,8 +633,10 @@ function makeUpstreamRequest(
           ) {
             try {
               clientRes.end();
-            } catch {
-              /* client already gone */
+            } catch (endErr) {
+              logger?.debug(
+                `Failed to end client response: ${endErr instanceof Error ? endErr.message : "unknown"}`,
+              );
             }
           }
           resolve({

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -25,6 +25,7 @@ import {
   isToolCallResponse,
   isContentWithToolCallsResponse,
   isErrorResponse,
+  serializeErrorResponse,
   flattenHeaders,
   getTestId,
   resolveResponse,
@@ -253,12 +254,12 @@ function responsesUsage(overrides?: ResponseOverrides): {
   total_tokens: number;
 } {
   if (!overrides?.usage) return { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+  const input = overrides.usage.input_tokens ?? overrides.usage.prompt_tokens ?? 0;
+  const output = overrides.usage.output_tokens ?? overrides.usage.completion_tokens ?? 0;
   return {
-    input_tokens: overrides.usage.input_tokens ?? 0,
-    output_tokens: overrides.usage.output_tokens ?? 0,
-    total_tokens:
-      overrides.usage.total_tokens ??
-      (overrides.usage.input_tokens ?? 0) + (overrides.usage.output_tokens ?? 0),
+    input_tokens: input,
+    output_tokens: output,
+    total_tokens: overrides.usage.total_tokens ?? input + output,
   };
 }
 
@@ -320,49 +321,29 @@ export function buildToolCallStreamEvents(
   toolCalls: ToolCall[],
   model: string,
   chunkSize: number,
+  webSearches?: string[],
   overrides?: ResponseOverrides,
 ): ResponsesSSEEvent[] {
-  const respId = overrides?.id ?? responseId();
-  const created = overrides?.created ?? Math.floor(Date.now() / 1000);
-  const effectiveModel = overrides?.model ?? model;
-  const events: ResponsesSSEEvent[] = [];
+  const { respId, created, events, prefixOutputItems, nextOutputIndex } = buildResponsePreamble(
+    model,
+    chunkSize,
+    undefined,
+    webSearches,
+    overrides,
+  );
 
-  // response.created
-  events.push({
-    type: "response.created",
-    response: {
-      id: respId,
-      object: "response",
-      created_at: created,
-      model: effectiveModel,
-      status: "in_progress",
-      output: [],
-    },
-  });
-
-  events.push({
-    type: "response.in_progress",
-    response: {
-      id: respId,
-      object: "response",
-      created_at: created,
-      model: effectiveModel,
-      status: "in_progress",
-      output: [],
-    },
-  });
-
-  const outputItems: object[] = [];
+  const fcOutputItems: object[] = [];
 
   for (let idx = 0; idx < toolCalls.length; idx++) {
     const tc = toolCalls[idx];
     const callId = tc.id || generateToolCallId();
     const fcId = generateId("fc");
+    const outputIndex = nextOutputIndex + idx;
 
     // output_item.added (function_call)
     events.push({
       type: "response.output_item.added",
-      output_index: idx,
+      output_index: outputIndex,
       item: {
         type: "function_call",
         id: fcId,
@@ -380,7 +361,7 @@ export function buildToolCallStreamEvents(
       events.push({
         type: "response.function_call_arguments.delta",
         item_id: fcId,
-        output_index: idx,
+        output_index: outputIndex,
         delta: slice,
       });
     }
@@ -389,7 +370,7 @@ export function buildToolCallStreamEvents(
     events.push({
       type: "response.function_call_arguments.done",
       item_id: fcId,
-      output_index: idx,
+      output_index: outputIndex,
       arguments: args,
     });
 
@@ -405,11 +386,11 @@ export function buildToolCallStreamEvents(
     // output_item.done
     events.push({
       type: "response.output_item.done",
-      output_index: idx,
+      output_index: outputIndex,
       item: doneItem,
     });
 
-    outputItems.push(doneItem);
+    fcOutputItems.push(doneItem);
   }
 
   // response.completed
@@ -419,9 +400,9 @@ export function buildToolCallStreamEvents(
       id: respId,
       object: "response",
       created_at: created,
-      model: effectiveModel,
+      model: overrides?.model ?? model,
       status: responsesStatus(overrides?.finishReason, "completed"),
-      output: outputItems,
+      output: [...prefixOutputItems, ...fcOutputItems],
       usage: responsesUsage(overrides),
     },
   });
@@ -737,20 +718,31 @@ function buildTextResponse(
 function buildToolCallResponse(
   toolCalls: ToolCall[],
   model: string,
+  webSearches?: string[],
   overrides?: ResponseOverrides,
 ): object {
-  return buildResponseEnvelope(
-    model,
-    toolCalls.map((tc) => ({
+  const output: object[] = [];
+  if (webSearches && webSearches.length > 0) {
+    for (const query of webSearches) {
+      output.push({
+        type: "web_search_call",
+        id: generateId("ws"),
+        status: "completed",
+        action: { type: "search", query },
+      });
+    }
+  }
+  for (const tc of toolCalls) {
+    output.push({
       type: "function_call",
       id: generateId("fc"),
       call_id: tc.id || generateToolCallId(),
       name: tc.name,
       arguments: tc.arguments,
       status: "completed",
-    })),
-    overrides,
-  );
+    });
+  }
+  return buildResponseEnvelope(model, output, overrides);
 }
 
 export function buildContentWithToolCallsStreamEvents(
@@ -1002,6 +994,7 @@ export async function handleResponses(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
@@ -1062,7 +1055,7 @@ export async function handleResponses(
       body: completionReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 
@@ -1171,7 +1164,12 @@ export async function handleResponses(
       response: { status: 200, fixture },
     });
     if (responsesReq.stream !== true) {
-      const body = buildToolCallResponse(response.toolCalls, completionReq.model, overrides);
+      const body = buildToolCallResponse(
+        response.toolCalls,
+        completionReq.model,
+        response.webSearches,
+        overrides,
+      );
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(body));
     } else {
@@ -1179,6 +1177,7 @@ export async function handleResponses(
         response.toolCalls,
         completionReq.model,
         chunkSize,
+        response.webSearches,
         overrides,
       );
       const interruption = createInterruptionSignal(fixture);

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,9 +25,11 @@ import {
   isToolCallResponse,
   isContentWithToolCallsResponse,
   isErrorResponse,
+  serializeErrorResponse,
   isAudioResponse,
   flattenHeaders,
   getTestId,
+  readBody,
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
@@ -37,7 +39,11 @@ import { handleMessages } from "./messages.js";
 import { handleGemini } from "./gemini.js";
 import { handleBedrock, handleBedrockStream } from "./bedrock.js";
 import { handleConverse, handleConverseStream } from "./bedrock-converse.js";
-import { handleGeminiInteractions } from "./gemini-interactions.js";
+import {
+  handleGeminiInteractions,
+  resetInteractionCounter,
+  resetEventIdCounter,
+} from "./gemini-interactions.js";
 import { handleEmbeddings } from "./embeddings.js";
 import { handleImages } from "./images.js";
 import { handleSpeech } from "./speech.js";
@@ -172,26 +178,6 @@ function setCorsHeaders(res: http.ServerResponse): void {
   }
 }
 
-const DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
-
-async function readBody(
-  req: http.IncomingMessage,
-  maxBytes: number = DEFAULT_MAX_BODY_BYTES,
-): Promise<string> {
-  const buffers: Buffer[] = [];
-  let totalBytes = 0;
-  for await (const chunk of req) {
-    const buf = chunk as Buffer;
-    totalBytes += buf.length;
-    if (totalBytes > maxBytes) {
-      req.destroy();
-      throw new Error(`Request body exceeded size limit of ${maxBytes} bytes`);
-    }
-    buffers.push(buf);
-  }
-  return Buffer.concat(buffers).toString();
-}
-
 function handleOptions(res: http.ServerResponse): void {
   setCorsHeaders(res);
   res.writeHead(204);
@@ -309,6 +295,8 @@ async function handleControlAPI(
     videoStates.clear();
     falJobs.clear();
     falQueueStates.clear();
+    resetInteractionCounter();
+    resetEventIdCounter();
     if (defaults.registry) {
       defaults.registry.setGauge("aimock_fixtures_loaded", {}, fixtures.length);
     }
@@ -600,7 +588,7 @@ async function handleCompletions(
         hookOptions,
       );
       if (outcome === "handled_by_hook") return;
-      if (outcome === "relayed") {
+      if (outcome !== "not_configured") {
         journal.add({
           method: req.method ?? "POST",
           path: req.url ?? COMPLETIONS_PATH,
@@ -664,17 +652,7 @@ async function handleCompletions(
       body,
       response: { status, fixture },
     });
-    // Serialize only the error envelope (strip internal-only fields like `status`)
-    // and ensure `param` is present per OpenAI spec
-    const errorBody = {
-      error: {
-        message: response.error.message,
-        type: response.error.type ?? "server_error",
-        param: null,
-        code: response.error.code ?? null,
-      },
-    };
-    writeErrorResponse(res, status, JSON.stringify(errorBody));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 
@@ -803,6 +781,11 @@ async function handleCompletions(
 
   // Tool call response
   if (isToolCallResponse(response)) {
+    if (response.webSearches?.length) {
+      defaults.logger.warn(
+        "webSearches in fixture response are not supported for Chat Completions API — ignoring",
+      );
+    }
     const overrides = extractOverrides(response);
     const journalEntry = journal.add({
       method: req.method ?? "POST",
@@ -1748,48 +1731,6 @@ export async function createServer(
       setCorsHeaders(res);
       try {
         const raw = await readBody(req);
-        // Try to match a fixture so chaos evaluation can use fixture-level overrides
-        let elSoundFixture: Fixture | null = null;
-        try {
-          const parsed = JSON.parse(raw) as Record<string, unknown>;
-          const syntheticReq: ChatCompletionRequest = {
-            model: (parsed.model_id as string) ?? "eleven_text_to_sound_v2",
-            messages: [{ role: "user", content: (parsed.text as string) ?? "" }],
-            _endpointType: "audio-gen",
-          };
-          const testId = getTestId(req);
-          elSoundFixture = matchFixture(
-            fixtures,
-            syntheticReq,
-            journal.getFixtureMatchCountsForTest(testId),
-            defaults.requestTransform,
-          );
-        } catch {
-          // JSON parse failure — fixture matching not possible, handler will report the error
-        }
-        const chaosAction = evaluateChaos(
-          elSoundFixture,
-          defaults.chaos,
-          req.headers,
-          defaults.logger,
-        );
-        if (chaosAction) {
-          applyChaosAction(
-            chaosAction,
-            res,
-            elSoundFixture,
-            journal,
-            {
-              method: req.method ?? "POST",
-              path: pathname,
-              headers: flattenHeaders(req.headers),
-              body: { model: "", messages: [] },
-            },
-            "fixture",
-            defaults.registry,
-          );
-          return;
-        }
         await handleElevenLabsAudio(req, res, raw, fixtures, defaults, journal, "sound-generation");
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : "Internal error";
@@ -1813,55 +1754,6 @@ export async function createServer(
       const musicSubType = musicMatch[1] ?? "music";
       try {
         const raw = await readBody(req);
-        // Try to match a fixture so chaos evaluation can use fixture-level overrides
-        let elMusicFixture: Fixture | null = null;
-        try {
-          const parsed = JSON.parse(raw) as Record<string, unknown>;
-          const prompt =
-            (typeof parsed.prompt === "string" ? parsed.prompt : null) ??
-            (parsed.composition_plan != null
-              ? typeof parsed.composition_plan === "string"
-                ? parsed.composition_plan
-                : JSON.stringify(parsed.composition_plan)
-              : "");
-          const syntheticReq: ChatCompletionRequest = {
-            model: (parsed.model_id as string) ?? "music_v1",
-            messages: [{ role: "user", content: prompt }],
-            _endpointType: "audio-gen",
-          };
-          const testId = getTestId(req);
-          elMusicFixture = matchFixture(
-            fixtures,
-            syntheticReq,
-            journal.getFixtureMatchCountsForTest(testId),
-            defaults.requestTransform,
-          );
-        } catch {
-          // JSON parse failure — fixture matching not possible, handler will report the error
-        }
-        const chaosAction = evaluateChaos(
-          elMusicFixture,
-          defaults.chaos,
-          req.headers,
-          defaults.logger,
-        );
-        if (chaosAction) {
-          applyChaosAction(
-            chaosAction,
-            res,
-            elMusicFixture,
-            journal,
-            {
-              method: req.method ?? "POST",
-              path: pathname,
-              headers: flattenHeaders(req.headers),
-              body: { model: "", messages: [] },
-            },
-            "fixture",
-            defaults.registry,
-          );
-          return;
-        }
         await handleElevenLabsAudio(req, res, raw, fixtures, defaults, journal, musicSubType);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : "Internal error";
@@ -1933,52 +1825,6 @@ export async function createServer(
       setCorsHeaders(res);
       try {
         const raw = falBody ?? (await readBody(req));
-        // Try to match a fixture so chaos evaluation can use fixture-level overrides
-        let falSubmitFixture: Fixture | null = null;
-        try {
-          const parsed = raw.trim() ? (JSON.parse(raw) as Record<string, unknown>) : {};
-          const prompt =
-            (typeof parsed.prompt === "string" ? parsed.prompt : null) ??
-            (typeof parsed.text === "string" ? parsed.text : null) ??
-            "";
-          const syntheticReq: ChatCompletionRequest = {
-            model: falQueueSubmitMatch[1],
-            messages: [{ role: "user", content: prompt }],
-            _endpointType: "fal-audio",
-          };
-          const testId = getTestId(req);
-          falSubmitFixture = matchFixture(
-            fixtures,
-            syntheticReq,
-            journal.getFixtureMatchCountsForTest(testId),
-            defaults.requestTransform,
-          );
-        } catch {
-          // JSON parse failure — fixture matching not possible, handler will report the error
-        }
-        const chaosAction = evaluateChaos(
-          falSubmitFixture,
-          defaults.chaos,
-          req.headers,
-          defaults.logger,
-        );
-        if (chaosAction) {
-          applyChaosAction(
-            chaosAction,
-            res,
-            falSubmitFixture,
-            journal,
-            {
-              method: req.method ?? "POST",
-              path: pathname,
-              headers: flattenHeaders(req.headers),
-              body: { model: "", messages: [] },
-            },
-            "fixture",
-            defaults.registry,
-          );
-          return;
-        }
         await handleFalQueue(req, res, raw, pathname, fixtures, defaults, journal);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : "Internal error";
@@ -2045,52 +1891,6 @@ export async function createServer(
       setCorsHeaders(res);
       try {
         const raw = falBody ?? (await readBody(req));
-        // Try to match a fixture so chaos evaluation can use fixture-level overrides
-        let falRunFixture: Fixture | null = null;
-        try {
-          const parsed = raw.trim() ? (JSON.parse(raw) as Record<string, unknown>) : {};
-          const prompt =
-            (typeof parsed.prompt === "string" ? parsed.prompt : null) ??
-            (typeof parsed.text === "string" ? parsed.text : null) ??
-            "";
-          const syntheticReq: ChatCompletionRequest = {
-            model: falRunMatch[1],
-            messages: [{ role: "user", content: prompt }],
-            _endpointType: "fal-audio",
-          };
-          const testId = getTestId(req);
-          falRunFixture = matchFixture(
-            fixtures,
-            syntheticReq,
-            journal.getFixtureMatchCountsForTest(testId),
-            defaults.requestTransform,
-          );
-        } catch {
-          // JSON parse failure — fixture matching not possible, handler will report the error
-        }
-        const chaosAction = evaluateChaos(
-          falRunFixture,
-          defaults.chaos,
-          req.headers,
-          defaults.logger,
-        );
-        if (chaosAction) {
-          applyChaosAction(
-            chaosAction,
-            res,
-            falRunFixture,
-            journal,
-            {
-              method: req.method ?? "POST",
-              path: pathname,
-              headers: flattenHeaders(req.headers),
-              body: { model: "", messages: [] },
-            },
-            "fixture",
-            defaults.registry,
-          );
-          return;
-        }
         await handleFalQueue(req, res, raw, pathname, fixtures, defaults, journal);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : "Internal error";

--- a/src/speech.ts
+++ b/src/speech.ts
@@ -3,6 +3,7 @@ import type { ChatCompletionRequest, Fixture, HandlerDefaults } from "./types.js
 import {
   isAudioResponse,
   isErrorResponse,
+  serializeErrorResponse,
   flattenHeaders,
   getTestId,
   FORMAT_TO_CONTENT_TYPE,
@@ -130,6 +131,7 @@ export async function handleSpeech(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method,
@@ -179,7 +181,7 @@ export async function handleSpeech(
       body: syntheticReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -3,6 +3,7 @@ import type { ChatCompletionRequest, Fixture, HandlerDefaults } from "./types.js
 import {
   isTranscriptionResponse,
   isErrorResponse,
+  serializeErrorResponse,
   flattenHeaders,
   getTestId,
   resolveResponse,
@@ -16,20 +17,59 @@ import { applyChaos } from "./chaos.js";
 import { proxyAndRecord } from "./recorder.js";
 
 /**
- * Extract a text field from multipart form data using regex.
- * NOTE: This runs against the full body including binary audio data.
- * It works because text metadata fields (model, response_format, etc.)
- * appear before the binary audio part in standard multipart encoding.
- * A proper multipart parser would be more robust but is overkill for
- * the small set of fields we extract.
+ * Extract the multipart boundary string from a Content-Type header.
  */
-function extractFormField(raw: string, fieldName: string): string | undefined {
-  const pattern = new RegExp(
-    `Content-Disposition:\\s*form-data;[^\\r\\n]*name="${fieldName}"[^\\r\\n]*\\r\\n\\r\\n([^\\r\\n]*)`,
-    "i",
-  );
-  const match = raw.match(pattern);
+function extractBoundary(contentType: string | undefined): string | undefined {
+  if (!contentType) return undefined;
+  const match = contentType.match(/boundary=([^\s;]+)/i);
   return match?.[1];
+}
+
+/**
+ * Extract a text field from multipart form data using boundary-based parsing.
+ * Splits the body by the multipart boundary so each part is isolated, then
+ * checks each part's Content-Disposition header for the target field name.
+ * This avoids false matches from binary audio data that might contain
+ * header-like byte sequences.
+ */
+function extractFormField(
+  raw: string,
+  fieldName: string,
+  boundary: string | undefined,
+): string | undefined {
+  if (!boundary) {
+    // Fallback: no boundary available, use simple regex (best-effort)
+    const pattern = new RegExp(
+      `Content-Disposition:\\s*form-data;[^\\r\\n]*name="${fieldName}"[^\\r\\n]*\\r\\n\\r\\n([^\\r\\n]*)`,
+      "i",
+    );
+    const match = raw.match(pattern);
+    return match?.[1];
+  }
+
+  // Split by boundary delimiter — each chunk is one part
+  const delimiter = `--${boundary}`;
+  const parts = raw.split(delimiter);
+
+  for (const part of parts) {
+    // Skip the preamble (before first boundary) and epilogue (after closing boundary)
+    if (!part || part.trimStart().startsWith("--")) continue;
+
+    // Split part into headers and body at the first blank line (\r\n\r\n)
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const body = part.slice(headerEnd + 4);
+
+    // Check if this part's Content-Disposition names the target field
+    const cdMatch = headers.match(/Content-Disposition:\s*form-data;[^\r\n]*name="([^"]+)"/i);
+    if (cdMatch && cdMatch[1] === fieldName) {
+      // Return the body value, trimming trailing \r\n from the part boundary
+      return body.replace(/\r\n$/, "");
+    }
+  }
+  return undefined;
 }
 
 export async function handleTranscription(
@@ -45,8 +85,13 @@ export async function handleTranscription(
   const path = req.url ?? "/v1/audio/transcriptions";
   const method = req.method ?? "POST";
 
-  const model = extractFormField(raw, "model") ?? "whisper-1";
-  const responseFormat = extractFormField(raw, "response_format") ?? "json";
+  const contentType = Array.isArray(req.headers["content-type"])
+    ? req.headers["content-type"][0]
+    : req.headers["content-type"];
+  const boundary = extractBoundary(contentType);
+
+  const model = extractFormField(raw, "model", boundary) ?? "whisper-1";
+  const responseFormat = extractFormField(raw, "response_format", boundary) ?? "json";
 
   const syntheticReq: ChatCompletionRequest = {
     model,
@@ -96,6 +141,7 @@ export async function handleTranscription(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method,
@@ -149,7 +195,7 @@ export async function handleTranscription(
       body: syntheticReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,7 @@ export interface ToolCall {
 
 export interface ToolCallResponse extends ResponseOverrides {
   toolCalls: ToolCall[];
+  webSearches?: string[];
 }
 
 export interface ContentWithToolCallsResponse extends ResponseOverrides {
@@ -288,6 +289,7 @@ export interface FixtureFileToolCall {
 
 export interface FixtureFileToolCallResponse extends ResponseOverrides {
   toolCalls: FixtureFileToolCall[];
+  webSearches?: string[];
 }
 
 export interface FixtureFileTextResponse extends ResponseOverrides {

--- a/src/video.ts
+++ b/src/video.ts
@@ -3,6 +3,7 @@ import type { ChatCompletionRequest, Fixture, HandlerDefaults, VideoResponse } f
 import {
   isVideoResponse,
   isErrorResponse,
+  serializeErrorResponse,
   flattenHeaders,
   getTestId,
   resolveResponse,
@@ -39,15 +40,37 @@ interface VideoStateEntry {
  */
 export class VideoStateMap {
   private readonly entries = new Map<string, VideoStateEntry>();
+  private readonly sweepTimer: ReturnType<typeof setInterval>;
 
-  get(key: string): VideoResponse["video"] | undefined {
+  constructor() {
+    // Proactive sweep every 60 seconds to evict expired entries
+    this.sweepTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [key, entry] of this.entries) {
+        if (now - entry.createdAt > VIDEO_STATE_TTL_MS) {
+          this.entries.delete(key);
+        }
+      }
+    }, 60_000);
+    // Allow the process to exit even if the timer is still running
+    if (this.sweepTimer.unref) {
+      this.sweepTimer.unref();
+    }
+  }
+
+  getEntry(key: string): { video: VideoResponse["video"]; createdAtUnix: number } | undefined {
     const entry = this.entries.get(key);
     if (!entry) return undefined;
     if (Date.now() - entry.createdAt > VIDEO_STATE_TTL_MS) {
       this.entries.delete(key);
       return undefined;
     }
-    return entry.video;
+    return { video: entry.video, createdAtUnix: Math.floor(entry.createdAt / 1000) };
+  }
+
+  getCreatedAtUnix(key: string): number | undefined {
+    const e = this.getEntry(key);
+    return e?.createdAtUnix;
   }
 
   set(key: string, video: VideoResponse["video"]): void {
@@ -68,6 +91,11 @@ export class VideoStateMap {
   }
 
   clear(): void {
+    this.entries.clear();
+  }
+
+  destroy(): void {
+    clearInterval(this.sweepTimer);
     this.entries.clear();
   }
 
@@ -182,6 +210,7 @@ export async function handleVideoCreate(
         defaults,
         raw,
       );
+      if (outcome === "handled_by_hook") return;
       if (outcome !== "not_configured") {
         journal.add({
           method,
@@ -231,7 +260,7 @@ export async function handleVideoCreate(
       body: syntheticReq,
       response: { status, fixture },
     });
-    writeErrorResponse(res, status, JSON.stringify(response));
+    writeErrorResponse(res, status, serializeErrorResponse(response));
     return;
   }
 
@@ -262,11 +291,11 @@ export async function handleVideoCreate(
   });
 
   const video = response.video;
-  const created_at = Math.floor(Date.now() / 1000);
 
   // Store for GET status checks
   const stateKey = `${testId}:${video.id}`;
   videoStates.set(stateKey, video);
+  const created_at = videoStates.getCreatedAtUnix(stateKey)!;
 
   if (video.status === "completed") {
     res.writeHead(200, { "Content-Type": "application/json" });
@@ -307,9 +336,9 @@ export function handleVideoStatus(
 
   const testId = getTestId(req);
   const stateKey = `${testId}:${videoId}`;
-  const video = videoStates.get(stateKey);
+  const entry = videoStates.getEntry(stateKey);
 
-  if (!video) {
+  if (!entry) {
     journal.add({
       method,
       path,
@@ -325,6 +354,8 @@ export function handleVideoStatus(
     return;
   }
 
+  const { video, createdAtUnix: created_at } = entry;
+
   journal.add({
     method,
     path,
@@ -333,7 +364,6 @@ export function handleVideoStatus(
     response: { status: 200, fixture: null },
   });
 
-  const created_at = Math.floor(Date.now() / 1000);
   const body: Record<string, unknown> = {
     id: video.id,
     status: video.status,

--- a/src/ws-gemini-live.ts
+++ b/src/ws-gemini-live.ts
@@ -20,6 +20,7 @@ import {
   isContentWithToolCallsResponse,
   isErrorResponse,
   isAudioResponse,
+  flattenHeaders,
   formatToMime,
   generateToolCallId,
   resolveResponse,
@@ -165,15 +166,16 @@ function geminiTurnsToMessages(turns: GeminiLiveTurn[]): ChatMessage[] {
       const textParts = turn.parts.filter((p) => p.text !== undefined && !p.thought);
 
       if (funcCalls.length > 0) {
+        const text = textParts.map((p) => p.text!).join("");
         messages.push({
           role: "assistant",
-          content: null,
+          content: text || null,
           tool_calls: funcCalls.map((p, i) => ({
             id: `call_gemini_${p.functionCall!.name}_${i}`,
             type: "function" as const,
             function: {
               name: p.functionCall!.name,
-              arguments: JSON.stringify(p.functionCall!.args),
+              arguments: JSON.stringify(p.functionCall!.args ?? {}),
             },
           })),
         });
@@ -251,8 +253,10 @@ export function handleWebSocketGeminiLive(
               error: { code: 13, message: msg, status: "INTERNAL" },
             }),
           );
-        } catch {
-          // Connection already gone — original error already logged above
+        } catch (sendErr) {
+          defaults.logger.debug(
+            `Failed to send error to client: ${sendErr instanceof Error ? sendErr.message : "unknown"}`,
+          );
         }
       }),
     );
@@ -362,6 +366,7 @@ async function processMessage(
     messages: [...session.conversationHistory, ...newMessages],
     stream: true,
     tools: session.tools.length > 0 ? session.tools : undefined,
+    _endpointType: "chat",
   };
 
   const testId = defaults.testId ?? DEFAULT_TEST_ID;
@@ -383,10 +388,10 @@ async function processMessage(
       journal.add({
         method: "WS",
         path,
-        headers: {},
+        headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
         body: completionReq,
         response: {
-          status: 404,
+          status: 503,
           fixture: null,
           ...strictOverrideField(defaults.strict, defaults.upgradeHeaders),
         },
@@ -397,9 +402,13 @@ async function processMessage(
     journal.add({
       method: "WS",
       path,
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
-      response: { status: 404, fixture: null },
+      response: {
+        status: 404,
+        fixture: null,
+        ...strictOverrideField(defaults.strict, defaults.upgradeHeaders),
+      },
     });
     ws.send(
       JSON.stringify({
@@ -422,7 +431,7 @@ async function processMessage(
     journal.add({
       method: "WS",
       path,
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status, fixture },
     });
@@ -443,7 +452,7 @@ async function processMessage(
     journal.add({
       method: "WS",
       path,
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status: 200, fixture },
     });
@@ -483,7 +492,7 @@ async function processMessage(
     const journalEntry = journal.add({
       method: "WS",
       path,
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status: 200, fixture },
     });
@@ -619,7 +628,7 @@ async function processMessage(
     const journalEntry = journal.add({
       method: "WS",
       path,
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status: 200, fixture },
     });
@@ -706,7 +715,7 @@ async function processMessage(
     const journalEntry = journal.add({
       method: "WS",
       path,
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status: 200, fixture },
     });
@@ -789,7 +798,7 @@ async function processMessage(
   journal.add({
     method: "WS",
     path,
-    headers: {},
+    headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
     body: completionReq,
     response: { status: 500, fixture },
   });

--- a/src/ws-realtime.ts
+++ b/src/ws-realtime.ts
@@ -11,8 +11,10 @@ import type { ChatCompletionRequest, ChatMessage, Fixture } from "./types.js";
 import { matchFixture } from "./router.js";
 import {
   generateToolCallId,
+  flattenHeaders,
   isTextResponse,
   isToolCallResponse,
+  isContentWithToolCallsResponse,
   isErrorResponse,
   resolveResponse,
   resolveStrictMode,
@@ -191,8 +193,10 @@ export function handleWebSocketRealtime(
           logger.error(`WebSocket realtime error: ${msg}`);
           try {
             ws.send(buildErrorRealtimeEvent(msg, "server_error"));
-          } catch {
-            // Connection already gone — original error already logged above
+          } catch (sendErr) {
+            defaults.logger.debug(
+              `Failed to send error to client: ${sendErr instanceof Error ? sendErr.message : "unknown"}`,
+            );
           }
         },
       ),
@@ -291,7 +295,15 @@ async function processMessage(
 
   // ── response.create ───────────────────────────────────────────────────
   if (msgType === "response.create") {
-    await handleResponseCreate(ws, fixtures, journal, defaults, session, conversationItems);
+    await handleResponseCreate(
+      ws,
+      fixtures,
+      journal,
+      defaults,
+      session,
+      conversationItems,
+      parsed.response,
+    );
     return;
   }
 
@@ -314,13 +326,15 @@ async function handleResponseCreate(
   },
   session: SessionConfig,
   conversationItems: RealtimeItem[],
+  responseOverrides?: { instructions?: string; [key: string]: unknown },
 ): Promise<void> {
-  const instructions = session.instructions || undefined;
+  const instructions = (responseOverrides?.instructions ?? session.instructions) || undefined;
   const messages = realtimeItemsToMessages(conversationItems, instructions, defaults.logger);
 
   const completionReq: ChatCompletionRequest = {
     model: session.model,
     messages,
+    _endpointType: "chat",
   };
 
   const testId = defaults.testId ?? DEFAULT_TEST_ID;
@@ -339,13 +353,24 @@ async function handleResponseCreate(
   if (!fixture) {
     if (resolveStrictMode(defaults.strict, defaults.upgradeHeaders)) {
       defaults.logger.warn(`STRICT: No fixture matched for WebSocket message`);
+      journal.add({
+        method: "WS",
+        path: "/v1/realtime",
+        headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
+        body: completionReq,
+        response: {
+          status: 503,
+          fixture: null,
+          ...strictOverrideField(defaults.strict, defaults.upgradeHeaders),
+        },
+      });
       ws.close(1008, "Strict mode: no fixture matched");
       return;
     }
     journal.add({
       method: "WS",
       path: "/v1/realtime",
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: {
         status: 404,
@@ -398,7 +423,7 @@ async function handleResponseCreate(
     journal.add({
       method: "WS",
       path: "/v1/realtime",
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status, fixture },
     });
@@ -436,12 +461,295 @@ async function handleResponseCreate(
     return;
   }
 
+  // ── Content + tool calls response ──────────────────────────────────
+  if (isContentWithToolCallsResponse(response)) {
+    const journalEntry = journal.add({
+      method: "WS",
+      path: "/v1/realtime",
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
+      body: completionReq,
+      response: { status: 200, fixture },
+    });
+
+    // response.created
+    ws.send(
+      evt("response.created", {
+        response: {
+          id: responseId,
+          object: "realtime.response",
+          status: "in_progress",
+          status_details: null,
+          output: [],
+          usage: null,
+        },
+      }),
+    );
+
+    const interruption = createInterruptionSignal(fixture);
+    let interrupted = false;
+    const allOutputItems: unknown[] = [];
+
+    // ── Text content part ──────────────────────────────────────────
+    const textItemId = realtimeId("item");
+    const contentIndex = 0;
+    const textOutputIndex = 0;
+
+    const textOutputItem = {
+      id: textItemId,
+      type: "message",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "text", text: response.content }],
+    };
+
+    // response.output_item.added (text)
+    ws.send(
+      evt("response.output_item.added", {
+        response_id: responseId,
+        output_index: textOutputIndex,
+        item: {
+          id: textItemId,
+          type: "message",
+          role: "assistant",
+          status: "in_progress",
+          content: [],
+        },
+      }),
+    );
+
+    // response.content_part.added
+    ws.send(
+      evt("response.content_part.added", {
+        response_id: responseId,
+        item_id: textItemId,
+        output_index: textOutputIndex,
+        content_index: contentIndex,
+        part: { type: "text", text: "" },
+      }),
+    );
+
+    // response.text.delta (chunked)
+    const content = response.content;
+    for (let i = 0; i < content.length; i += chunkSize) {
+      if (ws.isClosed) break;
+      if (latency > 0) await delay(latency, interruption?.signal);
+      if (interruption?.signal.aborted) {
+        interrupted = true;
+        break;
+      }
+      if (ws.isClosed) break;
+      const chunk = content.slice(i, i + chunkSize);
+      ws.send(
+        evt("response.text.delta", {
+          response_id: responseId,
+          item_id: textItemId,
+          output_index: textOutputIndex,
+          content_index: contentIndex,
+          delta: chunk,
+        }),
+      );
+      interruption?.tick();
+      if (interruption?.signal.aborted) {
+        interrupted = true;
+        break;
+      }
+    }
+
+    if (interrupted) {
+      ws.destroy();
+      journalEntry.response.interrupted = true;
+      journalEntry.response.interruptReason = interruption?.reason();
+      interruption?.cleanup();
+      return;
+    }
+
+    if (ws.isClosed) {
+      interruption?.cleanup();
+      return;
+    }
+
+    // response.text.done
+    ws.send(
+      evt("response.text.done", {
+        response_id: responseId,
+        item_id: textItemId,
+        output_index: textOutputIndex,
+        content_index: contentIndex,
+        text: content,
+      }),
+    );
+
+    if (ws.isClosed) {
+      interruption?.cleanup();
+      return;
+    }
+
+    // response.content_part.done
+    ws.send(
+      evt("response.content_part.done", {
+        response_id: responseId,
+        item_id: textItemId,
+        output_index: textOutputIndex,
+        content_index: contentIndex,
+        part: { type: "text", text: content },
+      }),
+    );
+
+    if (ws.isClosed) {
+      interruption?.cleanup();
+      return;
+    }
+
+    // response.output_item.done (text)
+    ws.send(
+      evt("response.output_item.done", {
+        response_id: responseId,
+        output_index: textOutputIndex,
+        item: textOutputItem,
+      }),
+    );
+
+    if (ws.isClosed) {
+      interruption?.cleanup();
+      return;
+    }
+
+    allOutputItems.push(textOutputItem);
+
+    // ── Tool call parts ────────────────────────────────────────────
+    for (let tcIdx = 0; tcIdx < response.toolCalls.length; tcIdx++) {
+      const tc = response.toolCalls[tcIdx];
+      const callId = tc.id ?? generateToolCallId();
+      const itemId = realtimeId("item");
+      const outputIndex = tcIdx + 1; // offset by 1 for the text item
+
+      const toolOutputItem = {
+        id: itemId,
+        type: "function_call",
+        status: "completed",
+        call_id: callId,
+        name: tc.name,
+        arguments: tc.arguments,
+      };
+
+      // response.output_item.added
+      ws.send(
+        evt("response.output_item.added", {
+          response_id: responseId,
+          output_index: outputIndex,
+          item: {
+            id: itemId,
+            type: "function_call",
+            status: "in_progress",
+            call_id: callId,
+            name: tc.name,
+            arguments: "",
+          },
+        }),
+      );
+
+      // response.function_call_arguments.delta (chunked)
+      const args = tc.arguments;
+      for (let i = 0; i < args.length; i += chunkSize) {
+        if (ws.isClosed) break;
+        if (latency > 0) await delay(latency, interruption?.signal);
+        if (interruption?.signal.aborted) {
+          interrupted = true;
+          break;
+        }
+        if (ws.isClosed) break;
+        const chunk = args.slice(i, i + chunkSize);
+        ws.send(
+          evt("response.function_call_arguments.delta", {
+            response_id: responseId,
+            item_id: itemId,
+            output_index: outputIndex,
+            call_id: callId,
+            delta: chunk,
+          }),
+        );
+        interruption?.tick();
+        if (interruption?.signal.aborted) {
+          interrupted = true;
+          break;
+        }
+      }
+
+      if (interrupted) break;
+
+      if (ws.isClosed) break;
+
+      // response.function_call_arguments.done
+      ws.send(
+        evt("response.function_call_arguments.done", {
+          response_id: responseId,
+          item_id: itemId,
+          output_index: outputIndex,
+          call_id: callId,
+          arguments: args,
+        }),
+      );
+
+      if (ws.isClosed) break;
+
+      // response.output_item.done
+      ws.send(
+        evt("response.output_item.done", {
+          response_id: responseId,
+          output_index: outputIndex,
+          item: toolOutputItem,
+        }),
+      );
+
+      if (ws.isClosed) break;
+
+      allOutputItems.push(toolOutputItem);
+    }
+
+    if (interrupted) {
+      ws.destroy();
+      journalEntry.response.interrupted = true;
+      journalEntry.response.interruptReason = interruption?.reason();
+      interruption?.cleanup();
+      return;
+    }
+
+    interruption?.cleanup();
+
+    if (ws.isClosed) return;
+
+    // response.done
+    ws.send(
+      evt("response.done", {
+        response: {
+          id: responseId,
+          object: "realtime.response",
+          status: "completed",
+          output: allOutputItems,
+          usage: { total_tokens: 0, input_tokens: 0, output_tokens: 0 },
+        },
+      }),
+    );
+
+    // Accumulate into conversation for multi-turn
+    conversationItems.push({
+      type: "message",
+      id: textItemId,
+      role: "assistant",
+      content: [{ type: "text", text: content }],
+    });
+    for (const item of allOutputItems.slice(1)) {
+      conversationItems.push(item as RealtimeItem);
+    }
+    return;
+  }
+
   // ── Text response ───────────────────────────────────────────────────
   if (isTextResponse(response)) {
     const journalEntry = journal.add({
       method: "WS",
       path: "/v1/realtime",
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status: 200, fixture },
     });
@@ -599,7 +907,7 @@ async function handleResponseCreate(
     const journalEntry = journal.add({
       method: "WS",
       path: "/v1/realtime",
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status: 200, fixture },
     });
@@ -681,6 +989,8 @@ async function handleResponseCreate(
 
       if (interrupted) break;
 
+      if (ws.isClosed) break;
+
       // response.function_call_arguments.done
       ws.send(
         evt("response.function_call_arguments.done", {
@@ -741,7 +1051,7 @@ async function handleResponseCreate(
   journal.add({
     method: "WS",
     path: "/v1/realtime",
-    headers: {},
+    headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
     body: completionReq,
     response: { status: 500, fixture },
   });

--- a/src/ws-responses.ts
+++ b/src/ws-responses.ts
@@ -12,15 +12,19 @@ import {
   responsesToCompletionRequest,
   buildTextStreamEvents,
   buildToolCallStreamEvents,
+  buildContentWithToolCallsStreamEvents,
   type ResponsesSSEEvent,
 } from "./responses.js";
 import {
   isTextResponse,
   isToolCallResponse,
+  isContentWithToolCallsResponse,
   isErrorResponse,
+  extractOverrides,
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  flattenHeaders,
 } from "./helpers.js";
 import { createInterruptionSignal } from "./interruption.js";
 import { delay } from "./sse-writer.js";
@@ -85,8 +89,10 @@ export function handleWebSocketResponses(
         logger.error(`WebSocket responses error: ${msg}`);
         try {
           ws.send(JSON.stringify(buildErrorEvent(msg, "server_error")));
-        } catch {
-          // Connection already gone — original error already logged above
+        } catch (sendErr) {
+          defaults.logger.debug(
+            `Failed to send error to client: ${sendErr instanceof Error ? sendErr.message : "unknown"}`,
+          );
         }
       }),
     );
@@ -164,6 +170,7 @@ async function processMessage(
   };
 
   const completionReq = responsesToCompletionRequest(responsesReq);
+  completionReq._endpointType = "chat";
   const testId = defaults.testId ?? DEFAULT_TEST_ID;
   const fixture = matchFixture(
     fixtures,
@@ -179,13 +186,24 @@ async function processMessage(
   if (!fixture) {
     if (resolveStrictMode(defaults.strict, defaults.upgradeHeaders)) {
       defaults.logger.warn(`STRICT: No fixture matched for WebSocket message`);
+      journal.add({
+        method: "WS",
+        path: "/v1/responses",
+        headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
+        body: completionReq,
+        response: {
+          status: 503,
+          fixture: null,
+          ...strictOverrideField(defaults.strict, defaults.upgradeHeaders),
+        },
+      });
       ws.close(1008, "Strict mode: no fixture matched");
       return;
     }
     journal.add({
       method: "WS",
       path: "/v1/responses",
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: {
         status: 404,
@@ -211,7 +229,7 @@ async function processMessage(
     journal.add({
       method: "WS",
       path: "/v1/responses",
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status, fixture },
     });
@@ -223,12 +241,49 @@ async function processMessage(
     return;
   }
 
+  // Content + tool calls response (must be checked before isTextResponse / isToolCallResponse)
+  if (isContentWithToolCallsResponse(response)) {
+    const journalEntry = journal.add({
+      method: "WS",
+      path: "/v1/responses",
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
+      body: completionReq,
+      response: { status: 200, fixture },
+    });
+
+    const events = buildContentWithToolCallsStreamEvents(
+      response.content,
+      response.toolCalls,
+      completionReq.model,
+      chunkSize,
+      response.reasoning,
+      response.webSearches,
+      extractOverrides(response),
+    );
+
+    const interruption = createInterruptionSignal(fixture);
+    const completed = await sendEvents(
+      ws,
+      events,
+      latency,
+      interruption?.signal,
+      interruption?.tick,
+    );
+    if (!completed) {
+      ws.destroy();
+      journalEntry.response.interrupted = true;
+      journalEntry.response.interruptReason = interruption?.reason();
+    }
+    interruption?.cleanup();
+    return;
+  }
+
   // Text response
   if (isTextResponse(response)) {
     const journalEntry = journal.add({
       method: "WS",
       path: "/v1/responses",
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status: 200, fixture },
     });
@@ -239,6 +294,7 @@ async function processMessage(
       chunkSize,
       response.reasoning,
       response.webSearches,
+      extractOverrides(response),
     );
     const interruption = createInterruptionSignal(fixture);
     const completed = await sendEvents(
@@ -262,11 +318,17 @@ async function processMessage(
     const journalEntry = journal.add({
       method: "WS",
       path: "/v1/responses",
-      headers: {},
+      headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
       body: completionReq,
       response: { status: 200, fixture },
     });
-    const events = buildToolCallStreamEvents(response.toolCalls, completionReq.model, chunkSize);
+    const events = buildToolCallStreamEvents(
+      response.toolCalls,
+      completionReq.model,
+      chunkSize,
+      response.webSearches,
+      extractOverrides(response),
+    );
     const interruption = createInterruptionSignal(fixture);
     const completed = await sendEvents(
       ws,
@@ -288,7 +350,7 @@ async function processMessage(
   journal.add({
     method: "WS",
     path: "/v1/responses",
-    headers: {},
+    headers: flattenHeaders(defaults.upgradeHeaders ?? {}),
     body: completionReq,
     response: { status: 500, fixture },
   });
@@ -307,10 +369,10 @@ async function sendEvents(
   onChunkSent?: () => void,
 ): Promise<boolean> {
   for (const event of events) {
-    if (ws.isClosed) return true;
+    if (ws.isClosed) return false;
     if (latency > 0) await delay(latency, signal);
     if (signal?.aborted) return false;
-    if (ws.isClosed) return true;
+    if (ws.isClosed) return false;
     ws.send(JSON.stringify(event));
     onChunkSent?.();
     if (signal?.aborted) return false;


### PR DESCRIPTION
## Summary

Addresses 14 of 16 pre-existing issues from the dual-context header CR bucket (c) list, plus 12 additional issues discovered during CR fix rounds (26 total fixes across 23 files).

**Core hardening** — readBody size limit (10MB) + double-settlement guard, matchesPattern lastIndex reset for global/sticky regex, tightened isErrorResponse type guard, deep-copy toolCalls in normalizeFactoryResponse, deduplicated DEFAULT_TEST_ID constant

**WebSocket handlers** — ContentWithToolCallsResponse support for ws-responses + ws-realtime (was 500 error), isClosed guards on post-streaming sends, interruption timer cleanup, per-response instructions passthrough, consistent journal header capture

**Bedrock** — forward max_tokens in request conversion, use || null for empty-string content (tool-call-only messages), type-safe event removal replacing fragile pop()

**Double-journal prevention** — added handled_by_hook guard to all 14 proxy handler sites across 11 files (ollama, cohere, speech, messages, images, embeddings, gemini, responses, transcription, bedrock, bedrock-converse)

**Endpoint hardening** — journal headers captured in all 47 ElevenLabs/fal/WS sites, proactive TTL sweep for video + fal job maps with proper lifecycle (clear preserves timer, destroy stops it), atomic video getEntry() for consistent TTL check, persistent created_at across status polls, fal queue 409 journal entry, boundary-based multipart parsing, cli help text

## Test plan

- [x] 2891 tests pass (80 files, 37 skipped)
- [x] TypeScript typecheck clean
- [x] Prettier + ESLint clean
- [x] 3 CR rounds with 7 agents each (21 agent-rounds)