### PR TITLE
fix(ci): limit credential exposure in fix-drift

### DIFF
--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -26,6 +26,8 @@ jobs:
       # issues: write  # removed — no longer creating issues on drift failure
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -126,6 +128,13 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: pnpm test:drift
+
+      # Inject git credentials only when needed for push (persist-credentials: false above)
+      - name: Configure git for push
+        if: steps.autofix.outcome == 'success' && success() && steps.check.outputs.skip != 'true'
+        run: git config --local url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Step 5: Create PR on success
       - name: Create PR

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,13 +5,14 @@
 
 rules:
   # ─── artipacked ────────────────────────────────────────────────────────
-  # These three workflows push back to the repo (commits / tags / branches)
+  # These workflows push back to the repo (commits / tags / branches)
   # using the default `GITHUB_TOKEN`, so `persist-credentials: false` is not
   # an option. The token is scoped per-job and the workflows only run on the
   # `main` branch or via `workflow_dispatch`, never on untrusted PR HEADs.
+  # Note: fix-drift.yml now uses persist-credentials: false with scoped
+  # url.insteadOf injection before push, so it no longer needs suppression.
   artipacked:
     ignore:
-      - fix-drift.yml
       # Dependabot auto-merge: uses pull_request_target for write token.
       # Does NOT checkout PR code. Actor-gated to dependabot[bot].
       - dependabot-auto-merge.yml


### PR DESCRIPTION
## Summary

fix-drift.yml runs Claude Code AI auto-fix with API keys and write-scoped
GITHUB_TOKEN persisted in git config for ~30 minutes. Prompt injection via
crafted repo content could exfiltrate the git credentials.

- Add `persist-credentials: false` to the checkout step so GITHUB_TOKEN is not
  stored in `.git/config` for the duration of the run
- Inject `url.insteadOf` credentials only in the "Configure git for push" step,
  scoped to the PR creation phase (not the 30-minute Claude Code execution)
- Remove `fix-drift.yml` from zizmor `artipacked` suppression list since the
  underlying issue is now fixed

The `fix-drift.ts --create-pr` path uses `git push` directly (via
`execFileSafe`), so the `url.insteadOf` pattern is required. The `gh pr create`
and `gh pr merge` commands use `GH_TOKEN` env var which is already set.