### PR TITLE
fix: fix-drift.ts path truncation and missing label

### DIFF
--- a/.github/workflows/changelog-radar.yml
+++ b/.github/workflows/changelog-radar.yml
@@ -1,0 +1,71 @@
+name: Changelog Radar
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # Daily 8am UTC (1am PT)
+  workflow_dispatch:
+
+concurrency:
+  group: changelog-radar
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run changelog radar
+        id: radar
+        run: |
+          OUTPUT=$(npx tsx scripts/changelog-radar.ts 2>&1)
+          echo "$OUTPUT"
+
+          # Check if output is valid JSON (means new entries found)
+          if echo "$OUTPUT" | jq -e '.newEntries | length > 0' >/dev/null 2>&1; then
+            echo "found=true" >> $GITHUB_OUTPUT
+
+            COUNT=$(echo "$OUTPUT" | jq -r '.newEntries | length')
+            SINCE=$(echo "$OUTPUT" | jq -r '.since')
+            echo "count=$COUNT" >> $GITHUB_OUTPUT
+            echo "since=$SINCE" >> $GITHUB_OUTPUT
+
+            # Build issue body
+            BODY="The changelog radar detected **${COUNT}** new API changelog entries since ${SINCE} that may affect aimock's provider surface.\n\n"
+            BODY+="| Date | Title | Keywords |\n|------|-------|----------|\n"
+
+            while IFS= read -r line; do
+              DATE=$(echo "$line" | jq -r '.date')
+              TITLE=$(echo "$line" | jq -r '.title')
+              URL=$(echo "$line" | jq -r '.url')
+              KW=$(echo "$line" | jq -r '.keywords | join(", ")')
+              BODY+="| ${DATE} | [${TITLE}](${URL}) | ${KW} |\n"
+            done < <(echo "$OUTPUT" | jq -c '.newEntries[]')
+
+            BODY+="\n\n**Action required:** Review these entries for new models, endpoints, deprecations, or breaking changes that may need aimock updates.\n"
+            BODY+="\nSource: ${CHANGELOG_URL:-https://platform.openai.com/docs/changelog}"
+
+            # Write body to file for gh issue create
+            echo -e "$BODY" > /tmp/radar-issue-body.md
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub issue
+        if: steps.radar.outputs.found == 'true'
+        run: |
+          gh issue create \
+            --title "API changelog: ${{ steps.radar.outputs.count }} new entries since ${{ steps.radar.outputs.since }}" \
+            --body-file /tmp/radar-issue-body.md \
+            --label drift
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ coverage/
 **/__pycache__/
 packages/.remember/
 packages/.claude/
+# Changelog radar cursor (local state)
+.changelog-radar-cursor
+
 # Internal planning docs — NEVER commit these
 docs/superpowers/
 docs/plans/

--- a/scripts/changelog-radar.ts
+++ b/scripts/changelog-radar.ts
@@ -1,0 +1,235 @@
+/// <reference types="node" />
+
+/**
+ * Changelog Radar
+ *
+ * Fetches the OpenAI API changelog, filters for entries relevant to aimock's
+ * provider surface, and outputs a JSON report of new entries since the last run.
+ *
+ * On first run (no cursor file), sets the cursor to today and reports nothing.
+ * If parsing fails, logs a warning and exits 0 (never fails the workflow).
+ *
+ * Usage:
+ *   npx tsx scripts/changelog-radar.ts
+ *
+ * Output (stdout): JSON report when new entries found, empty otherwise.
+ * Side effect: updates .changelog-radar-cursor with the latest entry date.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const CHANGELOG_URL = "https://platform.openai.com/docs/changelog";
+const CURSOR_FILE = resolve(import.meta.dirname ?? ".", "../.changelog-radar-cursor");
+
+const SURFACE_KEYWORDS = [
+  "realtime",
+  "chat",
+  "completions",
+  "embeddings",
+  "responses",
+  "audio",
+  "speech",
+  "transcription",
+  "images",
+  "moderation",
+  "models",
+  "deprecat",
+  "breaking",
+  "websocket",
+];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ChangelogEntry {
+  date: string;
+  title: string;
+  url: string;
+  keywords: string[];
+}
+
+interface RadarReport {
+  newEntries: ChangelogEntry[];
+  since: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readCursor(): string | null {
+  if (!existsSync(CURSOR_FILE)) return null;
+  const raw = readFileSync(CURSOR_FILE, "utf-8").trim();
+  // Validate it looks like a date
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+  return null;
+}
+
+function writeCursor(date: string): void {
+  writeFileSync(CURSOR_FILE, date + "\n", "utf-8");
+}
+
+function matchKeywords(text: string): string[] {
+  const lower = text.toLowerCase();
+  return SURFACE_KEYWORDS.filter((kw) => lower.includes(kw));
+}
+
+/**
+ * Parse changelog entries from the HTML page.
+ *
+ * The OpenAI changelog page uses a structured format with date headings and
+ * entry titles. We look for common patterns:
+ *   - Date strings like "January 15, 2025" or "2025-01-15"
+ *   - Heading-like elements following dates
+ *
+ * This is intentionally loose — we'd rather over-match than miss entries.
+ */
+function parseEntries(html: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = [];
+
+  // Strategy 1: Look for date patterns followed by content blocks.
+  // OpenAI's changelog typically has entries with dates in heading elements.
+  // Match patterns like: <h2>January 15, 2025</h2> or date attributes
+  const dateContentPattern =
+    /(?:<h[23][^>]*>|<time[^>]*>|<div[^>]*date[^>]*>)\s*([A-Z][a-z]+ \d{1,2},?\s*\d{4}|\d{4}-\d{2}-\d{2})\s*(?:<\/h[23]>|<\/time>|<\/div>)/gi;
+
+  // Also try: entries as list items or article elements with dates
+  const entryPattern =
+    /(\d{4}-\d{2}-\d{2}|(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},?\s*\d{4})[^<]*<[^>]*>([^<]{5,200})/gi;
+
+  // Strategy 2: Broader pattern — grab anything that looks like a dated entry
+  const broadPattern =
+    /((?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},?\s*\d{4}|\d{4}-\d{2}-\d{2})[\s\S]{0,500}?(?:<[hH][1-6][^>]*>|<a[^>]*>|<strong>|<b>)\s*([^<]{5,200})/g;
+
+  const seen = new Set<string>();
+
+  for (const pattern of [dateContentPattern, entryPattern, broadPattern]) {
+    let match;
+    while ((match = pattern.exec(html)) !== null) {
+      const rawDate = match[1]!.trim();
+      const title = (match[2] ?? "").replace(/<[^>]+>/g, "").trim();
+
+      // Normalize date to YYYY-MM-DD
+      const normalizedDate = normalizeDate(rawDate);
+      if (!normalizedDate) continue;
+
+      const key = `${normalizedDate}:${title.slice(0, 80)}`;
+      if (seen.has(key) || !title) continue;
+      seen.add(key);
+
+      entries.push({
+        date: normalizedDate,
+        title,
+        url: `${CHANGELOG_URL}#${normalizedDate}`,
+        keywords: [],
+      });
+    }
+  }
+
+  // Sort newest first
+  entries.sort((a, b) => b.date.localeCompare(a.date));
+  return entries;
+}
+
+function normalizeDate(raw: string): string | null {
+  // Already YYYY-MM-DD
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw;
+
+  // "Month DD, YYYY" or "Month DD YYYY"
+  const parsed = new Date(raw);
+  if (isNaN(parsed.getTime())) return null;
+
+  const y = parsed.getFullYear();
+  const m = String(parsed.getMonth() + 1).padStart(2, "0");
+  const d = String(parsed.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  // Fetch the changelog page
+  let html: string;
+  try {
+    const resp = await fetch(CHANGELOG_URL, {
+      headers: { "User-Agent": "aimock-changelog-radar/1.0" },
+    });
+    if (!resp.ok) {
+      console.warn(`Changelog fetch failed: ${resp.status} ${resp.statusText}`);
+      process.exit(0);
+    }
+    html = await resp.text();
+  } catch (err) {
+    console.warn(`Changelog fetch error: ${err}`);
+    process.exit(0);
+  }
+
+  // Parse entries
+  const allEntries = parseEntries(html);
+  if (allEntries.length === 0) {
+    console.warn("No changelog entries parsed — format may have changed");
+    process.exit(0);
+  }
+
+  // Read cursor
+  const cursor = readCursor();
+  const today = new Date().toISOString().slice(0, 10);
+
+  // First run: set cursor and exit
+  if (!cursor) {
+    const newestDate = allEntries[0]?.date ?? today;
+    writeCursor(newestDate);
+    console.log(`First run — cursor set to ${newestDate}. No entries to report.`);
+    process.exit(0);
+  }
+
+  // Filter to entries newer than cursor
+  const newEntries = allEntries.filter((e) => e.date > cursor);
+
+  if (newEntries.length === 0) {
+    console.log(`No new entries since ${cursor}.`);
+    process.exit(0);
+  }
+
+  // Filter for surface-relevant entries
+  const relevant: ChangelogEntry[] = [];
+  for (const entry of newEntries) {
+    const kw = matchKeywords(`${entry.title} ${entry.url}`);
+    if (kw.length > 0) {
+      entry.keywords = kw;
+      relevant.push(entry);
+    }
+  }
+
+  // Update cursor to newest entry
+  const newestDate = newEntries[0]?.date ?? today;
+  writeCursor(newestDate);
+
+  if (relevant.length === 0) {
+    console.log(
+      `${newEntries.length} new entries since ${cursor}, but none matched surface keywords.`,
+    );
+    process.exit(0);
+  }
+
+  // Output report
+  const report: RadarReport = {
+    newEntries: relevant,
+    since: cursor,
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch((err) => {
+  console.warn(`Unhandled error: ${err}`);
+  process.exit(0);
+});

--- a/scripts/fix-drift.ts
+++ b/scripts/fix-drift.ts
@@ -101,7 +101,7 @@ function formatExecError(cmd: string, err: unknown): Error {
  */
 function exec(cmd: string): string {
   try {
-    return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+    return execSync(cmd, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trimEnd();
   } catch (err: unknown) {
     throw formatExecError(cmd, err);
   }


### PR DESCRIPTION
## Summary
- Change exec() .trim() to .trimEnd() — preserves leading whitespace in git porcelain output that encodes index/worktree status
- Create `drift` label on repo so gh issue create --label drift succeeds

## Test plan
- [x] Verified porcelain parsing logic handles ` M src/file.ts` correctly with trimEnd