### PR TITLE
Split /__aimock/reset into /reset/fixtures and /reset/journal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- `POST /__aimock/reset/fixtures` — full reset (clears fixtures, generation state, and journal).
+- `POST /__aimock/reset/journal` — clears only the request journal, leaving fixtures intact.
+- `aimock-pytest`: `reset_fixtures()` and `reset_journal()` client methods.
+- Control API reference documentation.
+
+### Deprecated
+
+- `POST /__aimock/reset` — now a deprecated alias for `/__aimock/reset/fixtures`; it still performs a full reset but emits a `Deprecation` response header and a `deprecated` field in the body. Use the explicit `/reset/fixtures` or `/reset/journal` routes instead.
+
 ## [1.28.0] - 2026-06-02
 
 ### Added

--- a/docs/control-api/index.html
+++ b/docs/control-api/index.html
@@ -1,0 +1,301 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Control API — aimock</title>
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../style.css" />
+    <script src="/pixels.js" defer></script>
+  </head>
+  <body>
+    <nav class="top-nav">
+      <div class="nav-inner">
+        <div style="display: flex; align-items: center; gap: 1rem">
+          <button
+            class="sidebar-toggle"
+            onclick="document.querySelector('.sidebar').classList.toggle('open')"
+            aria-label="Toggle sidebar"
+          >
+            &#9776;
+          </button>
+          <a href="/" class="nav-brand"> <span class="prompt">$</span> aimock </a>
+        </div>
+        <ul class="nav-links">
+          <li><a href="/">Home</a></li>
+          <li><a href="/docs" style="color: var(--accent)">Docs</a></li>
+          <li>
+            <a href="https://github.com/CopilotKit/aimock" class="gh-link" target="_blank"
+              ><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+              GitHub</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="docs-layout">
+      <aside class="sidebar" id="sidebar"></aside>
+
+      <main class="docs-content">
+        <h1>Control API</h1>
+        <p class="lead">
+          aimock exposes a small HTTP control surface under the <code>/__aimock/*</code> prefix for
+          inspecting recorded traffic and resetting server state between test runs &mdash; no
+          restart required.
+        </p>
+
+        <p>
+          All control routes are exact-match and live alongside your mocked LLM endpoints on the
+          same port. They are intended for use from test harnesses (directly via
+          <code>fetch</code> / <code>curl</code>, or through the
+          <a href="/test-plugins">aimock-pytest</a> client).
+        </p>
+
+        <h2>Route Overview</h2>
+        <table class="endpoint-table">
+          <thead>
+            <tr>
+              <th>Method</th>
+              <th>Path</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>GET</code></td>
+              <td><code>/__aimock/health</code></td>
+              <td>Liveness probe</td>
+            </tr>
+            <tr>
+              <td><code>GET</code></td>
+              <td><code>/__aimock/journal</code></td>
+              <td>Read-only snapshot of recorded requests</td>
+            </tr>
+            <tr>
+              <td><code>POST</code></td>
+              <td><code>/__aimock/fixtures</code></td>
+              <td>Add fixtures at runtime</td>
+            </tr>
+            <tr>
+              <td><code>DELETE</code></td>
+              <td><code>/__aimock/fixtures</code></td>
+              <td>Clear all fixtures</td>
+            </tr>
+            <tr>
+              <td><code>POST</code></td>
+              <td><code>/__aimock/reset/fixtures</code></td>
+              <td>Full reset: fixtures + generation state + journal</td>
+            </tr>
+            <tr>
+              <td><code>POST</code></td>
+              <td><code>/__aimock/reset/journal</code></td>
+              <td>Clear only the request journal</td>
+            </tr>
+            <tr>
+              <td><code>POST</code></td>
+              <td><code>/__aimock/reset</code></td>
+              <td><strong>Deprecated.</strong> Alias for <code>/reset/fixtures</code></td>
+            </tr>
+            <tr>
+              <td><code>POST</code></td>
+              <td><code>/__aimock/error</code></td>
+              <td>Queue a one-shot error injection</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2>Reset Routes</h2>
+        <p>
+          aimock keeps several kinds of in-memory state between requests: the loaded
+          <strong>fixtures</strong>, the per-provider <strong>generation state</strong> (video,
+          fal.ai, and Gemini counters), the <strong>fixture match-counts</strong> (sequence
+          position), and the <strong>request journal</strong> (recorded requests). The reset routes
+          let you clear these selectively &mdash; a full reset clears everything, while a journal
+          reset clears only the recorded requests and leaves the rest intact.
+        </p>
+
+        <div
+          class="callout"
+          style="
+            border: 1px solid var(--warning);
+            border-left-width: 4px;
+            border-radius: 6px;
+            background: var(--bg-card);
+            padding: 1rem 1.25rem;
+            margin: 1.5rem 0;
+          "
+        >
+          <strong style="color: var(--warning)">The footgun this split fixes</strong> &mdash; a
+          caller that wanted a clean journal between test runs used to call
+          <code>POST /__aimock/reset</code> and unintentionally wiped the loaded fixtures too. Every
+          subsequent request then returned <code>no_fixture_match</code> until the server was
+          restarted. If you only want a clean read between runs, use
+          <code>POST /__aimock/reset/journal</code> &mdash; it leaves your fixtures intact.
+        </div>
+
+        <h3>POST /__aimock/reset/fixtures</h3>
+        <p>
+          <strong>Full reset.</strong> Clears the in-memory fixtures, the generation state (video /
+          fal.ai / Gemini counters), <em>and</em> the journal. Use this when you want the server
+          returned to a pristine, fixture-free state.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Full reset <span class="lang-tag">shell</span></div>
+          <pre><code>$ curl -X POST http://localhost:4010/__aimock/reset/fixtures</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Response <span class="lang-tag">json</span></div>
+          <pre><code>{ <span class="prop">"reset"</span>: <span class="kw">true</span> }</code></pre>
+        </div>
+
+        <h3>POST /__aimock/reset/journal</h3>
+        <p>
+          <strong>Journal only.</strong> Clears only the request journal entries. Your loaded
+          fixtures, generation state, and fixture match-counts (sequence position) are preserved, so
+          the next request still matches. This is the recommended call for a clean read between test
+          runs.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">
+            Journal-only reset <span class="lang-tag">shell</span>
+          </div>
+          <pre><code>$ curl -X POST http://localhost:4010/__aimock/reset/journal</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Response <span class="lang-tag">json</span></div>
+          <pre><code>{ <span class="prop">"reset"</span>: <span class="kw">true</span> }</code></pre>
+        </div>
+
+        <h3>POST /__aimock/reset <span style="color: var(--warning)">(Deprecated)</span></h3>
+        <p>
+          <strong>Deprecated alias</strong> for <code>/__aimock/reset/fixtures</code>. It performs
+          the same full reset, but additionally sets a <code>Deprecation: true</code> response
+          header and adds <code>deprecated</code> / <code>deprecation</code> fields to the body.
+          Prefer the explicit <code>/reset/fixtures</code> or <code>/reset/journal</code> routes
+          &mdash; they make the intent (and blast radius) of the reset unambiguous.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Deprecated reset <span class="lang-tag">shell</span></div>
+          <pre><code>$ curl -i -X POST http://localhost:4010/__aimock/reset</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Response <span class="lang-tag">json</span></div>
+          <pre><code><span class="cm">// Deprecation: true   (response header)</span>
+{
+  <span class="prop">"reset"</span>: <span class="kw">true</span>,
+  <span class="prop">"deprecated"</span>: <span class="kw">true</span>,
+  <span class="prop">"deprecation"</span>: <span class="str">"POST /__aimock/reset is deprecated; use POST /__aimock/reset/fixtures (full reset) or POST /__aimock/reset/journal (journal only)"</span>
+}</code></pre>
+        </div>
+
+        <h2>Inspection</h2>
+
+        <h3>GET /__aimock/health</h3>
+        <p>
+          A simple liveness probe. Returns <code>200</code> once the server is accepting requests.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Health check <span class="lang-tag">shell</span></div>
+          <pre><code>$ curl http://localhost:4010/__aimock/health</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Response <span class="lang-tag">json</span></div>
+          <pre><code>{ <span class="prop">"status"</span>: <span class="str">"ok"</span> }</code></pre>
+        </div>
+
+        <h3>GET /__aimock/journal</h3>
+        <p>
+          Returns a read-only snapshot of the recorded request entries as a JSON array. The journal
+          records each incoming request so tests can assert on what was sent. Clearing it does not
+          affect fixtures &mdash; see <code>/__aimock/reset/journal</code> above.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Read the journal <span class="lang-tag">shell</span></div>
+          <pre><code>$ curl http://localhost:4010/__aimock/journal</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Response <span class="lang-tag">json</span></div>
+          <pre><code>[
+  <span class="cm">/* recorded request entries */</span>
+]</code></pre>
+        </div>
+
+        <h2>Fixtures</h2>
+
+        <h3>POST /__aimock/fixtures</h3>
+        <p>
+          Add fixtures at runtime without restarting the server. The body is an object with a
+          <code>"fixtures"</code> array of fixtures to register. Returns the number of fixtures
+          added.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Add fixtures <span class="lang-tag">shell</span></div>
+          <pre><code>$ curl -X POST http://localhost:4010/__aimock/fixtures \
+  -H <span class="str">"Content-Type: application/json"</span> \
+  -d <span class="str">'{ "fixtures": [{ "match": { ... }, "response": { ... } }] }'</span></code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Response <span class="lang-tag">json</span></div>
+          <pre><code>{ <span class="prop">"added"</span>: <span class="num">1</span> }</code></pre>
+        </div>
+
+        <h3>DELETE /__aimock/fixtures</h3>
+        <p>
+          Clears all registered fixtures. Generation state and the journal are left untouched. To
+          clear everything at once, use <code>/__aimock/reset/fixtures</code> instead.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Clear fixtures <span class="lang-tag">shell</span></div>
+          <pre><code>$ curl -X DELETE http://localhost:4010/__aimock/fixtures</code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Response <span class="lang-tag">json</span></div>
+          <pre><code>{ <span class="prop">"cleared"</span>: <span class="kw">true</span> }</code></pre>
+        </div>
+
+        <h2>Error Injection</h2>
+
+        <h3>POST /__aimock/error</h3>
+        <p>
+          Queues a one-shot error injection. The next matching request returns the queued error
+          instead of a normal response, after which the injection is consumed. See
+          <a href="/error-injection">Error Injection</a> for the full request shape and options.
+        </p>
+        <div class="code-block">
+          <div class="code-block-header">Queue an error <span class="lang-tag">shell</span></div>
+          <pre><code>$ curl -X POST http://localhost:4010/__aimock/error \
+  -H <span class="str">"Content-Type: application/json"</span> \
+  -d <span class="str">'{ "status": 429, "body": { "message": "rate limited", "type": "rate_limit_error" } }'</span></code></pre>
+        </div>
+        <div class="code-block">
+          <div class="code-block-header">Response <span class="lang-tag">json</span></div>
+          <pre><code>{ <span class="prop">"queued"</span>: <span class="kw">true</span> }</code></pre>
+        </div>
+      </main>
+      <aside class="page-toc" id="page-toc"></aside>
+    </div>
+    <footer class="docs-footer">
+      <div class="footer-inner">
+        <div class="footer-left"><span>$</span> aimock &middot; MIT License</div>
+        <ul class="footer-links">
+          <li><a href="https://github.com/CopilotKit/aimock" target="_blank">GitHub</a></li>
+          <li>
+            <a href="https://www.npmjs.com/package/@copilotkit/aimock" target="_blank">npm</a>
+          </li>
+        </ul>
+      </div>
+    </footer>
+    <script src="../sidebar.js"></script>
+  </body>
+</html>

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -81,6 +81,7 @@
       title: "Orchestration",
       links: [
         { label: "aimock CLI & Config", href: "/aimock-cli" },
+        { label: "Control API", href: "/control-api" },
         { label: "Docker & Helm", href: "/docker" },
         { label: "GitHub Action", href: "/github-action" },
         { label: "Test Plugins", href: "/test-plugins" },

--- a/packages/aimock-pytest/README.md
+++ b/packages/aimock-pytest/README.md
@@ -64,7 +64,9 @@ aimock.next_error(429, {"message": "Rate limited"})
 
 # Reset
 aimock.clear_fixtures()    # remove all fixtures
-aimock.reset()             # clear fixtures + journal
+aimock.reset_fixtures()    # clear fixtures + generation state (and journal)
+aimock.reset_journal()     # clear only the request journal (fixtures preserved)
+aimock.reset()             # alias for reset_fixtures()
 ```
 
 ## CLI Options

--- a/packages/aimock-pytest/src/aimock_pytest/_server.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_server.py
@@ -218,9 +218,23 @@ class AIMockServer:
         return self
 
     def reset(self) -> AIMockServer:
-        """Clear fixtures, journal, and match counts via ``POST /__aimock/reset``."""
+        """Full reset: clear fixtures + generation state + journal (alias for
+        :meth:`reset_fixtures`)."""
+        return self.reset_fixtures()
+
+    def reset_fixtures(self) -> AIMockServer:
+        """Clear fixtures + generation state (and journal) via
+        ``POST /__aimock/reset/fixtures``."""
         requests.post(
-            f"{self.base_url}/__aimock/reset", timeout=5
+            f"{self.base_url}/__aimock/reset/fixtures", timeout=5
+        ).raise_for_status()
+        return self
+
+    def reset_journal(self) -> AIMockServer:
+        """Clear ONLY the request journal, leaving fixtures intact, via
+        ``POST /__aimock/reset/journal``."""
+        requests.post(
+            f"{self.base_url}/__aimock/reset/journal", timeout=5
         ).raise_for_status()
         return self
 

--- a/packages/aimock-pytest/tests/test_basic.py
+++ b/packages/aimock-pytest/tests/test_basic.py
@@ -69,6 +69,38 @@ def test_reset_clears_fixtures(aimock):
     assert r.status_code == 404
 
 
+def test_reset_journal_preserves_fixtures(aimock):
+    """reset_journal() clears the journal but leaves fixtures intact."""
+    aimock.on_message("hello", {"content": "Hi there!"})
+
+    # Make a matching request so the journal records an entry.
+    r = requests.post(
+        f"{aimock.base_url}/v1/chat/completions",
+        json={
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+    assert r.status_code == 200
+    assert len(aimock.get_journal()) > 0
+
+    aimock.reset_journal()
+
+    # Journal cleared...
+    assert aimock.get_journal() == []
+
+    # ...but the fixture is preserved: the same matching request still hits it.
+    r = requests.post(
+        f"{aimock.base_url}/v1/chat/completions",
+        json={
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["choices"][0]["message"]["content"] == "Hi there!"
+
+
 def test_on_system_message_string(aimock):
     """on_system_message with a single-substring pattern gates on the system text."""
     aimock.on_system_message(

--- a/src/__tests__/control-api.test.ts
+++ b/src/__tests__/control-api.test.ts
@@ -200,9 +200,85 @@ describe("/__aimock control API", () => {
 
       const res = await httpRequest(`${instance.url}/__aimock/reset`, "POST");
       expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toMatchObject({ reset: true });
+      expect(fixtures.length).toBe(0);
+      expect(instance.journal.size).toBe(0);
+    });
+  });
+
+  describe("POST /__aimock/reset routes", () => {
+    it("POST /__aimock/reset/fixtures clears fixtures and journal", async () => {
+      const fixtures: Fixture[] = [
+        { match: { userMessage: "hello" }, response: { content: "Hi" } },
+      ];
+      instance = await createServer(fixtures);
+
+      // Make a request to populate journal
+      await httpRequest(`${instance.url}/v1/chat/completions`, "POST", chatRequest("hello"));
+      expect(instance.journal.size).toBeGreaterThan(0);
+
+      const res = await httpRequest(`${instance.url}/__aimock/reset/fixtures`, "POST");
+      expect(res.status).toBe(200);
       expect(JSON.parse(res.body)).toEqual({ reset: true });
       expect(fixtures.length).toBe(0);
       expect(instance.journal.size).toBe(0);
+    });
+
+    it("POST /__aimock/reset/journal clears journal but preserves fixtures", async () => {
+      const fixtures: Fixture[] = [
+        { match: { userMessage: "hello" }, response: { content: "Hi" } },
+      ];
+      instance = await createServer(fixtures);
+
+      // Make a request to populate journal
+      await httpRequest(`${instance.url}/v1/chat/completions`, "POST", chatRequest("hello"));
+      expect(instance.journal.size).toBeGreaterThan(0);
+
+      const before = fixtures.length;
+      expect(before).toBeGreaterThan(0);
+      const res = await httpRequest(`${instance.url}/__aimock/reset/journal`, "POST");
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ reset: true });
+      expect(fixtures.length).toBe(before); // fixtures preserved
+      expect(instance.journal.size).toBe(0); // journal cleared
+    });
+
+    it("POST /__aimock/reset/journal preserves fixture match-counts while clearing entries", async () => {
+      const fixtures: Fixture[] = [
+        { match: { userMessage: "hello" }, response: { content: "Hi" } },
+      ];
+      instance = await createServer(fixtures);
+
+      // Make a request so the journal records an entry AND the fixture's
+      // match-count is incremented to a non-zero value.
+      await httpRequest(`${instance.url}/v1/chat/completions`, "POST", chatRequest("hello"));
+      expect(instance.journal.size).toBeGreaterThan(0);
+      const countBefore = instance.journal.getFixtureMatchCount(fixtures[0]);
+      expect(countBefore).toBeGreaterThan(0);
+
+      // Reset ONLY the journal.
+      const res = await httpRequest(`${instance.url}/__aimock/reset/journal`, "POST");
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ reset: true });
+
+      // Journal entries cleared, but the fixture match-count must survive —
+      // clearing the journal must not rewind sequenced fixtures to index 0.
+      expect(instance.journal.size).toBe(0);
+      expect(instance.journal.getFixtureMatchCount(fixtures[0])).toBe(countBefore);
+    });
+
+    it("POST /__aimock/reset is a deprecated alias that still performs a full reset", async () => {
+      const fixtures: Fixture[] = [
+        { match: { userMessage: "hello" }, response: { content: "Hi" } },
+      ];
+      instance = await createServer(fixtures);
+
+      const res = await httpRequest(`${instance.url}/__aimock/reset`, "POST");
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body).toMatchObject({ reset: true, deprecated: true });
+      expect(typeof body.deprecation).toBe("string");
+      expect(fixtures.length).toBe(0);
     });
   });
 

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -198,6 +198,17 @@ export class Journal {
     }
   }
 
+  /**
+   * Clear ONLY the request journal entries, preserving fixture match-counts.
+   * Match-counts are fixture-matching/sequencing state, not journal data, so
+   * clearing the journal must not silently rewind sequenced fixtures. Used by
+   * `POST /__aimock/reset/journal`. For a full reset (entries + match-counts),
+   * use `clear()` instead.
+   */
+  clearEntries(): void {
+    this.entries = [];
+  }
+
   clear(): void {
     this.entries = [];
     this.fixtureMatchCountsByTestId.clear();

--- a/src/server.ts
+++ b/src/server.ts
@@ -214,6 +214,30 @@ function handleNotFound(res: http.ServerResponse, message: string): void {
 const CONTROL_PREFIX = "/__aimock";
 
 /**
+ * Perform a full fixtures reset: clear the fixtures array, journal, video/fal
+ * generation state, and the interaction/event-id counters, then zero the
+ * `aimock_fixtures_loaded` gauge. Shared by `/reset/fixtures` and the
+ * deprecated `/reset` alias.
+ */
+function performFixturesReset(
+  fixtures: Fixture[],
+  journal: Journal,
+  videoStates: VideoStateMap,
+  defaults: HandlerDefaults,
+): void {
+  fixtures.length = 0;
+  journal.clear();
+  videoStates.clear();
+  falJobs.clear();
+  falQueueStates.clear();
+  resetInteractionCounter();
+  resetEventIdCounter();
+  if (defaults.registry) {
+    defaults.registry.setGauge("aimock_fixtures_loaded", {}, fixtures.length);
+  }
+}
+
+/**
  * Handle requests under `/__aimock/`. Returns `true` if the request was
  * handled, `false` if the path doesn't match the control prefix.
  */
@@ -304,20 +328,33 @@ async function handleControlAPI(
     return true;
   }
 
-  // POST /__aimock/reset — clear fixtures + journal + match counts
-  if (subPath === "/reset" && req.method === "POST") {
-    fixtures.length = 0;
-    journal.clear();
-    videoStates.clear();
-    falJobs.clear();
-    falQueueStates.clear();
-    resetInteractionCounter();
-    resetEventIdCounter();
-    if (defaults.registry) {
-      defaults.registry.setGauge("aimock_fixtures_loaded", {}, fixtures.length);
-    }
+  // POST /__aimock/reset/fixtures — full reset (fixtures + journal + match counts)
+  if (subPath === "/reset/fixtures" && req.method === "POST") {
+    performFixturesReset(fixtures, journal, videoStates, defaults);
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ reset: true }));
+    return true;
+  }
+
+  // POST /__aimock/reset/journal — clear only the request journal entries,
+  // preserving fixture match-counts (sequencing state stays intact)
+  if (subPath === "/reset/journal" && req.method === "POST") {
+    journal.clearEntries();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ reset: true }));
+    return true;
+  }
+
+  // POST /__aimock/reset — DEPRECATED alias for /reset/fixtures (full reset)
+  if (subPath === "/reset" && req.method === "POST") {
+    performFixturesReset(fixtures, journal, videoStates, defaults);
+    const deprecation =
+      "POST /__aimock/reset is deprecated; use POST /__aimock/reset/fixtures (full reset) or POST /__aimock/reset/journal (journal only)";
+    defaults.logger.warn(
+      "POST /__aimock/reset is deprecated; use /__aimock/reset/fixtures or /__aimock/reset/journal",
+    );
+    res.writeHead(200, { "Content-Type": "application/json", Deprecation: "true" });
+    res.end(JSON.stringify({ reset: true, deprecated: true, deprecation }));
     return true;
   }
 


### PR DESCRIPTION
## Summary

Closes #244.

`POST /__aimock/reset` was ambiguous and a footgun: a caller intending to reset only the request **journal** (a clean read between test runs) would unintentionally wipe the loaded **fixtures**, after which aimock returned `no_fixture_match` for every request until restart. This splits the destructive reset surface into explicit routes:

- **`POST /__aimock/reset/fixtures`** — full reset: clears fixtures, generation state (video/fal/gemini counters), and the journal. This is the previous `/__aimock/reset` behavior.
- **`POST /__aimock/reset/journal`** — clears **only** the request journal entries, preserving loaded fixtures *and* fixture match-counts (so sequenced fixtures are not rewound to index 0).
- **`POST /__aimock/reset`** — deprecated alias for `/reset/fixtures`; still performs a full reset but emits a `Deprecation: true` response header and `deprecated`/`deprecation` fields in the body.

Updated alongside (docs/client in lockstep):

- **aimock-pytest client**: new `reset_fixtures()` and `reset_journal()`; `reset()` repointed to `reset_fixtures()` so it no longer hits the deprecated path.
- **Docs**: new `docs/control-api/index.html` reference page documenting every `/__aimock/*` control route, with a callout explaining the footgun this split fixes. Wired into the sidebar.

## Release

**No version bump in this PR.** The changes are recorded under CHANGELOG `[Unreleased]` and land on `main` un-released; they will be published with the next meaningful release (which will bump `package.json`, the Helm chart `appVersion`, the aimock-pytest package, and align `_version.py` together).

## Implementation notes

- The shared `performFixturesReset()` helper backs both `/reset/fixtures` and the deprecated `/reset`, so they cannot drift.
- `/reset/journal` uses a new `Journal.clearEntries()` (entries-only) rather than `Journal.clear()` (entries + match-counts), which is what preserves sequence position.

## Test plan

- [x] `pnpm test` — 3351 passed, 0 failed
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` — succeeds
- [x] aimock-pytest suite — 11 passed (run against the locally-built CLI via `AIMOCK_CLI_PATH`)
- [x] Red-green: new TS tests for all three routes (incl. deprecation envelope) and a test proving `/reset/journal` preserves match-counts; new pytest `test_reset_journal_preserves_fixtures`.

## Follow-ups (out of scope)

- **aimock-pytest `add_fixture` silently drops per-fixture options**: `**opts` (latency/chunkSize/sequenceIndex/chaos/…) are nested under an `opts` key the server ignores (it reads them top-level). Pre-existing, unrelated to the reset split — recommend a dedicated fix.
- Node engine floor mismatch: root `engines.node ">=24"` vs aimock-pytest's documented/enforced `>=20`. Pre-existing inconsistency worth reconciling.
- When the next release is cut, align `aimock-pytest` `_version.py` default-download to the published version that contains these routes.