### PR TITLE
feat: context-based fixture routing via X-AIMock-Context header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-05-18
+
 ### Added
 
 - **Timing-aware recording and replay** — proxy recording captures per-frame
@@ -13,6 +15,12 @@
   sources (recorded timings, streaming profiles, global latency). Per-fixture
   `replaySpeed` override. Covers SSE, NDJSON, Bedrock EventStream, and
   WebSocket protocols.
+- **Context-based fixture routing** — `X-AIMock-Context` header scopes fixtures per integration. Fixtures with `match.context` only match requests carrying that context; fixtures without `context` remain shared. Recorder auto-captures context and routes recorded fixtures into context subdirectories.
+
+## [1.25.0] - 2026-05-18
+
+### Added
+
 - **Gemini `embedContent` endpoint** — `POST /v1beta/models/{model}:embedContent`
   with deterministic fallback embeddings and fixture matching
 - **`/v1/images/edit` and `/v1/images/variations` endpoints** — multipart

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Run them all on one port with `npx @copilotkit/aimock --config aimock.json`, or 
 - **[MCP](https://aimock.copilotkit.dev/mcp-mock) / [A2A](https://aimock.copilotkit.dev/a2a-mock) / [AG-UI](https://aimock.copilotkit.dev/agui-mock) / [Vector](https://aimock.copilotkit.dev/vector-mock)** — Mock every protocol your AI agents use
 - **[Chaos Testing](https://aimock.copilotkit.dev/chaos-testing)** — 500 errors, malformed JSON, mid-stream disconnects at any probability
 - **Per-Request Strict Mode** — `X-AIMock-Strict` header overrides the server-level `--strict` flag per request (`true`/`1` = strict, `false`/`0` = lenient)
+- **Context-Based Fixture Routing** — `X-AIMock-Context` header scopes fixtures per integration; fixtures with `match.context` only match requests carrying that context, fixtures without it remain shared
 - **[Drift Detection](https://aimock.copilotkit.dev/drift-detection)** — Daily CI validation against real APIs
 - **[Streaming Physics](https://aimock.copilotkit.dev/streaming-physics)** — Configurable `ttft`, `tps`, and `jitter`
 - **[WebSocket APIs](https://aimock.copilotkit.dev/websocket)** — OpenAI Realtime (GA protocol with models: gpt-realtime, gpt-realtime-2, gpt-realtime-1.5, gpt-realtime-mini; transcription/translation via gpt-4o-transcribe, gpt-4o-mini-transcribe, whisper-1; image input; commentary phase), Responses WS, Gemini Live

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -290,6 +290,14 @@
             <p class="highlight-card-desc">One-line CI setup for mock-backed test suites</p>
             <a href="/github-action" class="highlight-card-cta">Setup <span>&rarr;</span></a>
           </div>
+
+          <div class="highlight-card">
+            <span class="highlight-card-title">Context Routing</span>
+            <p class="highlight-card-desc">
+              Scope fixtures per integration with <code>X-AIMock-Context</code> header
+            </p>
+            <a href="/fixtures#context" class="highlight-card-cta">Docs <span>&rarr;</span></a>
+          </div>
         </div>
 
         <!-- ─── The Suite (compact table) ───────────────────────────── -->

--- a/docs/fixtures/index.html
+++ b/docs/fixtures/index.html
@@ -161,6 +161,16 @@
               </td>
             </tr>
             <tr>
+              <td>context</td>
+              <td>string</td>
+              <td>
+                Restrict to a named context via <code>X-AIMock-Context</code> header. Fixtures with
+                <code>context</code> only match requests carrying that exact value; fixtures without
+                <code>context</code> match any request. Same opt-in semantics as
+                <code>endpoint</code>
+              </td>
+            </tr>
+            <tr>
               <td>predicate</td>
               <td>function</td>
               <td>Custom function: (req) => boolean (programmatic only)</td>
@@ -242,14 +252,15 @@
             <code>duplicate userMessage 'hello' — shadows fixture 0</code>, where
             <code>'hello'</code> is the duplicated message and <code>0</code> is the zero-based
             index of the earlier fixture being shadowed. This is advisory, not a hard error: the
-            check now factors in <code>turnIndex</code>, <code>hasToolResult</code>, and
-            <code>sequenceIndex</code> when deciding whether two fixtures truly collide, but it does
-            <em>not</em> consider <code>toolCallId</code>, <code>model</code>, or
-            <code>predicate</code>, so the warning may still fire when those discriminators are
-            present. Treat it as advisory: if a runtime differentiator is in place, the fixtures
-            won't actually shadow each other at match time. Only fixtures with no differentiator at
-            all will truly shadow on match &mdash; that's the case where the second is never reached
-            because the first wins. Safe to ignore in the former case; investigate in the latter.
+            check now factors in <code>turnIndex</code>, <code>hasToolResult</code>,
+            <code>context</code>, and <code>sequenceIndex</code> when deciding whether two fixtures
+            truly collide, but it does <em>not</em> consider <code>toolCallId</code>,
+            <code>model</code>, or <code>predicate</code>, so the warning may still fire when those
+            discriminators are present. Treat it as advisory: if a runtime differentiator is in
+            place, the fixtures won't actually shadow each other at match time. Only fixtures with
+            no differentiator at all will truly shadow on match &mdash; that's the case where the
+            second is never reached because the first wins. Safe to ignore in the former case;
+            investigate in the latter.
           </li>
           <li>
             <strong>Catch-all not last</strong> &mdash; a fixture with an empty <code>match</code>
@@ -510,6 +521,29 @@
             details.
           </p>
         </div>
+
+        <h3 id="context">Context-scoped fixtures</h3>
+        <div class="code-block">
+          <div class="code-block-header">
+            fixtures/context-example.json <span class="lang-tag">json</span>
+          </div>
+          <pre><code>{
+  <span class="key">"fixtures"</span>: [
+    {
+      <span class="key">"match"</span>: { <span class="key">"userMessage"</span>: <span class="str">"hello"</span>, <span class="key">"context"</span>: <span class="str">"langgraph-python"</span> },
+      <span class="key">"response"</span>: { <span class="key">"content"</span>: <span class="str">"Hi from LangGraph!"</span> }
+    },
+    {
+      <span class="key">"match"</span>: { <span class="key">"userMessage"</span>: <span class="str">"hello"</span> },
+      <span class="key">"response"</span>: { <span class="key">"content"</span>: <span class="str">"Hi from the shared fallback!"</span> }
+    }
+  ]
+}</code></pre>
+        </div>
+        <p>
+          Requests with <code>X-AIMock-Context: langgraph-python</code> match the first fixture; all
+          other requests fall through to the shared fixture.
+        </p>
 
         <h3>Programmatically</h3>
         <div class="code-block">

--- a/docs/multi-turn/index.html
+++ b/docs/multi-turn/index.html
@@ -291,7 +291,10 @@
           </p>
         </div>
 
-        <h2>Choosing between sequenceIndex, toolCallId, turnIndex, hasToolResult, and predicate</h2>
+        <h2>
+          Choosing between sequenceIndex, toolCallId, turnIndex, hasToolResult, context, and
+          predicate
+        </h2>
         <p>Five mechanisms handle different shapes of &ldquo;the same prompt twice&rdquo;:</p>
 
         <table class="endpoint-table">
@@ -339,6 +342,15 @@
               <td>
                 Boolean check for <code>role: "tool"</code> presence. Stateless. Does not require
                 pinning a specific <code>tool_call_id</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>Same user prompt, different response per integration or caller identity</td>
+              <td><code>context</code></td>
+              <td>
+                Exact match on the <code>X-AIMock-Context</code> header. Fixtures with
+                <code>context</code> only match requests carrying that value; fixtures without it
+                remain shared. Stateless.
               </td>
             </tr>
             <tr>
@@ -441,6 +453,15 @@
             server-side counter that drifts when multiple test runners share a single aimock
             instance. See <a href="/sequential-responses">Sequential Responses</a> for when
             <code>sequenceIndex</code> is the right tool.
+          </li>
+          <li>
+            <strong><code>context</code> is an additional discriminator, not a replacement.</strong>
+            <code>context</code> scopes fixtures by integration identity (<code
+              >X-AIMock-Context</code
+            >
+            header). It combines with all other match fields via AND. Two fixtures with the same
+            <code>userMessage</code> but different <code>context</code>
+            values are not duplicates &mdash; the validator accounts for this.
           </li>
         </ul>
       </main>

--- a/docs/record-replay/index.html
+++ b/docs/record-replay/index.html
@@ -556,6 +556,49 @@
 });</code></pre>
         </div>
 
+        <h2 id="context-aware-recording">Context-Aware Recording</h2>
+        <p>
+          When a request carries an <code>X-AIMock-Context</code> header, the recorder automatically
+          captures the context value in <code>match.context</code>. On replay, fixtures with
+          <code>context</code> only match requests carrying that exact header value &mdash; fixtures
+          without <code>context</code> remain shared across all callers.
+        </p>
+
+        <h3>Directory routing</h3>
+        <p>
+          Without snapshot-style recording (<code>X-Test-Id</code>), recorded fixtures for a given
+          context are written to a <code>&lt;fixturePath&gt;/&lt;context&gt;/</code> subdirectory:
+        </p>
+
+        <div class="code-block">
+          <div class="code-block-header">
+            Context directory layout <span class="lang-tag">text</span>
+          </div>
+          <pre><code>fixtures/recorded/
+  openai-2026-05-18T10-30-00-000Z-a1b2c3d4.json     # no context (shared)
+  langgraph-python/
+    openai-2026-05-18T10-30-01-000Z-e5f6a7b8.json   # context = langgraph-python
+  crewai/
+    openai-2026-05-18T10-30-02-000Z-c9d0e1f2.json   # context = crewai</code></pre>
+        </div>
+
+        <p>
+          When <code>X-Test-Id</code> is also present, snapshot-style paths take precedence and the
+          context is captured only in <code>match.context</code> within the fixture file, not in the
+          directory structure.
+        </p>
+
+        <h3>Sending <code>X-AIMock-Context</code></h3>
+        <div class="code-block">
+          <div class="code-block-header">Header example <span class="lang-tag">ts</span></div>
+          <pre><code><span class="cm">// Set as a default header on your LLM client</span>
+<span class="kw">const</span> <span class="op">client</span> = <span class="kw">new</span> <span class="fn">OpenAI</span>({
+  <span class="prop">baseURL</span>: <span class="str">"http://localhost:4010/v1"</span>,
+  <span class="prop">apiKey</span>: <span class="str">"mock"</span>,
+  <span class="prop">defaultHeaders</span>: { <span class="str">"X-AIMock-Context"</span>: <span class="str">"langgraph-python"</span> },
+});</code></pre>
+        </div>
+
         <h2 id="upstream-timeouts">Upstream Timeouts</h2>
 
         <p>
@@ -858,7 +901,10 @@ await mock.start();</code></pre>
   }
   <span class="cm">// Chat/multimedia — key on the LAST user message only</span>
   <span class="kw">const</span> lastUser = <span class="fn">getLastMessageByRole</span>(request.messages, <span class="str">"user"</span>);
-  <span class="kw">return</span> { <span class="prop">userMessage</span>: <span class="fn">getTextContent</span>(lastUser.content) };
+  <span class="kw">const</span> match = { <span class="prop">userMessage</span>: <span class="fn">getTextContent</span>(lastUser.content) };
+  <span class="cm">// Capture context from X-AIMock-Context header if present</span>
+  <span class="kw">if</span> (request._context) match.<span class="prop">context</span> = request._context;
+  <span class="kw">return</span> match;
 }</code></pre>
         </div>
 

--- a/src/__tests__/fixture-loader.test.ts
+++ b/src/__tests__/fixture-loader.test.ts
@@ -1006,6 +1006,30 @@ describe("validateFixtures", () => {
     ).toBe(true);
   });
 
+  // --- match.context type checks ---
+
+  it("validateFixtures reports error for non-string context", () => {
+    const fixtures = [
+      makeFixture({ match: { userMessage: "test", context: 42 as unknown as string } }),
+    ];
+    const results = validateFixtures(fixtures);
+    expect(
+      results.some((r) => r.severity === "error" && r.message.includes("must be a string")),
+    ).toBe(true);
+  });
+
+  it("context is a valid discriminator", () => {
+    const fixtures = [
+      makeFixture({ match: { context: "x" } }),
+      makeFixture({ match: { userMessage: "hello" } }),
+    ];
+    const results = validateFixtures(fixtures);
+    const catchAllWarnings = results.filter(
+      (r) => r.severity === "warning" && r.message.includes("catch-all"),
+    );
+    expect(catchAllWarnings).toHaveLength(0);
+  });
+
   // --- Warning checks ---
 
   it("warning: duplicate userMessage", () => {
@@ -1543,6 +1567,15 @@ describe("auto-stringify JSON objects in fixture entries", () => {
     };
     const fixture = entryToFixture(entry);
     expect((fixture.response as TextResponse).content).toBe("Hello, world!");
+  });
+
+  it("entryToFixture preserves context field", () => {
+    const entry: FixtureFileEntry = {
+      match: { context: "my-ctx", userMessage: "hi" },
+      response: { content: "ok" },
+    };
+    const fixture = entryToFixture(entry);
+    expect(fixture.match.context).toBe("my-ctx");
   });
 
   it("passes systemMessage through entryToFixture", () => {

--- a/src/__tests__/helpers.test.ts
+++ b/src/__tests__/helpers.test.ts
@@ -1,3 +1,4 @@
+import http from "node:http";
 import { describe, it, expect } from "vitest";
 import {
   generateId,
@@ -11,6 +12,7 @@ import {
   buildToolCallChunks,
   buildTextCompletion,
   buildToolCallCompletion,
+  getContext,
 } from "../helpers.js";
 
 describe("generateId", () => {
@@ -289,6 +291,32 @@ describe("buildToolCallChunks", () => {
     );
     expect(argChunks.length).toBe(1);
     expect(argChunks[0].choices[0].delta.tool_calls![0].function!.arguments).toBe('{"x":1}');
+  });
+});
+
+describe("getContext", () => {
+  it("returns header value", () => {
+    const req = {
+      headers: { "x-aimock-context": "langgraph-python" },
+    } as unknown as http.IncomingMessage;
+    expect(getContext(req)).toBe("langgraph-python");
+  });
+
+  it("returns undefined when header absent", () => {
+    const req = { headers: {} } as unknown as http.IncomingMessage;
+    expect(getContext(req)).toBeUndefined();
+  });
+
+  it("returns first value from array header", () => {
+    const req = {
+      headers: { "x-aimock-context": ["first", "second"] },
+    } as unknown as http.IncomingMessage;
+    expect(getContext(req)).toBe("first");
+  });
+
+  it("returns undefined for empty string", () => {
+    const req = { headers: { "x-aimock-context": "" } } as unknown as http.IncomingMessage;
+    expect(getContext(req)).toBeUndefined();
   });
 });
 

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Fixture, FixtureFile } from "../types.js";
 import { createServer, type ServerInstance } from "../server.js";
-import { proxyAndRecord, type ProxyCapturedResponse } from "../recorder.js";
+import { proxyAndRecord, buildFixtureMatch, type ProxyCapturedResponse } from "../recorder.js";
 import type { RecordConfig } from "../types.js";
 import { Logger } from "../logger.js";
 import { LLMock } from "../llmock.js";
@@ -4102,6 +4102,29 @@ describe("buildFixtureMatch model recording", () => {
     expect(files.length).toBe(1);
     const fixture = JSON.parse(fs.readFileSync(path.join(localTmpDir, files[0]), "utf-8"));
     expect(fixture.fixtures[0].match.model).toBe("claude-opus-4-20250514");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFixtureMatch context
+// ---------------------------------------------------------------------------
+
+describe("buildFixtureMatch context", () => {
+  it("captures _context in match criteria", () => {
+    const match = buildFixtureMatch({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "hello" }],
+      _context: "langgraph-python",
+    });
+    expect(match.context).toBe("langgraph-python");
+  });
+
+  it("omits context when _context is absent", () => {
+    const match = buildFixtureMatch({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(match.context).toBeUndefined();
   });
 });
 

--- a/src/__tests__/router.test.ts
+++ b/src/__tests__/router.test.ts
@@ -1108,6 +1108,43 @@ describe("matchFixture — hasToolResult", () => {
 });
 
 // ---------------------------------------------------------------------------
+// matchFixture — context matching
+// ---------------------------------------------------------------------------
+
+describe("matchFixture — context matching", () => {
+  it("matches fixture with matching context", () => {
+    const fixture = makeFixture({ context: "foo" });
+    const req = makeReq({ _context: "foo" });
+    expect(matchFixture([fixture], req)).toBe(fixture);
+  });
+
+  it("skips fixture with non-matching context", () => {
+    const fixture = makeFixture({ context: "foo" });
+    const req = makeReq({ _context: "bar" });
+    expect(matchFixture([fixture], req)).toBeNull();
+  });
+
+  it("matches fixture without context regardless of request context", () => {
+    const fixture = makeFixture({});
+    const req = makeReq({ _context: "bar" });
+    expect(matchFixture([fixture], req)).toBe(fixture);
+  });
+
+  it("skips context fixture when request has no context", () => {
+    const fixture = makeFixture({ context: "foo" });
+    const req = makeReq();
+    expect(matchFixture([fixture], req)).toBeNull();
+  });
+
+  it("context fixture wins over shared when listed first", () => {
+    const contextual = makeFixture({ context: "foo" }, { content: "contextual" });
+    const shared = makeFixture({}, { content: "shared" });
+    const req = makeReq({ _context: "foo" });
+    expect(matchFixture([contextual, shared], req)).toBe(contextual);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // matchFixture — first-match-wins
 // ---------------------------------------------------------------------------
 

--- a/src/__tests__/strict-header.test.ts
+++ b/src/__tests__/strict-header.test.ts
@@ -220,6 +220,28 @@ describe("X-AIMock-Strict header integration", () => {
     expect(entries[0].response.strictOverride).toBe(false);
   });
 
+  it("strict mode 503 fires when context filtering removes all matches", async () => {
+    const contextFixture: Fixture = {
+      match: { context: "foo", userMessage: "hello" },
+      response: { content: "Hello from foo context" },
+    };
+    server = await createServer([contextFixture], { port: 0, strict: true });
+
+    // Context "bar" filters out the only fixture → strict 503
+    const mismatched = await httpPost(`${server.url}/v1/chat/completions`, chatRequest("hello"), {
+      "X-AIMock-Context": "bar",
+    });
+    expect(mismatched.status).toBe(503);
+    const body503 = JSON.parse(mismatched.body);
+    expect(body503.error.message).toBe("Strict mode: no fixture matched");
+
+    // Context "foo" matches → 200
+    const matched = await httpPost(`${server.url}/v1/chat/completions`, chatRequest("hello"), {
+      "X-AIMock-Context": "foo",
+    });
+    expect(matched.status).toBe(200);
+  });
+
   it("strict header prevents proxy in record mode", async () => {
     server = await createServer([], {
       port: 0,

--- a/src/bedrock-converse.ts
+++ b/src/bedrock-converse.ts
@@ -25,6 +25,7 @@ import {
   isContentWithToolCallsResponse,
   isErrorResponse,
   flattenHeaders,
+  getContext,
   getTestId,
   resolveResponse,
   resolveStrictMode,
@@ -560,6 +561,7 @@ export async function handleConverse(
 
   const completionReq = converseToCompletionRequest(converseReq, modelId, logger);
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(
@@ -853,6 +855,7 @@ export async function handleConverseStream(
   const completionReq = converseToCompletionRequest(converseReq, modelId, logger);
   completionReq.stream = true;
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -36,6 +36,7 @@ import {
   isContentWithToolCallsResponse,
   isErrorResponse,
   flattenHeaders,
+  getContext,
   getTestId,
   resolveResponse,
   resolveStrictMode,
@@ -388,6 +389,7 @@ export async function handleBedrock(
   // Convert to ChatCompletionRequest for fixture matching
   const completionReq = bedrockToCompletionRequest(bedrockReq, modelId, logger);
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(
@@ -1031,6 +1033,7 @@ export async function handleBedrockStream(
   const completionReq = bedrockToCompletionRequest(bedrockReq, modelId, logger);
   completionReq.stream = true;
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(

--- a/src/cohere.ts
+++ b/src/cohere.ts
@@ -37,6 +37,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse, delay, calculateDelay } from "./sse-writer.js";
@@ -833,6 +834,7 @@ export async function handleCohere(
   // Convert to ChatCompletionRequest for fixture matching
   const completionReq = cohereToCompletionRequest(cohereReq);
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(
@@ -1238,6 +1240,7 @@ export async function handleCohereEmbed(
     messages: [],
     embeddingInput: combinedInput,
     _endpointType: "embedding",
+    _context: getContext(req),
   };
 
   const testId = getTestId(req);

--- a/src/elevenlabs-audio.ts
+++ b/src/elevenlabs-audio.ts
@@ -7,6 +7,7 @@ import {
   serializeErrorResponse,
   flattenHeaders,
   FORMAT_TO_CONTENT_TYPE,
+  getContext,
   getTestId,
   resolveResponse,
   resolveStrictMode,
@@ -65,6 +66,7 @@ export async function handleElevenLabsTTS(
     model: (parsed.model_id as string) ?? "eleven_multilingual_v2",
     messages: [{ role: "user", content: promptText ?? "" }],
     _endpointType: "elevenlabs-tts",
+    _context: getContext(req),
   };
 
   // Validate required field
@@ -316,6 +318,7 @@ export async function handleElevenLabsAudio(
       (subType === "sound-generation" ? "eleven_text_to_sound_v2" : "music_v1"),
     messages: [{ role: "user", content: promptText ?? "" }],
     _endpointType: "audio-gen",
+    _context: getContext(req),
   };
 
   // Validate required field

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -24,6 +24,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse } from "./sse-writer.js";
@@ -119,6 +120,7 @@ export async function handleEmbeddings(
     messages: [],
     embeddingInput: combinedInput,
     _endpointType: "embedding",
+    _context: getContext(req),
   };
 
   const testId = getTestId(req);

--- a/src/fal-audio.ts
+++ b/src/fal-audio.ts
@@ -14,6 +14,7 @@ import {
   serializeErrorResponse,
   flattenHeaders,
   FORMAT_TO_CONTENT_TYPE,
+  getContext,
   getTestId,
   resolveResponse,
   resolveStrictMode,
@@ -297,6 +298,7 @@ async function handleQueueSubmit(
     model: modelId,
     messages: [{ role: "user", content: prompt }],
     _endpointType: "fal-audio",
+    _context: getContext(req),
   };
 
   const fixture = matchFixture(fixtures, syntheticReq, matchCounts, defaults.requestTransform);
@@ -824,6 +826,7 @@ async function handleSyncRun(
     model: modelId,
     messages: [{ role: "user", content: prompt }],
     _endpointType: "fal-audio",
+    _context: getContext(req),
   };
 
   const fixture = matchFixture(fixtures, syntheticReq, matchCounts, defaults.requestTransform);

--- a/src/fal.ts
+++ b/src/fal.ts
@@ -16,6 +16,7 @@ import {
   serializeErrorResponse,
   isJSONResponse,
   flattenHeaders,
+  getContext,
   getTestId,
   resolveResponse,
   resolveStrictMode,
@@ -522,6 +523,7 @@ export async function handleFal(
         model: modelId,
         messages: [{ role: "user", content: prompt || JSON.stringify(parsedBody ?? {}) }],
         _endpointType: "fal",
+        _context: getContext(req),
       };
 
       const matchCounts = journal.getFixtureMatchCountsForTest(testId);

--- a/src/fixture-loader.ts
+++ b/src/fixture-loader.ts
@@ -67,6 +67,7 @@ export function entryToFixture(entry: FixtureFileEntry, logger?: Logger): Fixtur
       ...(entry.match.hasToolResult !== undefined && {
         hasToolResult: entry.match.hasToolResult,
       }),
+      ...(entry.match.context !== undefined && { context: entry.match.context }),
     },
     response: normalizeResponse(entry.response),
     ...(entry.latency !== undefined && { latency: entry.latency }),
@@ -682,6 +683,13 @@ export function validateFixtures(fixtures: Fixture[]): ValidationResult[] {
         });
       }
     }
+    if (f.match.context !== undefined && typeof f.match.context !== "string") {
+      results.push({
+        severity: "error",
+        fixtureIndex: i,
+        message: `match.context must be a string, got ${typeof f.match.context}`,
+      });
+    }
 
     // --- Warning checks ---
 
@@ -690,7 +698,7 @@ export function validateFixtures(fixtures: Fixture[]): ValidationResult[] {
     // but differ on those fields are NOT considered duplicates.
     const um = f.match.userMessage;
     if (typeof um === "string" && um) {
-      const dedupKey = `${um}|${f.match.turnIndex}|${f.match.hasToolResult}|${f.match.sequenceIndex}`;
+      const dedupKey = `${um}|${f.match.turnIndex}|${f.match.hasToolResult}|${f.match.sequenceIndex}|${f.match.context}`;
       const prev = seenUserMessages.get(dedupKey);
       if (prev !== undefined) {
         results.push({
@@ -707,6 +715,7 @@ export function validateFixtures(fixtures: Fixture[]): ValidationResult[] {
     const match = f.match;
     const hasDiscriminator =
       match.endpoint !== undefined ||
+      match.context !== undefined ||
       match.userMessage !== undefined ||
       match.systemMessage !== undefined ||
       match.inputText !== undefined ||

--- a/src/gemini-embeddings.ts
+++ b/src/gemini-embeddings.ts
@@ -26,6 +26,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse } from "./sse-writer.js";
@@ -117,6 +118,7 @@ export async function handleGeminiEmbedContent(
     messages: [],
     embeddingInput: inputText,
     _endpointType: "embedding",
+    _context: getContext(req),
   };
 
   const testId = getTestId(req);

--- a/src/gemini-interactions.ts
+++ b/src/gemini-interactions.ts
@@ -28,6 +28,7 @@ import {
   generateToolCallId,
   flattenHeaders,
   getTestId,
+  getContext,
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
@@ -668,6 +669,7 @@ export async function handleGeminiInteractions(
   // Convert to ChatCompletionRequest for fixture matching
   const completionReq = geminiInteractionsToCompletionRequest(interactionsReq);
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const streaming = interactionsReq.stream !== false; // default true
   const model = completionReq.model;

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -29,6 +29,7 @@ import {
   extractOverrides,
   formatToMime,
   flattenHeaders,
+  getContext,
   getTestId,
   resolveResponse,
   resolveStrictMode,
@@ -632,6 +633,7 @@ export async function handleGemini(
   // Convert to ChatCompletionRequest for fixture matching
   const completionReq = geminiToCompletionRequest(geminiReq, model, streaming);
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -861,6 +861,16 @@ export function getTestId(req: http.IncomingMessage): string {
   return DEFAULT_TEST_ID;
 }
 
+export function getContext(req: http.IncomingMessage): string | undefined {
+  const headerValue = req.headers["x-aimock-context"];
+  if (Array.isArray(headerValue)) {
+    if (headerValue.length > 0 && headerValue[0]) return headerValue[0];
+  } else if (typeof headerValue === "string" && headerValue) {
+    return headerValue;
+  }
+  return undefined;
+}
+
 // ─── Snapshot recording helpers ──────────────────────────────────────────────
 
 /**

--- a/src/images.ts
+++ b/src/images.ts
@@ -5,6 +5,7 @@ import {
   isErrorResponse,
   serializeErrorResponse,
   flattenHeaders,
+  getContext,
   getTestId,
   resolveResponse,
   resolveStrictMode,
@@ -32,11 +33,16 @@ interface GeminiPredictRequest {
   [key: string]: unknown;
 }
 
-function buildSyntheticRequest(model: string, prompt: string): ChatCompletionRequest {
+function buildSyntheticRequest(
+  model: string,
+  prompt: string,
+  context?: string,
+): ChatCompletionRequest {
   return {
     model,
     messages: [{ role: "user", content: prompt }],
     _endpointType: "image",
+    ...(context !== undefined && { _context: context }),
   };
 }
 
@@ -110,7 +116,7 @@ export async function handleImages(
     return;
   }
 
-  const syntheticReq = buildSyntheticRequest(model, prompt);
+  const syntheticReq = buildSyntheticRequest(model, prompt, getContext(req));
   const testId = getTestId(req);
   const fixture = matchFixture(
     fixtures,
@@ -342,7 +348,7 @@ export async function handleImageEdit(
     return;
   }
 
-  const syntheticReq = buildSyntheticRequest(model, prompt);
+  const syntheticReq = buildSyntheticRequest(model, prompt, getContext(req));
   const testId = getTestId(req);
   const fixture = matchFixture(
     fixtures,
@@ -526,7 +532,7 @@ export async function handleImageVariations(
   const model = extractFormField(raw, "model", boundary) ?? "dall-e-2";
 
   // Variations don't have a prompt — use a synthetic placeholder for fixture matching
-  const syntheticReq = buildSyntheticRequest(model, "[variation]");
+  const syntheticReq = buildSyntheticRequest(model, "[variation]", getContext(req));
   const testId = getTestId(req);
   const fixture = matchFixture(
     fixtures,

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -31,6 +31,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse, delay, calculateDelay } from "./sse-writer.js";
@@ -747,6 +748,7 @@ export async function handleMessages(
 
   // Convert to ChatCompletionRequest for fixture matching
   const completionReq = claudeToCompletionRequest(claudeReq);
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -35,6 +35,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse } from "./sse-writer.js";
@@ -539,6 +540,7 @@ export async function handleOllama(
   // Convert to ChatCompletionRequest for fixture matching
   const completionReq = ollamaToCompletionRequest(ollamaReq);
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(
@@ -889,6 +891,7 @@ export async function handleOllamaGenerate(
   // Convert to ChatCompletionRequest for fixture matching
   const completionReq = ollamaGenerateToCompletionRequest(generateReq);
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(
@@ -1212,6 +1215,7 @@ export async function handleOllamaEmbeddings(
     messages: [],
     embeddingInput: inputText,
     _endpointType: "embedding",
+    _context: getContext(req),
   };
 
   const testId = getTestId(req);

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -163,10 +163,10 @@ export function persistFixture(opts: {
     }
   } else {
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    filepath = path.join(
-      fixturePath,
-      `${providerKey}-${timestamp}-${crypto.randomUUID().slice(0, 8)}.json`,
-    );
+    const timestampFile = `${providerKey}-${timestamp}-${crypto.randomUUID().slice(0, 8)}.json`;
+    filepath = fixture.match.context
+      ? path.join(fixturePath, fixture.match.context, timestampFile)
+      : path.join(fixturePath, timestampFile);
   }
 
   const fileWarnings = [
@@ -175,7 +175,7 @@ export function persistFixture(opts: {
   ];
 
   try {
-    fs.mkdirSync(isSnapshotMode ? path.dirname(filepath) : fixturePath, { recursive: true });
+    fs.mkdirSync(path.dirname(filepath), { recursive: true });
 
     // Auth headers are forwarded to upstream but excluded from saved fixtures.
     // The persisted fixture is always the real upstream response, even when
@@ -1274,6 +1274,7 @@ export function buildFixtureMatch(
   endpoint?: EndpointType;
   turnIndex?: number;
   hasToolResult?: boolean;
+  context?: string;
 } {
   const match: {
     userMessage?: string;
@@ -1282,6 +1283,7 @@ export function buildFixtureMatch(
     endpoint?: EndpointType;
     turnIndex?: number;
     hasToolResult?: boolean;
+    context?: string;
   } = {};
 
   // Include endpoint type for multimedia fixtures
@@ -1319,6 +1321,10 @@ export function buildFixtureMatch(
   if (messages.length > 0) {
     match.turnIndex = messages.filter((m) => m.role === "assistant").length;
     match.hasToolResult = messages.some((m) => m.role === "tool");
+  }
+
+  if (request._context) {
+    match.context = request._context;
   }
 
   return match;

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -31,6 +31,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse, delay, calculateDelay } from "./sse-writer.js";
@@ -946,6 +947,7 @@ export async function handleResponses(
   // Convert to ChatCompletionRequest for fixture matching
   const completionReq = responsesToCompletionRequest(responsesReq);
   completionReq._endpointType = "chat";
+  completionReq._context = getContext(req);
 
   const testId = getTestId(req);
   const fixture = matchFixture(

--- a/src/router.ts
+++ b/src/router.ts
@@ -97,6 +97,13 @@ export function matchFixture(
       }
     }
 
+    // context — opt-in exact match against the request's _context field.
+    // If fixture specifies a context, only match requests with that exact context.
+    // If fixture omits context, match any request regardless of _context.
+    if (match.context !== undefined) {
+      if (effective._context !== match.context) continue;
+    }
+
     // userMessage — case-sensitive match against the last user message content.
     // String matching is intentionally case-sensitive so fixture authors can
     // rely on exact string values. This differs from the case-insensitive

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { handleResponses } from "./responses.js";
 import { handleMessages } from "./messages.js";
@@ -486,6 +487,7 @@ async function handleCompletions(
 
   // Set endpoint type once early so router/recorder and journal see it
   body._endpointType = "chat";
+  body._context = getContext(req);
 
   // Match fixture first — chaos resolution depends on fixture-level overrides
   // (headers > fixture.chaos > server defaults), so the fixture has to be

--- a/src/speech.ts
+++ b/src/speech.ts
@@ -10,6 +10,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse } from "./sse-writer.js";
@@ -87,6 +88,7 @@ export async function handleSpeech(
     model: speechReq.model ?? "tts-1",
     messages: [{ role: "user", content: speechReq.input }],
     _endpointType: "speech",
+    _context: getContext(req),
   };
 
   const testId = getTestId(req);

--- a/src/transcription.ts
+++ b/src/transcription.ts
@@ -9,6 +9,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse } from "./sse-writer.js";
@@ -100,6 +101,7 @@ export async function handleTranscription(
     model,
     messages: [],
     _endpointType: endpointType,
+    _context: getContext(req),
   };
 
   const testId = getTestId(req);

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export interface ChatCompletionRequest {
   embeddingInput?: string;
   /** Endpoint type, set by handlers for fixture endpoint filtering. */
   _endpointType?: string;
+  /** Context identifier, set by handlers for fixture context routing. */
+  _context?: string;
   [key: string]: unknown;
 }
 
@@ -105,6 +107,7 @@ export interface FixtureMatch {
     | "realtime"
     | "realtime-transcription"
     | "realtime-translation";
+  context?: string;
 }
 
 // Fixture response types
@@ -406,6 +409,7 @@ export interface FixtureFileEntry {
       | "realtime"
       | "realtime-transcription"
       | "realtime-translation";
+    context?: string;
     // predicate not supported in JSON files
   };
   response: FixtureFileResponse;

--- a/src/video.ts
+++ b/src/video.ts
@@ -9,6 +9,7 @@ import {
   resolveResponse,
   resolveStrictMode,
   strictOverrideField,
+  getContext,
 } from "./helpers.js";
 import { matchFixture } from "./router.js";
 import { writeErrorResponse } from "./sse-writer.js";
@@ -166,6 +167,7 @@ export async function handleVideoCreate(
     model: videoReq.model ?? "sora-2",
     messages: [{ role: "user", content: videoReq.prompt }],
     _endpointType: "video",
+    _context: getContext(req),
   };
 
   const testId = getTestId(req);

--- a/src/ws-gemini-live.ts
+++ b/src/ws-gemini-live.ts
@@ -363,12 +363,21 @@ async function processMessage(
   }
 
   // Build completion request for fixture matching (include new messages speculatively)
+  const geminiContextHeader = defaults.upgradeHeaders?.["x-aimock-context"];
+  const geminiContext =
+    typeof geminiContextHeader === "string"
+      ? geminiContextHeader
+      : Array.isArray(geminiContextHeader) && geminiContextHeader.length > 0
+        ? geminiContextHeader[0]
+        : undefined;
+
   const completionReq: ChatCompletionRequest = {
     model: session.model,
     messages: [...session.conversationHistory, ...newMessages],
     stream: true,
     tools: session.tools.length > 0 ? session.tools : undefined,
     _endpointType: "chat",
+    _context: geminiContext,
   };
 
   const testId = defaults.testId ?? DEFAULT_TEST_ID;

--- a/src/ws-realtime.ts
+++ b/src/ws-realtime.ts
@@ -680,10 +680,19 @@ async function handleResponseCreate(
   };
   const endpointType = endpointTypeMap[session.type] ?? "realtime";
 
+  const realtimeContextHeader = defaults.upgradeHeaders?.["x-aimock-context"];
+  const realtimeContext =
+    typeof realtimeContextHeader === "string"
+      ? realtimeContextHeader
+      : Array.isArray(realtimeContextHeader) && realtimeContextHeader.length > 0
+        ? realtimeContextHeader[0]
+        : undefined;
+
   const completionReq: ChatCompletionRequest = {
     model: session.model,
     messages,
     _endpointType: endpointType,
+    _context: realtimeContext,
   };
 
   const testId = defaults.testId ?? DEFAULT_TEST_ID;

--- a/src/ws-responses.ts
+++ b/src/ws-responses.ts
@@ -173,6 +173,13 @@ async function processMessage(
 
   const completionReq = responsesToCompletionRequest(responsesReq);
   completionReq._endpointType = "chat";
+  const contextHeader = defaults.upgradeHeaders?.["x-aimock-context"];
+  completionReq._context =
+    typeof contextHeader === "string"
+      ? contextHeader
+      : Array.isArray(contextHeader) && contextHeader.length > 0
+        ? contextHeader[0]
+        : undefined;
   const testId = defaults.testId ?? DEFAULT_TEST_ID;
   const fixture = matchFixture(
     fixtures,


### PR DESCRIPTION
## Summary

- Adds `X-AIMock-Context` header support for scoping fixtures per integration — fixtures with `match.context` only match requests carrying that exact context value; fixtures without `context` remain shared
- Injects context extraction in all 21 handler files (28 call sites) — HTTP handlers via `getContext(req)`, WebSocket handlers via `upgradeHeaders` extraction
- Enriches recorder to auto-capture context in `buildFixtureMatch()` and route recorded fixtures into context subdirectories in `persistFixture()`
- Adds context validation in fixture-loader (type check, dedup key, discriminator)
- 15 new tests across 5 test files covering matching, helper extraction, fixture loading, recording, and strict-mode interaction
- Bumps version to 1.26.0 (includes timing-replay from #223)

## Test plan

- [x] 3151 tests pass (90 files)
- [x] TypeScript clean (`tsc --noEmit` — 0 errors)
- [x] Prettier clean
- [x] ESLint clean
- [x] Pre-commit hooks pass on all commits
- [x] CR loop: 7-agent Round 1 + confirmation round — 0 bucket (a) findings on context routing code