### PR TITLE
fix: drift test assertions for Malformed JSON detail

### DIFF
--- a/src/__tests__/drift/openai-chat.drift.ts
+++ b/src/__tests__/drift/openai-chat.drift.ts
@@ -321,7 +321,7 @@ describe("OpenAI Chat Completions error shapes", () => {
 
       const body = JSON.parse(res.body);
       expect(body.error).toBeDefined();
-      expect(body.error.message).toBe("Malformed JSON");
+      expect(body.error.message).toMatch(/^Malformed JSON/);
       expect(body.error.type).toBe("invalid_request_error");
       expect(body.error.code).toBe("invalid_json");
 

--- a/src/__tests__/drift/openai-responses.drift.ts
+++ b/src/__tests__/drift/openai-responses.drift.ts
@@ -304,7 +304,7 @@ describe("OpenAI Responses API error shapes", () => {
     ).toEqual([]);
 
     // Verify concrete values
-    expect(body.error.message).toBe("Malformed JSON");
+    expect(body.error.message).toMatch(/^Malformed JSON/);
     expect(body.error.type).toBe("invalid_request_error");
     expect(body.error.code).toBe("invalid_json");
   });


### PR DESCRIPTION
## Summary
- Update 2 drift test assertions from exact .toBe() to prefix .toMatch() for the Malformed JSON error message
- PR #177/#178 intentionally changed the error format to include parse error details, but the drift test assertions weren't updated

## Test plan
- [x] Drift tests pass locally