### PR TITLE
fix: preserve functionCall.id in Gemini conversation history conversion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "npm",
         "package": "@copilotkit/aimock",
-        "version": "^1.23.0"
+        "version": "^1.23.1"
       },
       "description": "Fixture authoring skill for @copilotkit/aimock — LLM, multimedia (image/TTS/transcription/video), MCP, A2A, AG-UI, vector, embeddings, structured output, sequential responses, streaming physics, record/replay, agent loop patterns, and debugging"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimock",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Fixture authoring guidance for @copilotkit/aimock — LLM, multimedia, MCP, A2A, AG-UI, vector, and service mocking",
   "author": {
     "name": "CopilotKit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.23.1] - 2026-05-14
+
+### Fixed
+
+- **Gemini functionCall.id preservation** — the Gemini conversation history converter generated new tool call IDs (`call_gemini_*`) instead of preserving the original IDs from `functionCall.id`. This broke `toolCallId`-based fixture matching on follow-up turns: the follow-up fixture couldn't match because the ID was overwritten, so the request fell through to `userMessage` fixtures which returned another tool call — creating an infinite loop for all Gemini/ADK showcase integrations. LangGraph-python (OpenAI format) was unaffected because it preserves IDs natively. ([#196](https://github.com/CopilotKit/aimock/pull/196))
+
 ## [1.23.0] - 2026-05-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, text-to-speech, transcription, audio generation, video generation, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/src/__tests__/gemini.test.ts
+++ b/src/__tests__/gemini.test.ts
@@ -379,6 +379,50 @@ describe("geminiToCompletionRequest", () => {
     expect(result.messages[0].tool_call_id).not.toBe(result.messages[1].tool_call_id);
   });
 
+  it("preserves functionCall.id from Gemini conversation history", () => {
+    const result = geminiToCompletionRequest(
+      {
+        contents: [
+          { role: "user", parts: [{ text: "weather in Tokyo" }] },
+          {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  name: "get_weather",
+                  args: { location: "Tokyo" },
+                  id: "call_fp_get_weather_001",
+                },
+              },
+            ],
+          },
+          {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  name: "get_weather",
+                  response: { temperature: 72 },
+                },
+              },
+            ],
+          },
+          { role: "user", parts: [{ text: "thanks" }] },
+        ],
+      },
+      "gemini-2.0-flash",
+      false,
+    );
+
+    const assistantMsg = result.messages.find((m) => m.role === "assistant" && m.tool_calls);
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.tool_calls![0].id).toBe("call_fp_get_weather_001");
+
+    const toolMsg = result.messages.find((m) => m.role === "tool");
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg!.tool_call_id).toBe("call_fp_get_weather_001");
+  });
+
   it("aligns functionCall and functionResponse IDs across a round trip", () => {
     // Model turn: two functionCall parts
     const modelTurn = geminiToCompletionRequest(

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -46,8 +46,8 @@ import { proxyAndRecord } from "./recorder.js";
 interface GeminiPart {
   text?: string;
   thought?: boolean;
-  functionCall?: { name: string; args: Record<string, unknown> };
-  functionResponse?: { name: string; response: unknown };
+  functionCall?: { name: string; args: Record<string, unknown>; id?: string };
+  functionResponse?: { name: string; response: unknown; id?: string };
   inlineData?: { mimeType: string; data: string };
 }
 
@@ -154,7 +154,7 @@ export function geminiToCompletionRequest(
             role: "assistant",
             content: text || null,
             tool_calls: funcCalls.map((fc, i) => ({
-              id: `call_gemini_${fc.functionCall!.name}_${i}`,
+              id: fc.functionCall!.id ?? `call_gemini_${fc.functionCall!.name}_${i}`,
               type: "function" as const,
               function: {
                 name: fc.functionCall!.name,


### PR DESCRIPTION
## Summary

One-line fix: preserve the original functionCall.id from Gemini conversation history instead of generating new IDs.

## Root Cause

gemini.ts line 157 generated call_gemini_${name}_${i} IDs, discarding the original fixture-assigned IDs
(e.g. call_fp_get_weather_001). On follow-up turns, toolCallId-based fixtures could not match because the
ID was overwritten. Requests fell through to userMessage fixtures which returned another tool call, creating
an infinite loop.

Affects all Gemini/ADK showcase integrations. LangGraph-python (OpenAI format) was unaffected because it
preserves IDs natively.

## Test plan

- [x] Red-green test: verify functionCall.id is preserved in conversion
- [x] Full test suite passes
- [x] Format + lint clean