### PR TITLE
fix: configure git credentials in publish job for tag push

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -82,6 +82,10 @@ jobs:
         with:
           name: workspace
 
+      - name: Configure git credentials
+        run: |
+          git config --local url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

The build/publish job split (4f9b81c) broke tag pushing — the publish
job downloads the workspace artifact which includes `.git` but not
the credential helper that `actions/checkout` configures. Adds
`url.insteadOf` to inject `GITHUB_TOKEN` for `git push` without
collapsing the read-only build / write publish security boundary.

## Test plan

- [x] Preserves the security split (build=read-only, publish=write)
- [x] No new secrets or tokens required — uses existing GITHUB_TOKEN
- [x] The publish job already has `contents: write` permission