### PR TITLE
fix(ci): add security-events permission and action.yml to zizmor paths

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,16 +7,19 @@ on:
       - ".github/workflows/**"
       - ".github/actions/**"
       - ".github/zizmor.yml"
+      - "action.yml"
   push:
     branches: [main]
     paths:
       - ".github/workflows/**"
       - ".github/actions/**"
       - ".github/zizmor.yml"
+      - "action.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   zizmor:


### PR DESCRIPTION
Two fixes for the Zizmor workflow:

1. **Add `security-events: write` permission** - The zizmor-action uploads SARIF results via `codeql-action/upload-sarif`, which requires this permission. Without it, every run fails with "Resource not accessible by integration" even when zizmor finds zero issues.

2. **Add `action.yml` to path triggers** - The repo's composite action (`action.yml`) was only scanned on `workflow_dispatch`, not on push/PR changes.