### PR TITLE
fix(ci): persist-credentials: false on remaining workflows

### DIFF
--- a/.github/workflows/changelog-radar.yml
+++ b/.github/workflows/changelog-radar.yml
@@ -16,8 +16,10 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,7 +14,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/update-competitive-matrix.yml
+++ b/.github/workflows/update-competitive-matrix.yml
@@ -20,6 +20,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -40,6 +42,12 @@ jobs:
           else
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Configure git credentials
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --local url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
       - name: Create PR
         if: steps.changes.outputs.changed == 'true'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,12 +5,10 @@
 
 rules:
   # ─── artipacked ────────────────────────────────────────────────────────
-  # These three workflows push back to the repo (commits / tags / branches)
-  # using the default `GITHUB_TOKEN`, so `persist-credentials: false` is not
-  # an option. The token is scoped per-job and the workflows only run on the
-  # `main` branch or via `workflow_dispatch`, never on untrusted PR HEADs.
   artipacked:
     ignore:
+      # fix-drift.yml pushes commits back using GITHUB_TOKEN; persist-credentials:
+      # false would break the push. Token scoped per-job, main-only trigger.
       - fix-drift.yml
       # Dependabot auto-merge: uses pull_request_target for write token.
       # Does NOT checkout PR code. Actor-gated to dependabot[bot].
@@ -18,8 +16,6 @@ rules:
       # Dependabot major analysis: uses pull_request_target for PR comments.
       # Does NOT checkout PR code. Actor-gated to dependabot[bot].
       - dependabot-major-analysis.yml
-      - publish-release.yml
-      - update-competitive-matrix.yml
 
   # ─── dangerous-triggers ────────────────────────────────────────────────
   # `notify-pr.yml` uses `pull_request_target` intentionally: it needs


### PR DESCRIPTION
## Summary
- **update-competitive-matrix.yml**: `persist-credentials: false` + insteadOf credential injection before `git push`
- **changelog-radar.yml**: `persist-credentials: false` (never pushes) + SHA-pin `actions/checkout` and `pnpm/action-setup` (were unpinned `@v4`)
- **publish-release.yml**: `persist-credentials: false` on build job (defense-in-depth; publish job already uses insteadOf)
- **zizmor.yml**: removed artipacked suppressions for `publish-release.yml` and `update-competitive-matrix.yml` (no longer needed)