### PR TITLE
feat: model-aware fixture recording with date-suffix normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Model-aware fixture recording** — recorded fixtures now include the model name in match criteria, preventing collisions when an app makes multiple LLM calls with the same user message but different models. Model names are normalized by stripping date/version suffixes (e.g., `claude-opus-4-20250514` → `claude-opus-4`) so fixtures survive version bumps. Disable with `recordFullModelVersion: true`. ([#185](https://github.com/CopilotKit/aimock/issues/185))
+- **Drift detection metadata** — recorded fixtures include `systemHash` and `toolsHash` in a `metadata` block for detecting system prompt or tool definition changes since recording.
+- **Prefix model matching** — fixture router uses `startsWith` for string model matching, so `model: "claude-opus-4"` matches any `claude-opus-4-*` version.
+
 ## [1.22.1] - 2026-05-12
 
 ### Fixed

--- a/docs/aimock-cli/index.html
+++ b/docs/aimock-cli/index.html
@@ -137,7 +137,7 @@ $ docker run -d -p 4010:4010 \
                 LLMock configuration. Accepts <code>fixtures</code>, <code>latency</code>,
                 <code>chunkSize</code>, <code>logLevel</code>, <code>validateOnLoad</code>,
                 <code>metrics</code>, <code>strict</code>, <code>chaos</code>,
-                <code>streamingProfile</code>.
+                <code>streamingProfile</code>, <code>record</code>.
               </td>
             </tr>
             <tr>
@@ -150,6 +150,76 @@ $ docker run -d -p 4010:4010 \
             </tr>
           </tbody>
         </table>
+
+        <h3>Recording Config (<code>llm.record</code>)</h3>
+        <p>
+          When <code>llm.record</code> is present, aimock proxies unmatched requests to real
+          providers and saves the responses as fixtures. See
+          <a href="/record-replay">Record &amp; Replay</a> for full details.
+        </p>
+
+        <table class="endpoint-table">
+          <thead>
+            <tr>
+              <th>Option</th>
+              <th>Type</th>
+              <th>Default</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>providers</code></td>
+              <td>object</td>
+              <td>&mdash;</td>
+              <td>
+                Map of provider names to upstream URLs or API keys (e.g.
+                <code>{ "openai": "sk-..." }</code>)
+              </td>
+            </tr>
+            <tr>
+              <td><code>fixturePath</code></td>
+              <td>string</td>
+              <td><code>./fixtures/recorded</code></td>
+              <td>Directory where recorded fixtures are saved</td>
+            </tr>
+            <tr>
+              <td><code>proxyOnly</code></td>
+              <td>boolean</td>
+              <td><code>false</code></td>
+              <td>Proxy without saving fixtures to disk or caching in memory</td>
+            </tr>
+            <tr>
+              <td><code>recordFullModelVersion</code></td>
+              <td>boolean</td>
+              <td><code>false</code></td>
+              <td>
+                Record the exact model string without stripping date/version suffixes. Use when
+                tests depend on exact model version matching. See
+                <a href="/record-replay#model-aware-recording">Model-Aware Recording</a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            Recording config example <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="prop">"llm"</span>: {
+    <span class="prop">"fixtures"</span>: <span class="str">"./fixtures"</span>,
+    <span class="prop">"record"</span>: {
+      <span class="prop">"providers"</span>: {
+        <span class="prop">"openai"</span>: <span class="str">"https://api.openai.com"</span>,
+        <span class="prop">"anthropic"</span>: <span class="str">"https://api.anthropic.com"</span>
+      },
+      <span class="prop">"fixturePath"</span>: <span class="str">"./fixtures/recorded"</span>,
+      <span class="prop">"recordFullModelVersion"</span>: <span class="kw">false</span>
+    }
+  }
+}</code></pre>
+        </div>
 
         <h2>CLI Flags</h2>
         <table class="endpoint-table">

--- a/docs/record-replay/index.html
+++ b/docs/record-replay/index.html
@@ -465,6 +465,106 @@
           fixture is saved to disk with a warning but not registered in memory.
         </p>
 
+        <h2 id="model-aware-recording">Model-Aware Recording</h2>
+        <p>
+          When recording fixtures, aimock automatically includes the model name in match criteria.
+          This prevents collisions when your app makes multiple LLM calls with the same user message
+          but different models (e.g., Opus for chat + Haiku for title generation).
+        </p>
+        <p>
+          Model names are normalized by stripping date/version suffixes so fixtures survive provider
+          version bumps:
+        </p>
+
+        <table class="endpoint-table">
+          <thead>
+            <tr>
+              <th>Request Model</th>
+              <th>Recorded As</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>claude-opus-4-20250514</code></td>
+              <td><code>claude-opus-4</code></td>
+            </tr>
+            <tr>
+              <td><code>gpt-4o-2024-08-06</code></td>
+              <td><code>gpt-4o</code></td>
+            </tr>
+            <tr>
+              <td><code>claude-3-5-sonnet-20241022</code></td>
+              <td><code>claude-3-5-sonnet</code></td>
+            </tr>
+            <tr>
+              <td><code>llama3.1</code></td>
+              <td><code>llama3.1</code> (no date suffix &mdash; unchanged)</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>
+          Matching uses prefix comparison, so <code>model: "claude-opus-4"</code> in a fixture
+          matches requests for <code>claude-opus-4-20250514</code>,
+          <code>claude-opus-4-20250915</code>, or any future version.
+        </p>
+
+        <p>
+          To record the full model version instead (disabling normalization), set
+          <code>recordFullModelVersion</code> to <code>true</code> in the recording config:
+        </p>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            Disable model normalization <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="key">"llm"</span>: {
+    <span class="key">"record"</span>: {
+      <span class="key">"providers"</span>: { <span class="key">"openai"</span>: <span class="str">"sk-..."</span> },
+      <span class="key">"recordFullModelVersion"</span>: <span class="kw">true</span>
+    }
+  }
+}</code></pre>
+        </div>
+
+        <p>Or programmatically:</p>
+
+        <div class="code-block">
+          <div class="code-block-header">Programmatic usage <span class="lang-tag">ts</span></div>
+          <pre><code><span class="op">mock</span>.<span class="fn">enableRecording</span>({
+  <span class="prop">providers</span>: { <span class="prop">openai</span>: <span class="str">"https://api.openai.com"</span> },
+  <span class="prop">fixturePath</span>: <span class="str">"./fixtures/recorded"</span>,
+  <span class="prop">recordFullModelVersion</span>: <span class="kw">true</span>,
+});</code></pre>
+        </div>
+
+        <h2>Drift Detection Metadata</h2>
+        <p>
+          Recorded fixtures include a <code>metadata</code> block with hashes of the system prompt
+          and tool definitions at recording time. These are informational only &mdash; not used for
+          matching &mdash; and help you detect when your prompts or tools have changed since the
+          fixture was recorded.
+        </p>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            Recorded fixture with metadata <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="key">"match"</span>: { <span class="key">"userMessage"</span>: <span class="str">"hello"</span>, <span class="key">"model"</span>: <span class="str">"claude-opus-4"</span> },
+  <span class="key">"metadata"</span>: { <span class="key">"systemHash"</span>: <span class="str">"a7f3c291"</span>, <span class="key">"toolsHash"</span>: <span class="str">"e4b12d08"</span> },
+  <span class="key">"response"</span>: { <span class="key">"content"</span>: <span class="str">"Hi there!"</span> }
+}</code></pre>
+        </div>
+
+        <p>
+          When you re-record a fixture and the hashes differ from the previous version, it signals
+          that your application&rsquo;s prompts or tool definitions have evolved. This is useful for
+          auditing fixture freshness &mdash; if the hashes don&rsquo;t match, the recorded response
+          may no longer reflect what the real provider would return for the current prompt.
+        </p>
+
         <h2 id="snapshot-style-recording">Snapshot-Style Recording</h2>
         <p>
           When the <code>X-Test-Id</code> header is present on a request, aimock uses

--- a/src/__tests__/model-utils.test.ts
+++ b/src/__tests__/model-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { normalizeModelName } from "../model-utils.js";
+
+describe("normalizeModelName", () => {
+  it("strips 8-digit date suffix", () => {
+    expect(normalizeModelName("claude-opus-4-20250514")).toBe("claude-opus-4");
+    expect(normalizeModelName("claude-3-5-sonnet-20241022")).toBe("claude-3-5-sonnet");
+    expect(normalizeModelName("gpt-4o-mini-20240718")).toBe("gpt-4o-mini");
+  });
+
+  it("strips YYYY-MM-DD date suffix", () => {
+    expect(normalizeModelName("gpt-4o-2024-08-06")).toBe("gpt-4o");
+    expect(normalizeModelName("gpt-4-turbo-2024-04-09")).toBe("gpt-4-turbo");
+  });
+
+  it("strips Bedrock version suffix after date", () => {
+    expect(normalizeModelName("anthropic.claude-3-5-sonnet-20241022-v2:0")).toBe(
+      "anthropic.claude-3-5-sonnet",
+    );
+  });
+
+  it("leaves models without date suffix unchanged", () => {
+    expect(normalizeModelName("gpt-4o")).toBe("gpt-4o");
+    expect(normalizeModelName("gpt-4o-mini")).toBe("gpt-4o-mini");
+    expect(normalizeModelName("llama3.1")).toBe("llama3.1");
+    expect(normalizeModelName("gemini-2.5-pro")).toBe("gemini-2.5-pro");
+    expect(normalizeModelName("fal-ai/flux/dev")).toBe("fal-ai/flux/dev");
+  });
+
+  it("leaves undefined/empty unchanged", () => {
+    expect(normalizeModelName(undefined)).toBeUndefined();
+    expect(normalizeModelName("")).toBe("");
+  });
+
+  it("respects skip flag", () => {
+    expect(normalizeModelName("claude-opus-4-20250514", true)).toBe("claude-opus-4-20250514");
+  });
+});

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -4016,6 +4016,95 @@ function createMockReqRes(): { req: http.IncomingMessage; res: http.ServerRespon
   return { req, res };
 }
 
+// ---------------------------------------------------------------------------
+// buildFixtureMatch model recording
+// ---------------------------------------------------------------------------
+
+describe("buildFixtureMatch model recording", () => {
+  let localUpstream: ServerInstance | undefined;
+  let localRecorder: ServerInstance | undefined;
+  let localTmpDir: string | undefined;
+
+  afterEach(async () => {
+    if (localRecorder) {
+      await new Promise<void>((resolve) => localRecorder!.server.close(() => resolve()));
+      localRecorder = undefined;
+    }
+    if (localUpstream) {
+      await new Promise<void>((resolve) => localUpstream!.server.close(() => resolve()));
+      localUpstream = undefined;
+    }
+    if (localTmpDir) {
+      fs.rmSync(localTmpDir, { recursive: true, force: true });
+      localTmpDir = undefined;
+    }
+  });
+
+  it("records normalized model for chat requests", async () => {
+    // Set up an upstream server that responds to the test message
+    localUpstream = await createServer(
+      [
+        {
+          match: { userMessage: "test model recording" },
+          response: { content: "model recorded" },
+        },
+      ],
+      { port: 0 },
+    );
+
+    localTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-model-"));
+    localRecorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: localUpstream.url },
+        fixturePath: localTmpDir,
+      },
+    });
+
+    await post(`${localRecorder.url}/v1/chat/completions`, {
+      model: "claude-opus-4-20250514",
+      messages: [{ role: "user", content: "test model recording" }],
+    });
+
+    const files = fs.readdirSync(localTmpDir).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+    const fixture = JSON.parse(fs.readFileSync(path.join(localTmpDir, files[0]), "utf-8"));
+    expect(fixture.fixtures[0].match.model).toBe("claude-opus-4");
+  });
+
+  it("records full model when recordFullModelVersion is true", async () => {
+    localUpstream = await createServer(
+      [
+        {
+          match: { userMessage: "test full model" },
+          response: { content: "full model recorded" },
+        },
+      ],
+      { port: 0 },
+    );
+
+    localTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-model-full-"));
+    localRecorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: localUpstream.url },
+        fixturePath: localTmpDir,
+        recordFullModelVersion: true,
+      },
+    });
+
+    await post(`${localRecorder.url}/v1/chat/completions`, {
+      model: "claude-opus-4-20250514",
+      messages: [{ role: "user", content: "test full model" }],
+    });
+
+    const files = fs.readdirSync(localTmpDir).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBe(1);
+    const fixture = JSON.parse(fs.readFileSync(path.join(localTmpDir, files[0]), "utf-8"));
+    expect(fixture.fixtures[0].match.model).toBe("claude-opus-4-20250514");
+  });
+});
+
 async function setupUpstreamAndRecorder(
   upstreamFixtures: Fixture[],
   providerKey: string = "openai",
@@ -4616,5 +4705,242 @@ describe("recorder Bedrock binary event stream progressive streaming", () => {
     });
 
     expect(clientCT.toLowerCase()).toContain("application/vnd.amazon.eventstream");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-call fixture collision (issue #185)
+// ---------------------------------------------------------------------------
+
+describe("multi-call fixture disambiguation (issue #185)", () => {
+  it("records distinct fixtures for same userMessage with different models", async () => {
+    // Upstream that responds to everything
+    const upstreamServer = await createServer(
+      [
+        {
+          match: { userMessage: "help me plan a trip" },
+          response: { content: "Here is your trip plan." },
+        },
+      ],
+      { port: 0 },
+    );
+
+    const fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-multicall-"));
+    const recorderServer = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: upstreamServer.url },
+        fixturePath,
+      },
+    });
+
+    const url = `${recorderServer.url}/v1/chat/completions`;
+
+    // Call 1: opus + tools (assistant chat)
+    await post(url, {
+      model: "claude-opus-4-20250514",
+      messages: [{ role: "user", content: "help me plan a trip" }],
+      tools: [{ type: "function", function: { name: "search", parameters: {} } }],
+    });
+
+    // Call 2: haiku (title generation)
+    await post(url, {
+      model: "claude-3-5-haiku-20241022",
+      messages: [
+        { role: "system", content: "Generate a short title." },
+        { role: "user", content: "help me plan a trip" },
+      ],
+    });
+
+    // Call 3: haiku (suggestion generation)
+    await post(url, {
+      model: "claude-3-5-haiku-20241022",
+      messages: [
+        { role: "system", content: "Generate travel suggestions." },
+        { role: "user", content: "help me plan a trip" },
+      ],
+    });
+
+    // Calls 2 and 3 share identical match criteria (model + userMessage +
+    // turnIndex + hasToolResult). systemHash is metadata for drift detection,
+    // not a match discriminator — so the second haiku call overwrites the first
+    // in the recorder cache. Only 2 distinct files are produced.
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBe(2);
+
+    const fixtures = files.map((f) => {
+      const data: FixtureFile = JSON.parse(fs.readFileSync(path.join(fixturePath, f), "utf-8"));
+      return data.fixtures[0];
+    });
+
+    // Both share userMessage
+    expect(fixtures.every((f) => f.match.userMessage === "help me plan a trip")).toBe(true);
+
+    // Models are recorded and normalized (date stripped)
+    const models = fixtures.map((f) => f.match.model);
+    expect(models).toContain("claude-opus-4");
+    expect(models).toContain("claude-3-5-haiku");
+
+    // The haiku fixture has systemHash metadata (from whichever call won)
+    const haikuFixture = fixtures.find((f) => f.match.model === "claude-3-5-haiku")!;
+    expect(haikuFixture).toBeDefined();
+    expect((haikuFixture as Record<string, unknown>).metadata).toBeDefined();
+    const meta = (haikuFixture as Record<string, unknown>).metadata as Record<string, unknown>;
+    expect(meta.systemHash).toMatch(/^[a-f0-9]{8}$/);
+
+    // Cleanup
+    await new Promise<void>((resolve) => recorderServer.server.close(() => resolve()));
+    await new Promise<void>((resolve) => upstreamServer.server.close(() => resolve()));
+    fs.rmSync(fixturePath, { recursive: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture metadata recording (systemHash / toolsHash)
+// ---------------------------------------------------------------------------
+
+describe("fixture metadata recording", () => {
+  let metaUpstream: ServerInstance | undefined;
+  let metaRecorder: ServerInstance | undefined;
+  let metaTmpDir: string | undefined;
+
+  afterEach(async () => {
+    if (metaRecorder) {
+      await new Promise<void>((resolve) => metaRecorder!.server.close(() => resolve()));
+      metaRecorder = undefined;
+    }
+    if (metaUpstream) {
+      await new Promise<void>((resolve) => metaUpstream!.server.close(() => resolve()));
+      metaUpstream = undefined;
+    }
+    if (metaTmpDir) {
+      fs.rmSync(metaTmpDir, { recursive: true, force: true });
+      metaTmpDir = undefined;
+    }
+  });
+
+  async function setupMetaRecorder(): Promise<{ recorderUrl: string; fixturePath: string }> {
+    metaUpstream = await createServer(
+      [
+        {
+          match: { userMessage: "test metadata sys" },
+          response: { content: "ok sys" },
+        },
+        {
+          match: { userMessage: "test metadata tools" },
+          response: { content: "ok tools" },
+        },
+        {
+          match: { userMessage: "test no metadata" },
+          response: { content: "ok none" },
+        },
+        {
+          match: { userMessage: "first hash probe" },
+          response: { content: "ok diff" },
+        },
+        {
+          match: { userMessage: "second hash probe" },
+          response: { content: "ok diff two" },
+        },
+      ],
+      { port: 0 },
+    );
+    metaTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-meta-"));
+    metaRecorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: metaUpstream.url },
+        fixturePath: metaTmpDir,
+      },
+    });
+    return { recorderUrl: metaRecorder.url, fixturePath: metaTmpDir };
+  }
+
+  it("records systemHash when system message present", async () => {
+    const { recorderUrl, fixturePath } = await setupMetaRecorder();
+
+    await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "test metadata sys" },
+      ],
+    });
+
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBeGreaterThanOrEqual(1);
+    const fixture = JSON.parse(
+      fs.readFileSync(path.join(fixturePath, files[0]), "utf-8"),
+    ) as FixtureFile;
+    expect(fixture.fixtures[0].metadata).toBeDefined();
+    expect(fixture.fixtures[0].metadata!.systemHash).toMatch(/^[a-f0-9]{8}$/);
+    expect(fixture.fixtures[0].metadata!.toolsHash).toBeUndefined();
+  });
+
+  it("records toolsHash when tools present", async () => {
+    const { recorderUrl, fixturePath } = await setupMetaRecorder();
+
+    await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "test metadata tools" }],
+      tools: [{ type: "function", function: { name: "get_weather", parameters: {} } }],
+    });
+
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBeGreaterThanOrEqual(1);
+    const fixture = JSON.parse(
+      fs.readFileSync(path.join(fixturePath, files[0]), "utf-8"),
+    ) as FixtureFile;
+    expect(fixture.fixtures[0].metadata).toBeDefined();
+    expect(fixture.fixtures[0].metadata!.toolsHash).toMatch(/^[a-f0-9]{8}$/);
+  });
+
+  it("omits metadata when no system message or tools", async () => {
+    const { recorderUrl, fixturePath } = await setupMetaRecorder();
+
+    await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "test no metadata" }],
+    });
+
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBeGreaterThanOrEqual(1);
+    const fixture = JSON.parse(
+      fs.readFileSync(path.join(fixturePath, files[0]), "utf-8"),
+    ) as FixtureFile;
+    expect(fixture.fixtures[0].metadata).toBeUndefined();
+  });
+
+  it("produces different systemHash for different system prompts", async () => {
+    const { recorderUrl, fixturePath } = await setupMetaRecorder();
+
+    // Use different user messages so the second request also proxies to upstream
+    // (same userMessage would match the first recorded fixture in memory).
+    await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "Generate a title." },
+        { role: "user", content: "first hash probe" },
+      ],
+    });
+
+    await post(`${recorderUrl}/v1/chat/completions`, {
+      model: "gpt-4o",
+      messages: [
+        { role: "system", content: "Generate suggestions." },
+        { role: "user", content: "second hash probe" },
+      ],
+    });
+
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBe(2);
+    const fixtures = files.map(
+      (f) => JSON.parse(fs.readFileSync(path.join(fixturePath, f), "utf-8")) as FixtureFile,
+    );
+    const hash1 = fixtures[0].fixtures[0].metadata?.systemHash;
+    const hash2 = fixtures[1].fixtures[0].metadata?.systemHash;
+    expect(hash1).toBeDefined();
+    expect(hash2).toBeDefined();
+    expect(hash1).not.toBe(hash2);
   });
 });

--- a/src/__tests__/router.test.ts
+++ b/src/__tests__/router.test.ts
@@ -624,10 +624,66 @@ describe("matchFixture — model (string)", () => {
     expect(matchFixture([fixture], req)).toBe(fixture);
   });
 
-  it("does not match when the model string differs", () => {
+  it("does not match gpt-4o fixture against gpt-4o-mini (dash + letter, not date suffix)", () => {
     const fixture = makeFixture({ model: "gpt-4o" });
     const req = makeReq({ model: "gpt-4o-mini" });
     expect(matchFixture([fixture], req)).toBeNull();
+  });
+
+  it("matches when the request model has a date suffix (dash + digit)", () => {
+    const fixture = makeFixture({ model: "gpt-4o" });
+    const req = makeReq({ model: "gpt-4o-2024-08-06" });
+    expect(matchFixture([fixture], req)).toBe(fixture);
+  });
+
+  it("does not match when the request model does not start with the fixture model", () => {
+    const fixture = makeFixture({ model: "gpt-4o" });
+    const req = makeReq({ model: "gpt-3.5-turbo" });
+    expect(matchFixture([fixture], req)).toBeNull();
+  });
+
+  it("does not match gpt-4 fixture against gpt-4o request (no dash boundary)", () => {
+    const fixture = makeFixture({ model: "gpt-4" });
+    const req = makeReq({ model: "gpt-4o" });
+    expect(matchFixture([fixture], req)).toBeNull();
+  });
+
+  it("does not match when request model is undefined", () => {
+    const fixture = makeFixture({ model: "gpt-4o" });
+    const req = makeReq({ model: undefined });
+    expect(matchFixture([fixture], req)).toBeNull();
+  });
+});
+
+describe("matchFixture — model (startsWith)", () => {
+  it("matches when request model starts with fixture model", () => {
+    const fixture = makeFixture({ model: "claude-opus-4" });
+    const req = makeReq({ model: "claude-opus-4-20250514" });
+    expect(matchFixture([fixture], req)).toBe(fixture);
+  });
+
+  it("matches exact model strings", () => {
+    const fixture = makeFixture({ model: "gpt-4o" });
+    const req = makeReq({ model: "gpt-4o" });
+    expect(matchFixture([fixture], req)).toBe(fixture);
+  });
+
+  it("does not match when models diverge", () => {
+    const fixture = makeFixture({ model: "claude-opus-4" });
+    const req = makeReq({ model: "claude-haiku-4" });
+    expect(matchFixture([fixture], req)).toBeNull();
+  });
+
+  it("does not match when fixture model is longer than request model", () => {
+    const fixture = makeFixture({ model: "claude-opus-4-20250514" });
+    const req = makeReq({ model: "claude-opus-4" });
+    expect(matchFixture([fixture], req)).toBeNull();
+  });
+
+  it("still supports regexp model matching", () => {
+    const fixture = makeFixture({ model: /^claude-opus/ });
+    const req = makeReq({ model: "claude-opus-4-20250514" });
+    expect(matchFixture([fixture], req)).toBe(fixture);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ Options:
       --validate-on-load    Validate fixture schemas at startup
       --metrics             Enable Prometheus metrics at GET /metrics
       --record              Record mode: proxy unmatched requests and save fixtures
+      --record-full-model-version  Record exact model version without date stripping (default: false)
       --proxy-only          Proxy mode: forward unmatched requests without saving
       --strict              Strict mode: fail on unmatched requests (overridable per-request via X-AIMock-Strict header)
       --journal-max <n>     Max request entries retained in memory (default: 1000, 0 = unbounded)
@@ -59,6 +60,7 @@ const { values } = parseArgs({
     "validate-on-load": { type: "boolean", default: false },
     metrics: { type: "boolean", default: false },
     record: { type: "boolean", default: false },
+    "record-full-model-version": { type: "boolean", default: false },
     "proxy-only": { type: "boolean", default: false },
     strict: { type: "boolean", default: false },
     "provider-openai": { type: "string" },
@@ -212,6 +214,7 @@ if (values.record || values["proxy-only"]) {
     // rather than resolving a URL string as a filesystem path.
     fixturePath: recordBaseIsUrl ? undefined : resolve(recordBase, "recorded"),
     proxyOnly: values["proxy-only"],
+    recordFullModelVersion: values["record-full-model-version"],
   };
 }
 

--- a/src/fixture-loader.ts
+++ b/src/fixture-loader.ts
@@ -77,6 +77,7 @@ export function entryToFixture(entry: FixtureFileEntry): Fixture {
     ...(entry.disconnectAfterMs !== undefined && { disconnectAfterMs: entry.disconnectAfterMs }),
     ...(entry.streamingProfile !== undefined && { streamingProfile: entry.streamingProfile }),
     ...(entry.chaos !== undefined && { chaos: entry.chaos }),
+    ...(entry.metadata !== undefined && { metadata: entry.metadata }),
   };
 }
 

--- a/src/model-utils.ts
+++ b/src/model-utils.ts
@@ -1,0 +1,9 @@
+const DATE_SUFFIX_RE = /[-](\d{8}(-v\d+([:.]\d+)*)?)$|[-]\d{4}-\d{2}-\d{2}$/;
+
+export function normalizeModelName(
+  model: string | undefined,
+  skipNormalization?: boolean,
+): string | undefined {
+  if (!model || skipNormalization) return model;
+  return model.replace(DATE_SUFFIX_RE, "");
+}

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -12,6 +12,7 @@ import type {
   ToolCall,
 } from "./types.js";
 import { getLastMessageByRole, getTextContent } from "./router.js";
+import { normalizeModelName } from "./model-utils.js";
 import type { Logger } from "./logger.js";
 import { collapseStreamingResponse } from "./stream-collapse.js";
 import { writeErrorResponse } from "./sse-writer.js";
@@ -332,12 +333,16 @@ export async function proxyAndRecord(
 
   // Build the match criteria from the (optionally transformed) request
   const matchRequest = defaults.requestTransform ? defaults.requestTransform(request) : request;
-  const fixtureMatch = buildFixtureMatch(matchRequest);
+  const fixtureMatch = buildFixtureMatch(matchRequest, defaults.record);
+
+  // Build metadata (drift-detection hashes, not match criteria)
+  const metadata = buildFixtureMetadata(request);
 
   // Build and save the fixture
   const fixture: Fixture = {
     match: fixtureMatch,
     response: fixtureResponse,
+    ...(metadata && { metadata }),
   };
 
   // Check if the match is empty — warn but still save to disk.
@@ -1158,7 +1163,10 @@ type EndpointType =
   | "fal-audio"
   | "fal";
 
-function buildFixtureMatch(request: ChatCompletionRequest): {
+function buildFixtureMatch(
+  request: ChatCompletionRequest,
+  recordConfig?: RecordConfig,
+): {
   userMessage?: string;
   inputText?: string;
   model?: string;
@@ -1195,11 +1203,11 @@ function buildFixtureMatch(request: ChatCompletionRequest): {
     }
   }
 
-  // fal.ai fixtures are typically authored against the model id (e.g.
-  // /flux/, /kling/) since the request body is opaque per-model JSON. Persist
-  // the resolved model so replay matches what `onFalQueue(/flux/, ...)` writes.
-  if (request._endpointType === "fal" && request.model) {
-    match.model = request.model;
+  // Record normalized model for all requests so fixtures disambiguate
+  // calls that share the same userMessage but target different models.
+  if (request.model) {
+    match.model =
+      normalizeModelName(request.model, recordConfig?.recordFullModelVersion) ?? request.model;
   }
 
   // Multi-turn disambiguation: writing only `userMessage` lets the recorder's
@@ -1213,4 +1221,34 @@ function buildFixtureMatch(request: ChatCompletionRequest): {
   }
 
   return match;
+}
+
+/**
+ * Build optional metadata for drift detection. Contains 8-char SHA-256
+ * hashes of the system prompt and tool definitions present in the request.
+ * Returns undefined when neither is present.
+ */
+function buildFixtureMetadata(
+  request: ChatCompletionRequest,
+): { systemHash?: string; toolsHash?: string } | undefined {
+  const meta: { systemHash?: string; toolsHash?: string } = {};
+
+  const messages = request.messages ?? [];
+  const systemTexts = messages
+    .filter((m) => m.role === "system")
+    .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
+    .join("\n");
+  if (systemTexts) {
+    meta.systemHash = crypto.createHash("sha256").update(systemTexts).digest("hex").slice(0, 8);
+  }
+
+  if (request.tools && request.tools.length > 0) {
+    meta.toolsHash = crypto
+      .createHash("sha256")
+      .update(JSON.stringify(request.tools))
+      .digest("hex")
+      .slice(0, 8);
+  }
+
+  return Object.keys(meta).length > 0 ? meta : undefined;
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -199,13 +199,19 @@ export function matchFixture(
       if (reqType !== match.responseFormat) continue;
     }
 
-    // model — exact string or regexp
+    // model — exact match or prefix + dash-digit boundary for strings (so that
+    // "claude-opus-4" matches "claude-opus-4-20250514" but "gpt-4" does NOT
+    // match "gpt-4o" and "gpt-4o" does NOT match "gpt-4o-mini"), regexp unchanged
     if (match.model !== undefined) {
       if (typeof match.model === "string") {
-        if (effective.model !== match.model) continue;
+        if (effective.model !== match.model) {
+          if (!effective.model?.startsWith(match.model)) continue;
+          const rest = effective.model.slice(match.model.length);
+          if (!/^-\d/.test(rest)) continue;
+        }
       } else {
         match.model.lastIndex = 0;
-        if (!match.model.test(effective.model)) continue;
+        if (!match.model.test(effective.model ?? "")) continue;
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,6 +268,10 @@ export interface Fixture {
   disconnectAfterMs?: number;
   streamingProfile?: StreamingProfile;
   chaos?: ChaosConfig;
+  metadata?: {
+    systemHash?: string;
+    toolsHash?: string;
+  };
 }
 
 export type FixtureOpts = Omit<Fixture, "match" | "response">;
@@ -359,6 +363,10 @@ export interface FixtureFileEntry {
   disconnectAfterMs?: number;
   streamingProfile?: StreamingProfile;
   chaos?: ChaosConfig;
+  metadata?: {
+    systemHash?: string;
+    toolsHash?: string;
+  };
 }
 
 // Request journal
@@ -468,6 +476,12 @@ export interface RecordConfig {
   fixturePath?: string;
   /** Proxy unmatched requests without saving fixtures or caching in memory. */
   proxyOnly?: boolean;
+  /**
+   * When true, record the exact model version string returned by the provider
+   * (e.g. "gpt-4o-2024-08-06") instead of stripping the date suffix to a
+   * canonical alias (e.g. "gpt-4o"). Default: false.
+   */
+  recordFullModelVersion?: boolean;
 }
 
 export interface MockServerOptions {


### PR DESCRIPTION
## Summary

- **Record model in fixture match criteria** for all requests (not just fal.ai), preventing fixture collisions when apps make multiple LLM calls with the same user message but different models
- **Date-suffix normalization** strips version dates from model names (e.g., `claude-opus-4-20250514` → `claude-opus-4`) so fixtures survive provider version bumps
- **Dash+digit boundary matching** in the router: `claude-opus-4` matches `claude-opus-4-20250514` but `gpt-4` does NOT match `gpt-4o` and `gpt-4o` does NOT match `gpt-4o-mini`
- **Drift detection metadata** records `systemHash` and `toolsHash` (8-char SHA-256) alongside fixtures for detecting prompt/tool changes since recording
- **`recordFullModelVersion`** config option and CLI flag to disable normalization
- **Documentation** updates for recording behavior, config reference, and CLI

## Why

Issue #185 — when an app triggers multiple distinct LLM calls from a single user message (e.g., Opus+tools for chat, Haiku for title gen, Haiku for suggestions), recorded fixtures collide because `buildFixtureMatch()` only keyed on `userMessage`/`turnIndex`/`hasToolResult`. Adding `model` to match criteria disambiguates the calls.

## Test plan

- [ ] `normalizeModelName` strips dates correctly across all provider formats
- [ ] Router dash+digit boundary: `gpt-4` ✗ `gpt-4o`, `gpt-4o` ✗ `gpt-4o-mini`, `claude-opus-4` ✓ `claude-opus-4-20250514`
- [ ] Recorder writes normalized model + metadata to fixture files
- [ ] `recordFullModelVersion: true` preserves full model string
- [ ] Old fixtures without model field still match (backwards compatible)
- [ ] Integration test: 3 distinct LLM calls produce distinguishable fixtures

Closes #185