### PR TITLE
fix: make husky CI-safe in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "lint": "eslint .",
     "format:check": "prettier --check .",
     "release": "pnpm build && pnpm test && pnpm lint && npm publish",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "lint-staged": {
     "*.{ts,mts,js,mjs,cjs,json,html,css,md}": "prettier --write",


### PR DESCRIPTION
## Summary

The v1.22.1 npm publish failed because the `prepare` lifecycle script runs `husky` during `npm publish` in the publish job, which doesn't have husky on the PATH.

Changes `"prepare": "husky"` to `"prepare": "husky || true"` — husky's recommended CI-safe pattern.

Merging this will re-trigger the release workflow and publish v1.22.1 to npm.

## Test plan

- [x] `husky || true` is husky's documented pattern for CI
- [x] No change to local dev (husky still installs hooks)