### PR TITLE
feat: configurable upstream + body-idle timeouts on RecordConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable proxy timeouts** — `RecordConfig` now accepts `upstreamTimeoutMs` (default 30s) and `bodyTimeoutMs` (default 30s). The body-idle timeout is the Node socket inactivity timer that fires `req.destroy()` mid-stream; under concurrent load against reasoning models (e.g. Grok 4.3 + structured output), token-emission gaps can routinely exceed 30s during the thinking phase, causing record-mode runs to truncate SSE responses mid-stream with no `[DONE]` and no `finish_reason`. Lift to e.g. `bodyTimeoutMs: 180_000` to record cleanly under that workload.
+
 ## [1.24.1] - 2026-05-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ npx @copilotkit/aimock --config aimock.json
 # Record mode: proxy to real APIs, save fixtures
 npx -p @copilotkit/aimock llmock --record --provider-openai https://api.openai.com
 
+# Record with extended timeout for reasoning models
+npx -p @copilotkit/aimock llmock --record --provider-openai https://api.openai.com \
+  --body-timeout-ms 180000
+
 # Convert fixtures from other tools
 npx @copilotkit/aimock convert vidaimock ./templates/ ./fixtures/
 npx @copilotkit/aimock convert mockllm ./config.yaml ./fixtures/

--- a/docs/record-replay/index.html
+++ b/docs/record-replay/index.html
@@ -258,6 +258,23 @@
               <td>Upstream URL for Cohere</td>
             </tr>
             <tr>
+              <td><code>--upstream-timeout-ms &lt;ms&gt;</code></td>
+              <td>
+                Connection idle timeout (ms) on the upstream request socket before the response body
+                begins (default: <code>30000</code>). Increase for upstreams with slow initial
+                responses (reasoning models, queue-backed providers).
+              </td>
+            </tr>
+            <tr>
+              <td><code>--body-timeout-ms &lt;ms&gt;</code></td>
+              <td>
+                Inter-chunk idle timeout (ms) on the upstream response body &mdash; fires if no
+                bytes arrive for this duration after the response has started streaming (default:
+                <code>30000</code>). Reasoning models under concurrent load can leave 30s+ gaps
+                between chunks; increase to e.g. <code>180000</code> in those setups.
+              </td>
+            </tr>
+            <tr>
               <td><code>--agui-record</code></td>
               <td>Enable AG-UI recording (proxy unmatched AG-UI requests)</td>
             </tr>
@@ -538,6 +555,30 @@
   <span class="prop">recordFullModelVersion</span>: <span class="kw">true</span>,
 });</code></pre>
         </div>
+
+        <h2 id="upstream-timeouts">Upstream Timeouts</h2>
+
+        <p>
+          By default, aimock aborts a proxied request if the upstream socket is idle for 30 seconds
+          (before the response body) or if no bytes arrive for 30 seconds during streaming.
+          Reasoning models under concurrent load can exceed these limits during the thinking phase.
+          Override with <code>upstreamTimeoutMs</code> and <code>bodyTimeoutMs</code>:
+        </p>
+
+        <div class="code-block">
+          <div class="code-block-header">Custom timeouts <span class="lang-tag">ts</span></div>
+          <pre><code><span class="op">mock</span>.<span class="fn">enableRecording</span>({
+  <span class="prop">providers</span>: { <span class="prop">openai</span>: <span class="str">"https://api.openai.com"</span> },
+  <span class="prop">fixturePath</span>: <span class="str">"./fixtures/recorded"</span>,
+  <span class="prop">bodyTimeoutMs</span>: <span class="num">180_000</span>,
+});</code></pre>
+        </div>
+
+        <p>
+          Or via CLI: <code>--body-timeout-ms 180000</code>. Values must be positive finite numbers;
+          zero, negative, <code>NaN</code>, and <code>Infinity</code> are rejected (CLI exits
+          non-zero; programmatic API falls back to the 30s default).
+        </p>
 
         <h2>Drift Detection Metadata</h2>
         <p>

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -4206,6 +4206,205 @@ describe("makeUpstreamRequest body timeout", () => {
     // Verify res.setTimeout was called with the 30-second body accumulation timeout
     expect(setTimeoutSpy).toHaveBeenCalledWith(30_000, expect.any(Function));
   });
+
+  it("honors custom bodyTimeoutMs value", async () => {
+    fastRawServer = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          choices: [{ message: { content: "ok", role: "assistant" }, finish_reason: "stop" }],
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => fastRawServer!.listen(0, "127.0.0.1", resolve));
+    const { port } = fastRawServer!.address() as { port: number };
+
+    setTimeoutSpy = vi.spyOn(http.IncomingMessage.prototype, "setTimeout");
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-custom-body-timeout-"));
+    const record: RecordConfig = {
+      providers: { openai: `http://127.0.0.1:${port}` },
+      fixturePath: tmpDir,
+      bodyTimeoutMs: 120_000,
+    };
+    const logger = new Logger("silent");
+    const fixtures: Fixture[] = [];
+
+    const { req, res } = createMockReqRes();
+    const chunks: Buffer[] = [];
+    Object.assign(res, {
+      writeHead: () => res,
+      end: (data?: Buffer | string) => {
+        if (data) chunks.push(typeof data === "string" ? Buffer.from(data) : data);
+        return res;
+      },
+      setHeader: () => res,
+    });
+
+    await proxyAndRecord(
+      req,
+      res,
+      { model: "gpt-4", messages: [{ role: "user", content: "hello" }] },
+      "openai",
+      "/v1/chat/completions",
+      fixtures,
+      { record, logger },
+    );
+
+    // Verify res.setTimeout was called with the custom 120s body timeout, not the default 30s
+    expect(setTimeoutSpy).toHaveBeenCalledWith(120_000, expect.any(Function));
+  });
+
+  it("honors custom upstreamTimeoutMs value", async () => {
+    // Server that accepts connections but never responds — triggers the upstream timeout
+    fastRawServer = http.createServer(() => {
+      // intentionally never respond
+    });
+    await new Promise<void>((resolve) => fastRawServer!.listen(0, "127.0.0.1", resolve));
+    const { port } = fastRawServer!.address() as { port: number };
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-custom-upstream-timeout-"));
+    const record: RecordConfig = {
+      providers: { openai: `http://127.0.0.1:${port}` },
+      fixturePath: tmpDir,
+      upstreamTimeoutMs: 100, // very short timeout to trigger quickly
+    };
+    const logger = new Logger("silent");
+    const fixtures: Fixture[] = [];
+
+    const { req, res } = createMockReqRes();
+    let writtenStatus: number | undefined;
+    let writtenBody = "";
+    Object.assign(res, {
+      writeHead: (status: number) => {
+        writtenStatus = status;
+        return res;
+      },
+      end: (data?: Buffer | string) => {
+        if (data) writtenBody = typeof data === "string" ? data : data.toString();
+        return res;
+      },
+      setHeader: () => res,
+    });
+
+    const outcome = await proxyAndRecord(
+      req,
+      res,
+      { model: "gpt-4", messages: [{ role: "user", content: "hello" }] },
+      "openai",
+      "/v1/chat/completions",
+      fixtures,
+      { record, logger },
+    );
+
+    // The custom 100ms timeout should fire and produce a 502 proxy error
+    expect(outcome).toBe("relayed");
+    expect(writtenStatus).toBe(502);
+    expect(writtenBody).toContain("timed out");
+    // The error message includes the custom timeout value (0.1s)
+    expect(writtenBody).toContain("0.1s");
+  });
+
+  it("clampTimeout falls back to default 30s for zero and negative values", async () => {
+    // Verify bodyTimeoutMs clamping via setTimeout spy (zero value)
+    fastRawServer = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          choices: [{ message: { content: "ok", role: "assistant" }, finish_reason: "stop" }],
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => fastRawServer!.listen(0, "127.0.0.1", resolve));
+    const { port } = fastRawServer!.address() as { port: number };
+
+    setTimeoutSpy = vi.spyOn(http.IncomingMessage.prototype, "setTimeout");
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-clamp-timeout-"));
+    // Pass 0 for bodyTimeoutMs — clampTimeout should reject and fall back to 30_000
+    const record: RecordConfig = {
+      providers: { openai: `http://127.0.0.1:${port}` },
+      fixturePath: tmpDir,
+      bodyTimeoutMs: 0,
+    };
+    const logger = new Logger("silent");
+    const fixtures: Fixture[] = [];
+
+    const { req, res } = createMockReqRes();
+    const chunks: Buffer[] = [];
+    Object.assign(res, {
+      writeHead: () => res,
+      end: (data?: Buffer | string) => {
+        if (data) chunks.push(typeof data === "string" ? Buffer.from(data) : data);
+        return res;
+      },
+      setHeader: () => res,
+    });
+
+    await proxyAndRecord(
+      req,
+      res,
+      { model: "gpt-4", messages: [{ role: "user", content: "hello" }] },
+      "openai",
+      "/v1/chat/completions",
+      fixtures,
+      { record, logger },
+    );
+
+    // Zero should be clamped to the default 30_000
+    expect(setTimeoutSpy).toHaveBeenCalledWith(30_000, expect.any(Function));
+
+    // Now test negative bodyTimeoutMs value
+    setTimeoutSpy.mockRestore();
+    setTimeoutSpy = vi.spyOn(http.IncomingMessage.prototype, "setTimeout");
+
+    // Close and recreate the server for the second call
+    await new Promise<void>((resolve) => fastRawServer!.close(() => resolve()));
+    fastRawServer = http.createServer((_req, res2) => {
+      res2.writeHead(200, { "Content-Type": "application/json" });
+      res2.end(
+        JSON.stringify({
+          choices: [{ message: { content: "ok", role: "assistant" }, finish_reason: "stop" }],
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => fastRawServer!.listen(0, "127.0.0.1", resolve));
+    const port2 = (fastRawServer!.address() as { port: number }).port;
+
+    const tmpDir2 = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-clamp-neg-"));
+    const record2: RecordConfig = {
+      providers: { openai: `http://127.0.0.1:${port2}` },
+      fixturePath: tmpDir2,
+      bodyTimeoutMs: -500,
+    };
+
+    const { req: req2, res: res2 } = createMockReqRes();
+    const chunks2: Buffer[] = [];
+    Object.assign(res2, {
+      writeHead: () => res2,
+      end: (data?: Buffer | string) => {
+        if (data) chunks2.push(typeof data === "string" ? Buffer.from(data) : data);
+        return res2;
+      },
+      setHeader: () => res2,
+    });
+
+    await proxyAndRecord(
+      req2,
+      res2,
+      { model: "gpt-4", messages: [{ role: "user", content: "hello" }] },
+      "openai",
+      "/v1/chat/completions",
+      fixtures,
+      { record: record2, logger },
+    );
+
+    // Negative values should also be clamped to 30_000
+    expect(setTimeoutSpy).toHaveBeenCalledWith(30_000, expect.any(Function));
+
+    // Clean up the extra tmpDir
+    fs.rmSync(tmpDir2, { recursive: true, force: true });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,8 @@ Options:
       --provider-azure <url>      Upstream URL for Azure OpenAI
       --provider-ollama <url>     Upstream URL for Ollama
       --provider-cohere <url>     Upstream URL for Cohere
+      --upstream-timeout-ms <ms>  Idle timeout (ms) on upstream socket before response (default: 30000)
+      --body-timeout-ms <ms>      Idle timeout (ms) on upstream response body between chunks (default: 30000)
       --agui-record              Enable AG-UI recording (proxy unmatched AG-UI requests)
       --agui-upstream <url>      Upstream AG-UI agent URL (used with --agui-record)
       --agui-proxy-only          AG-UI proxy mode: forward without saving
@@ -71,6 +73,8 @@ const { values } = parseArgs({
     "provider-azure": { type: "string" },
     "provider-ollama": { type: "string" },
     "provider-cohere": { type: "string" },
+    "upstream-timeout-ms": { type: "string" },
+    "body-timeout-ms": { type: "string" },
     "agui-record": { type: "boolean", default: false },
     "agui-upstream": { type: "string" },
     "agui-proxy-only": { type: "boolean", default: false },
@@ -135,6 +139,30 @@ if (Number.isNaN(fixtureCountsMax) || !Number.isInteger(fixtureCountsMax) || fix
     `Invalid fixture-counts-max: ${fixtureCountsMaxStr} (must be a non-negative integer; 0 = unbounded)`,
   );
   process.exit(1);
+}
+
+const upstreamTimeoutMsStr = values["upstream-timeout-ms"];
+let upstreamTimeoutMs: number | undefined;
+if (upstreamTimeoutMsStr !== undefined) {
+  upstreamTimeoutMs = Number(upstreamTimeoutMsStr);
+  if (!Number.isFinite(upstreamTimeoutMs) || upstreamTimeoutMs <= 0) {
+    console.error(
+      `Invalid upstream-timeout-ms: ${upstreamTimeoutMsStr} (must be a positive finite number)`,
+    );
+    process.exit(1);
+  }
+}
+
+const bodyTimeoutMsStr = values["body-timeout-ms"];
+let bodyTimeoutMs: number | undefined;
+if (bodyTimeoutMsStr !== undefined) {
+  bodyTimeoutMs = Number(bodyTimeoutMsStr);
+  if (!Number.isFinite(bodyTimeoutMs) || bodyTimeoutMs <= 0) {
+    console.error(
+      `Invalid body-timeout-ms: ${bodyTimeoutMsStr} (must be a positive finite number)`,
+    );
+    process.exit(1);
+  }
 }
 
 const logger = new Logger(logLevel);
@@ -215,6 +243,8 @@ if (values.record || values["proxy-only"]) {
     fixturePath: recordBaseIsUrl ? undefined : resolve(recordBase, "recorded"),
     proxyOnly: values["proxy-only"],
     recordFullModelVersion: values["record-full-model-version"],
+    upstreamTimeoutMs,
+    bodyTimeoutMs,
   };
 }
 

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -296,6 +296,7 @@ export async function proxyAndRecord(
       res,
       req.method,
       defaults.logger,
+      { upstreamTimeoutMs: record.upstreamTimeoutMs, bodyTimeoutMs: record.bodyTimeoutMs },
     );
     upstreamStatus = result.status;
     upstreamHeaders = result.headers;
@@ -550,6 +551,11 @@ export async function proxyAndRecord(
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+function clampTimeout(value: number | undefined, fallback: number): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) return fallback;
+  return value;
+}
+
 function makeUpstreamRequest(
   target: URL,
   headers: Record<string, string>,
@@ -557,6 +563,7 @@ function makeUpstreamRequest(
   clientRes?: http.ServerResponse,
   method: string = "POST",
   logger?: Logger,
+  timeouts?: Pick<RecordConfig, "upstreamTimeoutMs" | "bodyTimeoutMs">,
 ): Promise<{
   status: number;
   headers: http.IncomingHttpHeaders;
@@ -567,8 +574,8 @@ function makeUpstreamRequest(
 }> {
   return new Promise((resolve, reject) => {
     const transport = target.protocol === "https:" ? https : http;
-    const UPSTREAM_TIMEOUT_MS = 30_000;
-    const BODY_TIMEOUT_MS = 30_000;
+    const UPSTREAM_TIMEOUT_MS = clampTimeout(timeouts?.upstreamTimeoutMs, 30_000);
+    const BODY_TIMEOUT_MS = clampTimeout(timeouts?.bodyTimeoutMs, 30_000);
     const req = transport.request(
       target,
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -521,6 +521,21 @@ export interface RecordConfig {
    * the poll cadence and timeout here if upstream is unusually slow or fast.
    */
   fal?: FalRecordConfig;
+  /**
+   * Connection idle timeout (ms) on the upstream request socket — fires if the
+   * socket is inactive for this duration at any point before the response body
+   * begins. Default: 30_000 (30s). Increase for upstreams with slow initial
+   * responses (reasoning models, queue-backed providers).
+   */
+  upstreamTimeoutMs?: number;
+  /**
+   * Idle timeout (ms) on the upstream response body — fires if the upstream
+   * goes silent (no bytes) for this long after the response has started.
+   * Default: 30_000 (30s). Reasoning models under concurrent load can leave
+   * 30s+ gaps between streaming chunks while the model is thinking; lift this
+   * to e.g. 180_000 in those setups.
+   */
+  bodyTimeoutMs?: number;
 }
 
 export interface FalRecordConfig {


### PR DESCRIPTION
## Summary

Adds \`RecordConfig.upstreamTimeoutMs\` and \`RecordConfig.bodyTimeoutMs\` so callers can lift the hardcoded 30s ceilings used by the proxy. Defaults stay 30s — back-compat preserved.

## Motivation

Reasoning models (e.g. Grok 4.3 via OpenRouter with \`response_format: json_schema\`) routinely leave 30s+ gaps between SSE chunks during the thinking phase under concurrent load. The hardcoded \`BODY_TIMEOUT_MS = 30_000\` in \`makeUpstreamRequest\` fires \`req.destroy()\` mid-stream, and the captured fixture ends up with no \`[DONE]\` and no \`finish_reason\` — downstream \`JSON.parse(text)\` then blows up on \`Unterminated string\`.

Reproduces deterministically with a 6-way concurrent record run against the same Grok 4.3 + structured-output prompt:

\`\`\`
BEFORE (hardcoded 30s):
  jsonValid: 3/6   elapsed min=23.23s median=30.95s max=31.00s
  3 streams cut off at exactly 30.95–31.00s, no [DONE], no finish_reason

AFTER (bodyTimeoutMs: 180_000):
  jsonValid: 6/6   elapsed min=31.84s median=38.62s max=42.18s
  All 6 finish=stop, all done=true, all JSON valid
\`\`\`

For comparison, the same 6-way load fired direct to OpenRouter (no aimock in the loop) completes 6/6 up to 52s with clean \`[DONE]\` — i.e. the upstream is fine, only the proxy's idle timer was clipping us.

## Change

- \`RecordConfig\`: two new optional numeric fields, documented inline in \`src/types.ts\`.
- \`makeUpstreamRequest\`: optional 7th \`timeouts\` arg, falls back to \`30_000\` for both timers when omitted.
- \`proxyAndRecord\`: threads \`record.upstreamTimeoutMs\` / \`record.bodyTimeoutMs\` into the upstream request.

## Test plan

- [x] Existing \`recorder.test.ts\` "body timeout" test still passes (asserts the default 30_000 is applied when no override is set)
- [x] \`pnpm run build\` clean
- [x] Manual: 6-way concurrent Grok 4.3 streaming record through aimock with \`bodyTimeoutMs: 180_000\` — 6/6 finish=stop, vs 3/6 truncated without the override
- [ ] (Reviewer:) Worth adding a vitest that verifies a custom \`bodyTimeoutMs\` is honoured — happy to add if you'd like before merge

## Back-compat

No behavior change when the new fields are omitted — defaults stay at the original 30_000.