### PR TITLE
Add top-level permissions to changelog-radar workflow

### DIFF
--- a/.github/workflows/changelog-radar.yml
+++ b/.github/workflows/changelog-radar.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 8 * * *" # Daily 8am UTC (1am PT)
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: changelog-radar
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` at the top level of changelog-radar.yml
- Without a top-level permissions block, the workflow inherits the repo's default token permissions (often `write-all`), violating least-privilege

## Test plan
- [ ] Verify the scheduled run still creates issues (job-level `issues: write` is preserved)