### PR TITLE
aimock followups: pytest option forwarding, startup hardening, journal-clear, engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - `aimock-pytest`: `reset_fixtures()` and `reset_journal()` client methods.
 - Control API reference documentation.
 
+### Changed
+
+- `engines.node` lowered to `>=20.15.0`. The runtime supports Node 20 (the published CLI runs on Node 20/22/24); the previous `>=24.0.0` floor reflected an OIDC publish-time requirement, which is a CI concern handled by the publish workflow, not a runtime constraint for consumers.
+
 ### Deprecated
 
 - `POST /__aimock/reset` — now a deprecated alias for `/__aimock/reset/fixtures`; it still performs a full reset but emits a `Deprecation` response header and a `deprecated` field in the body. Use the explicit `/reset/fixtures` or `/reset/journal` routes instead.
@@ -16,6 +20,9 @@
 ### Fixed
 
 - **Video** — `POST /v1/videos` (`videos.create`) now parses `multipart/form-data` bodies. The OpenAI SDK (>=6.28.0) sends video-create requests as multipart instead of JSON (even for File-less bodies), which previously returned a `400 invalid_json`. The handler reuses the existing transcription multipart field parser and preserves the JSON path for older SDKs.
+- `aimock-pytest`: per-fixture options passed via `add_fixture`/`on_message`/etc. (`latency`, `chunkSize`, `sequenceIndex`, `chaos`, …) are now forwarded in the correct wire shape. They were previously nested under an `opts` key the server ignored, so they were silently dropped.
+- `aimock-pytest`: `_wait_for_ready` now honors its startup timeout (a background reader thread drains the child's stdout, so a no-output child can no longer hang past the deadline or deadlock on a full pipe buffer), tears down the subprocess on a startup failure, and surfaces the child's captured output (the health-check failure path also reports accurate elapsed time).
+- `DELETE /v1/_requests` now clears only the request-journal entries, preserving fixture match-counts (so sequenced fixtures are not rewound) — consistent with `POST /__aimock/reset/journal`.
 
 ## [1.28.0] - 2026-06-02
 

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -109,13 +109,20 @@
   // ─── Build Sidebar HTML ─────────────────────────────────────────
   function buildSidebar() {
     var html = "";
+    // Only the first link matching the current page gets `.active`, so
+    // duplicate hrefs across sections don't highlight more than one entry.
+    var activeMarked = false;
     for (var i = 0; i < sections.length; i++) {
       var section = sections[i];
       html += '<div class="sidebar-section">';
       html += "<h3>" + section.title + "</h3>";
       for (var j = 0; j < section.links.length; j++) {
         var link = section.links[j];
-        var activeClass = link.href === currentPage ? ' class="active"' : "";
+        var activeClass = "";
+        if (!activeMarked && link.href === currentPage) {
+          activeClass = ' class="active"';
+          activeMarked = true;
+        }
         html += '<a href="' + link.href + '"' + activeClass + ">" + link.label + "</a>";
       }
       html += "</div>";
@@ -142,16 +149,41 @@
     var headings = content.querySelectorAll("h2, h3");
 
     // Always assign ids so cross-page anchors resolve, even on short pages.
+    // Two-pass: reserve every hardcoded id first so an earlier bare heading
+    // can't claim a bare slug that a later hardcoded id needs (which would
+    // produce two elements sharing the same id).
+    var usedIds = {};
+
+    // First pass: reserve all pre-existing (hardcoded) ids up front.
     for (var i = 0; i < headings.length; i++) {
-      var h = headings[i];
-      if (!h.id) {
-        h.id = h.textContent
-          .toLowerCase()
-          .replace(/[^a-z0-9\s-]/g, "")
-          .replace(/\s+/g, "-")
-          .replace(/-+/g, "-")
-          .replace(/^-|-$/g, "");
+      if (headings[i].id) {
+        usedIds[headings[i].id] = true;
       }
+    }
+
+    // Second pass: generate slugs for headings without an id, de-duplicating
+    // against the now-fully-populated set (hardcoded ids + earlier auto ids).
+    for (var p = 0; p < headings.length; p++) {
+      var h = headings[p];
+      if (h.id) continue;
+      var slug = h.textContent
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, "")
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "");
+      // Fall back to a stable id when the heading slugifies to nothing.
+      if (!slug) slug = "section";
+      // De-duplicate so identical (or identically-slugifying) headings
+      // don't collide — append -2, -3, … on each repeat.
+      var uniqueSlug = slug;
+      var n = 2;
+      while (usedIds[uniqueSlug]) {
+        uniqueSlug = slug + "-" + n;
+        n++;
+      }
+      usedIds[uniqueSlug] = true;
+      h.id = uniqueSlug;
     }
 
     // TOC rendering requires at least 4 headings to be worth the space.
@@ -204,8 +236,8 @@
       { rootMargin: "-80px 0px -60% 0px", threshold: 0 },
     );
 
-    for (var p = 0; p < headingEls.length; p++) {
-      observer.observe(headingEls[p]);
+    for (var r = 0; r < headingEls.length; r++) {
+      observer.observe(headingEls[r]);
     }
 
     // Set initial active state

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "packageManager": "pnpm@10.28.2",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=20.15.0"
   },
   "type": "module",
   "exports": {

--- a/packages/aimock-pytest/src/aimock_pytest/_server.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_server.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import atexit
 import json
 import os
+import queue
 import re
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -31,6 +33,16 @@ class AIMockServer:
         self.fixtures_path = fixtures_path
         self._proc: subprocess.Popen[str] | None = None
         self._base_url: str | None = None
+        # Background stdout drainer state. The reader thread continuously
+        # consumes the child's stdout so (a) readiness detection can enforce
+        # a real timeout instead of blocking on readline(), and (b) a long
+        # run never deadlocks on a full stdout pipe buffer.
+        self._stdout_queue: queue.Queue[str | None] = queue.Queue()
+        self._reader_thread: threading.Thread | None = None
+        # Path to a temp fixtures dir we create when no fixtures_path is
+        # supplied; ``None`` until ``start()`` creates one. Always defined so
+        # ``stop()`` can clean up without a ``hasattr`` guard.
+        self._tmp_fixtures: str | None = None
 
     # ── lifecycle ───────────────────────────────────────────────────────
 
@@ -77,8 +89,31 @@ class AIMockServer:
         )
         atexit.register(self.stop)
 
+        # Start draining stdout immediately so the pipe never fills and the
+        # readiness wait can poll lines with a real deadline.
+        self._reader_thread = threading.Thread(
+            target=self._drain_stdout,
+            args=(self._proc.stdout,),
+            daemon=True,
+        )
+        self._reader_thread.start()
+
         self._base_url = self._wait_for_ready(timeout=15)
         return self._base_url
+
+    def _drain_stdout(self, stream: Any) -> None:
+        """Continuously read the child's stdout, forwarding each line to the
+        queue. Runs for the whole process lifetime so the stdout pipe buffer
+        never fills (which would otherwise deadlock the child). Pushes a
+        sentinel ``None`` when the stream closes (process exit)."""
+        try:
+            for line in iter(stream.readline, ""):
+                self._stdout_queue.put(line)
+        except (ValueError, OSError):
+            # Stream closed underneath us during shutdown.
+            pass
+        finally:
+            self._stdout_queue.put(None)
 
     def stop(self) -> None:
         """Terminate the aimock subprocess."""
@@ -96,8 +131,13 @@ class AIMockServer:
                     pass
             finally:
                 self._proc = None
+        # The reader thread is a daemon and exits on its own once the stdout
+        # stream closes; give it a brief moment to wind down.
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=1)
+            self._reader_thread = None
         # Clean up temp fixtures directory if we created one
-        if hasattr(self, "_tmp_fixtures") and self._tmp_fixtures:
+        if self._tmp_fixtures:
             import shutil
 
             shutil.rmtree(self._tmp_fixtures, ignore_errors=True)
@@ -116,7 +156,42 @@ class AIMockServer:
         """Alias for :attr:`base_url`."""
         return self.base_url
 
+    # Seconds to wait for the health check to pass once the child logs its
+    # listening URL. Used both to compute the health deadline and in the
+    # failure message, so the window is named in a single place.
+    _HEALTH_TIMEOUT_S = 3.0
+
     # ── control API methods ─────────────────────────────────────────────
+
+    # Match-level option keys. These belong under the fixture's ``match``
+    # block: the server reads exactly these fields from ``entry.match`` in
+    # ``entryToFixture`` (src/fixture-loader.ts). This set MUST track that
+    # function's match keys — if the server starts reading another field from
+    # ``entry.match``, add it here, or a kwarg opt with that name will be
+    # spread to the top level and silently dropped (over-broad matching).
+    #
+    # The list below is illustrative-but-must-stay-complete, NOT a validated
+    # or closed allow-list: any kwarg whose key is NOT in this set still
+    # spreads onto the top-level entry (that is how fixture-level options such
+    # as ``latency``, ``chunkSize``, ``truncateAfterChunks``,
+    # ``disconnectAfterMs``, ``streamingProfile``, ``recordedTimings``,
+    # ``replaySpeed``, ``chaos`` and ``metadata`` reach the server).
+    _MATCH_LEVEL_OPT_KEYS = frozenset(
+        {
+            "userMessage",
+            "systemMessage",
+            "inputText",
+            "toolCallId",
+            "toolName",
+            "model",
+            "responseFormat",
+            "endpoint",
+            "sequenceIndex",
+            "turnIndex",
+            "hasToolResult",
+            "context",
+        }
+    )
 
     def add_fixture(
         self,
@@ -124,10 +199,24 @@ class AIMockServer:
         response: dict[str, Any],
         **opts: Any,
     ) -> None:
-        """Add a single fixture via ``POST /__aimock/fixtures``."""
-        fixture: dict[str, Any] = {"match": match, "response": response}
-        if opts:
-            fixture["opts"] = opts
+        """Add a single fixture via ``POST /__aimock/fixtures``.
+
+        ``**opts`` are routed to the wire shape the server actually reads:
+        fixture-level options (e.g. ``latency``, ``chunkSize``, ``chaos``,
+        ``streamingProfile``) are spread onto the top-level entry, while
+        match-level options (any key the server reads from ``entry.match`` —
+        e.g. ``model``, ``toolName``, ``sequenceIndex``, ``turnIndex``,
+        ``hasToolResult``; see :data:`_MATCH_LEVEL_OPT_KEYS`) are merged into
+        the ``match`` block. There is no ``opts`` wrapper key in the server's
+        fixture schema.
+        """
+        fixture_match = dict(match)
+        fixture: dict[str, Any] = {"match": fixture_match, "response": response}
+        for key, value in opts.items():
+            if key in self._MATCH_LEVEL_OPT_KEYS:
+                fixture_match[key] = value
+            else:
+                fixture[key] = value
         r = requests.post(
             f"{self.base_url}/__aimock/fixtures",
             json={"fixtures": [fixture]},
@@ -149,9 +238,10 @@ class AIMockServer:
         self,
         pattern: str,
         response: dict[str, Any],
+        **opts: Any,
     ) -> AIMockServer:
         """Convenience: add a fixture matching ``inputText``."""
-        self.add_fixture({"inputText": pattern}, response)
+        self.add_fixture({"inputText": pattern}, response, **opts)
         return self
 
     def on_system_message(
@@ -264,44 +354,112 @@ class AIMockServer:
 
     # ── internal ────────────────────────────────────────────────────────
 
+    def _drain_collected(self) -> str:
+        """Non-blocking drain of whatever stdout lines are currently queued.
+
+        Used when building a startup-failure error message so the child's
+        captured output is surfaced. Does not block waiting for more output —
+        it only consumes what the reader thread has already enqueued. A
+        sentinel ``None`` (stream closed) is left intact for callers that
+        still need to observe process exit; only string lines are returned."""
+        lines: list[str] = []
+        while True:
+            try:
+                item = self._stdout_queue.get_nowait()
+            except queue.Empty:
+                break
+            if item is None:
+                # Preserve the exit sentinel; we don't consume it here.
+                self._stdout_queue.put(None)
+                break
+            lines.append(item)
+        return "".join(lines)
+
     def _wait_for_ready(self, timeout: int = 15) -> str:
-        """Read stdout lines until we see the listening URL, then verify via
-        health check."""
+        """Poll the background-drained stdout lines until we see the listening
+        URL, then verify via health check. Honors ``timeout`` strictly: the
+        deadline loop never blocks indefinitely because lines arrive via the
+        reader thread's queue rather than a blocking ``readline()``.
+
+        On any startup failure (process exit, health-check failure, or
+        readiness timeout) the subprocess is torn down via :meth:`stop`
+        before the ``RuntimeError`` propagates, so a half-started child and
+        its bound port never leak when ``start()`` raises (the pytest fixture
+        teardown never runs in that case)."""
+        try:
+            return self._wait_for_ready_inner(timeout)
+        except Exception:
+            # Tear down the half-started child so it (and its bound port) do
+            # not leak for the rest of the session. ``stop`` is idempotent
+            # and guards against a missing/already-reaped process.
+            self.stop()
+            raise
+
+    def _wait_for_ready_inner(self, timeout: int) -> str:
         assert self._proc is not None
-        assert self._proc.stdout is not None
 
         deadline = time.monotonic() + timeout
+        collected: list[str] = []
         while time.monotonic() < deadline:
-            # Check if process exited
-            if self._proc.poll() is not None:
-                remaining = ""
-                if self._proc.stdout:
-                    remaining = self._proc.stdout.read()
+            # Drain whatever startup output the reader thread has captured,
+            # bounded by the remaining time so we never block past the
+            # deadline.
+            try:
+                line = self._stdout_queue.get(
+                    timeout=max(0.0, deadline - time.monotonic())
+                )
+            except queue.Empty:
+                break
+
+            if line is None:
+                # Sentinel: stdout closed → the process exited.
+                self._proc.wait()
+                output = "".join(collected)
                 raise RuntimeError(
                     f"aimock process exited with code {self._proc.returncode}"
-                    f"{': ' + remaining if remaining else ''}"
+                    f"{': ' + output if output else ''}"
                 )
 
-            line = self._proc.stdout.readline()
-            if not line:
-                continue
+            collected.append(line)
 
             m = re.search(r"listening on (http://\S+)", line)
             if m:
                 url = m.group(1).rstrip("/")
-                # Verify health endpoint is reachable
-                for _ in range(30):
+                start = time.monotonic()
+                health_deadline = start + self._HEALTH_TIMEOUT_S
+                attempts = 0
+                while time.monotonic() < health_deadline:
+                    attempts += 1
                     try:
                         r = requests.get(
                             f"{url}/__aimock/health", timeout=0.5
                         )
                         if r.status_code == 200:
                             return url
-                        time.sleep(0.1)
                     except requests.RequestException:
+                        pass
+                    # Don't sleep past the health window: only back off if the
+                    # next attempt would still fall inside the deadline.
+                    if time.monotonic() + 0.1 < health_deadline:
                         time.sleep(0.1)
+                    else:
+                        break
+                elapsed = time.monotonic() - start
+                # Surface any further stdout the child emitted after the
+                # "listening on" line (e.g. a crash trace) to aid diagnosis.
+                collected.append(self._drain_collected())
+                output = "".join(collected)
                 raise RuntimeError(
-                    "aimock started but health check failed after 3 seconds"
+                    f"aimock started but health check failed after "
+                    f"{attempts} attempt(s) over {elapsed:.1f}s"
+                    f"{': ' + output if output else ''}"
                 )
 
-        raise RuntimeError(f"aimock did not start within {timeout}s")
+        # Readiness timeout: include whatever startup output was captured so
+        # a silent/slow child isn't an opaque failure.
+        collected.append(self._drain_collected())
+        output = "".join(collected)
+        raise RuntimeError(
+            f"aimock did not start within {timeout}s"
+            f"{': ' + output if output else ''}"
+        )

--- a/packages/aimock-pytest/src/aimock_pytest/plugin.py
+++ b/packages/aimock-pytest/src/aimock_pytest/plugin.py
@@ -5,6 +5,8 @@ Auto-discovered by pytest via the ``pytest11`` entry point in pyproject.toml.
 
 from __future__ import annotations
 
+from collections.abc import Generator
+
 import pytest
 
 from aimock_pytest._version import AIMOCK_VERSION
@@ -36,20 +38,20 @@ def _aimock_node_manager(request: pytest.FixtureRequest) -> NodeManager:
 
 
 @pytest.fixture
-def aimock(_aimock_node_manager: NodeManager) -> AIMockServer:
+def aimock(_aimock_node_manager: NodeManager) -> Generator[AIMockServer, None, None]:
     """Function-scoped aimock server.  A fresh server is started for every
     test that requests this fixture, and torn down afterwards."""
     server = AIMockServer(_aimock_node_manager, port=0)
     server.start()
-    yield server  # type: ignore[misc]
+    yield server
     server.stop()
 
 
 @pytest.fixture(scope="session")
-def aimock_session(_aimock_node_manager: NodeManager) -> AIMockServer:
+def aimock_session(_aimock_node_manager: NodeManager) -> Generator[AIMockServer, None, None]:
     """Session-scoped aimock server.  One server is shared across all tests
     that request this fixture."""
     server = AIMockServer(_aimock_node_manager, port=0)
     server.start()
-    yield server  # type: ignore[misc]
+    yield server
     server.stop()

--- a/packages/aimock-pytest/tests/test_basic.py
+++ b/packages/aimock-pytest/tests/test_basic.py
@@ -281,3 +281,55 @@ def test_match_level_kwarg_opt_routed_under_match():
 
     # ...and must NOT leak to the top level where the server ignores it.
     assert "model" not in entry
+
+
+def test_match_level_opt_keys_match_server_schema():
+    """Drift guard: ``_MATCH_LEVEL_OPT_KEYS`` must cover every match-level
+    field the server reads from ``entry.match`` in ``entryToFixture``.
+
+    The server (``src/fixture-loader.ts``) reads each match-level constraint as
+    ``entry.match.<key>``. If a new such field is added server-side but not to
+    ``_MATCH_LEVEL_OPT_KEYS``, the Python client silently spreads it to the top
+    level of the entry — where the server ignores it — so the constraint is
+    dropped and matching becomes over-broad. This test fails loudly when that
+    happens.
+
+    The guard is repo/CI-only: when the TypeScript source is unavailable (e.g.
+    the package is installed standalone), it skips rather than fails.
+    """
+    import re
+    from pathlib import Path
+
+    import pytest
+
+    from aimock_pytest._server import AIMockServer
+
+    # test file: <repo>/packages/aimock-pytest/tests/test_basic.py
+    #   parents[0] = tests, [1] = aimock-pytest, [2] = packages, [3] = <repo>
+    fixture_loader = (
+        Path(__file__).resolve().parents[3] / "src" / "fixture-loader.ts"
+    )
+    if not fixture_loader.exists():
+        pytest.skip("fixture-loader.ts not available outside the repo")
+
+    source = fixture_loader.read_text(encoding="utf-8")
+
+    # Isolate the body of entryToFixture so we only collect the match-key reads
+    # from inside that function (and not any unrelated entry.match.X references
+    # elsewhere in the file, e.g. in validateFixtures which uses f.match.X).
+    start = source.index("export function entryToFixture")
+    rest = source[start + len("export function entryToFixture") :]
+    next_export = rest.find("\nexport function ")
+    body = rest if next_export == -1 else rest[:next_export]
+
+    server_match_keys = set(re.findall(r"entry\.match\.(\w+)", body))
+    assert server_match_keys, (
+        "no entry.match.<key> references found in entryToFixture — "
+        "the regex or function-body isolation is broken"
+    )
+
+    missing = server_match_keys - set(AIMockServer._MATCH_LEVEL_OPT_KEYS)
+    assert not missing, (
+        f"_MATCH_LEVEL_OPT_KEYS is missing server match keys: {sorted(missing)}. "
+        "Update it in _server.py to match entryToFixture in src/fixture-loader.ts."
+    )

--- a/packages/aimock-pytest/tests/test_basic.py
+++ b/packages/aimock-pytest/tests/test_basic.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import requests
 
 # ── Session-scoped fixture tests ──────────────────────────────────────────
@@ -171,3 +173,111 @@ def test_on_system_message_array_requires_all(aimock):
         },
     )
     assert r.status_code == 404
+
+
+# ── Fixture-option forwarding tests ──────────────────────────────────────
+# These prove that per-fixture options passed via **opts reach the server's
+# fixture schema at the correct wire location instead of being silently
+# dropped under an unrecognized top-level "opts" key.
+
+
+def test_match_level_opt_routed_under_match(aimock):
+    """A match-level option (``sequenceIndex``) must be routed under ``match``
+    so the server's per-occurrence sequencing actually takes effect.
+
+    Two sibling fixtures share the same matcher but differ by
+    ``sequenceIndex``: the 0th occurrence must serve ``first-hit`` and the
+    1st occurrence ``second-hit``. Under the old nested-``opts`` shape the
+    server never sees ``sequenceIndex`` (both fixtures look identical), so the
+    first fixture shadows the second and BOTH requests return ``first-hit`` —
+    failing the second assertion.
+    """
+    aimock.on_message("seqtest", {"content": "first-hit"}, sequenceIndex=0)
+    aimock.on_message("seqtest", {"content": "second-hit"}, sequenceIndex=1)
+
+    payload = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "seqtest"}],
+    }
+
+    r1 = requests.post(f"{aimock.base_url}/v1/chat/completions", json=payload)
+    assert r1.status_code == 200
+    assert r1.json()["choices"][0]["message"]["content"] == "first-hit"
+
+    r2 = requests.post(f"{aimock.base_url}/v1/chat/completions", json=payload)
+    assert r2.status_code == 200
+    assert r2.json()["choices"][0]["message"]["content"] == "second-hit"
+
+
+def test_opts_emitted_at_correct_wire_level():
+    """Per-fixture options land at the correct wire location and NO ``opts``
+    wrapper key is emitted.
+
+    Fixture-level options (e.g. ``latency``, ``chunkSize``) belong at the top
+    level of the entry; match-level options (``sequenceIndex``) belong under
+    ``match``. The pre-fix code nested everything under ``fixture["opts"]``.
+    """
+    from aimock_pytest._server import AIMockServer
+
+    server = AIMockServer.__new__(AIMockServer)
+    server._base_url = "http://127.0.0.1:9999"
+
+    with mock.patch("aimock_pytest._server.requests.post") as post:
+        post.return_value.raise_for_status.return_value = None
+        server.add_fixture(
+            {"userMessage": "hi"},
+            {"content": "yo"},
+            latency=42,
+            chunkSize=7,
+            sequenceIndex=2,
+        )
+
+    assert post.call_count == 1
+    entry = post.call_args.kwargs["json"]["fixtures"][0]
+
+    # No legacy wrapper key.
+    assert "opts" not in entry
+
+    # Fixture-level options at the top level of the entry.
+    assert entry["latency"] == 42
+    assert entry["chunkSize"] == 7
+
+    # Match-level option under match (alongside the original matcher).
+    assert entry["match"]["userMessage"] == "hi"
+    assert entry["match"]["sequenceIndex"] == 2
+
+    # Match-level keys must NOT leak to the top level.
+    assert "sequenceIndex" not in entry
+
+
+def test_match_level_kwarg_opt_routed_under_match():
+    """Every key the server reads from ``entry.match`` must be routed under
+    ``match`` when passed as a kwarg opt — not just the original three.
+
+    ``model`` is a match-level constraint (the server reads
+    ``entry.match.model`` in ``entryToFixture``). If it is spread to the top
+    level the constraint is silently dropped, so the fixture matches requests
+    for ANY model (over-broad matching). This guards the completeness of
+    ``_MATCH_LEVEL_OPT_KEYS``.
+    """
+    from aimock_pytest._server import AIMockServer
+
+    server = AIMockServer.__new__(AIMockServer)
+    server._base_url = "http://127.0.0.1:9999"
+
+    with mock.patch("aimock_pytest._server.requests.post") as post:
+        post.return_value.raise_for_status.return_value = None
+        server.add_fixture(
+            {"userMessage": "x"},
+            {"content": "yo"},
+            model="gpt-4",
+        )
+
+    entry = post.call_args.kwargs["json"]["fixtures"][0]
+
+    # ``model`` belongs under match, alongside the original matcher.
+    assert entry["match"]["userMessage"] == "x"
+    assert entry["match"]["model"] == "gpt-4"
+
+    # ...and must NOT leak to the top level where the server ignores it.
+    assert "model" not in entry

--- a/packages/aimock-pytest/tests/test_startup_failure.py
+++ b/packages/aimock-pytest/tests/test_startup_failure.py
@@ -1,0 +1,75 @@
+"""Startup-failure-path tests for AIMockServer.start / _wait_for_ready.
+
+These exercise the failure branches (health-check failure, readiness timeout)
+to verify the half-started subprocess is reaped and the child's captured
+stdout is surfaced in the error — not the happy path.
+"""
+
+import pytest
+import requests
+
+from aimock_pytest import AIMockServer, NodeManager
+from aimock_pytest import _server as server_module
+
+
+def _node_manager() -> NodeManager:
+    return NodeManager(version=None, node_path=None)
+
+
+def test_health_check_failure_reaps_process_and_surfaces_output(monkeypatch):
+    """When the child starts (prints 'listening on') but the health check
+    never succeeds, start() raises, the subprocess is terminated (no leak),
+    and the captured stdout is included in the error message."""
+    server = AIMockServer(_node_manager(), port=0)
+
+    # Force every health-check probe to fail so the "listening on" branch
+    # falls through to the health-check-failure RuntimeError.
+    def _always_fail(*args, **kwargs):
+        raise requests.ConnectionError("forced health-check failure")
+
+    monkeypatch.setattr(requests, "get", _always_fail)
+
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            server.start()
+
+        msg = str(excinfo.value)
+        assert "health check failed" in msg
+        # The child logs a "listening on http://..." line on startup; that
+        # captured stdout must be surfaced in the error.
+        assert "listening on" in msg
+        # The half-started subprocess must have been reaped.
+        assert server._proc is None
+    finally:
+        server.stop()
+
+
+def test_readiness_timeout_reaps_process(monkeypatch):
+    """When the child never prints a recognizable 'listening on' line within
+    the timeout, start() raises a readiness-timeout RuntimeError and the
+    subprocess is reaped rather than leaked."""
+    server = AIMockServer(_node_manager(), port=0)
+
+    # Make the listening-line matcher never match and shorten the readiness
+    # window so the loop expires while the (real) child is still running.
+    monkeypatch.setattr(server_module.re, "search", lambda *a, **k: None)
+    real_start = AIMockServer.start
+
+    def _short_start(self):
+        # Mirror start()'s readiness timeout but make it tiny.
+        original_wait = self._wait_for_ready
+        self._wait_for_ready = lambda timeout=15: original_wait(timeout=0.2)
+        return real_start(self)
+
+    monkeypatch.setattr(AIMockServer, "start", _short_start)
+
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            server.start()
+
+        msg = str(excinfo.value)
+        assert "did not start within" in msg
+        # The half-started subprocess must have been reaped.
+        assert server._proc is None
+    finally:
+        server.stop()

--- a/src/__tests__/control-api.test.ts
+++ b/src/__tests__/control-api.test.ts
@@ -282,6 +282,31 @@ describe("/__aimock control API", () => {
     });
   });
 
+  describe("DELETE /v1/_requests", () => {
+    it("clears journal entries while preserving fixture match-counts", async () => {
+      const fixtures: Fixture[] = [
+        { match: { userMessage: "hello" }, response: { content: "Hi" } },
+      ];
+      instance = await createServer(fixtures);
+
+      // Make a request so the journal records an entry AND the fixture's
+      // match-count is incremented to a non-zero value.
+      await httpRequest(`${instance.url}/v1/chat/completions`, "POST", chatRequest("hello"));
+      expect(instance.journal.size).toBeGreaterThan(0);
+      const countBefore = instance.journal.getFixtureMatchCount(fixtures[0]);
+      expect(countBefore).toBeGreaterThan(0);
+
+      // Clear ONLY the request journal entries.
+      const res = await httpRequest(`${instance.url}/v1/_requests`, "DELETE");
+      expect(res.status).toBe(204);
+
+      // Journal entries cleared, but the fixture match-count must survive —
+      // clearing the request log must not rewind sequenced fixtures to index 0.
+      expect(instance.journal.size).toBe(0);
+      expect(instance.journal.getFixtureMatchCount(fixtures[0])).toBe(countBefore);
+    });
+  });
+
   describe("GET /__aimock/journal", () => {
     it("returns journal entries", async () => {
       const fixtures: Fixture[] = [

--- a/src/server.ts
+++ b/src/server.ts
@@ -1351,7 +1351,11 @@ export async function createServer(
         return;
       }
       if (req.method === "DELETE") {
-        journal.clear();
+        // Clear only the request journal entries, preserving fixture
+        // match-counts (sequencing state). Clearing the request log must not
+        // silently rewind sequenced fixtures. For a full reset (entries +
+        // match-counts), use POST /__aimock/reset/fixtures.
+        journal.clearEntries();
         res.writeHead(204);
         res.end();
         return;


### PR DESCRIPTION
## Summary

Cleanup/fix batch from the #244 CR follow-ups. No version bump — all changes land under CHANGELOG `[Unreleased]` for the next release.

### Fixes
- **aimock-pytest fixture options were silently dropped.** `add_fixture` nested `**opts` under an `opts` key the server ignores. Now fixture-level options (`latency`, `chunkSize`, `chaos`, …) are spread onto the top-level entry and match-level keys are routed under `match` — using the **complete** set of keys `entryToFixture` reads from `entry.match` (`userMessage, systemMessage, inputText, toolCallId, toolName, model, responseFormat, endpoint, sequenceIndex, turnIndex, hasToolResult, context`). `on_embedding` gains `**opts` parity. (red-green tests added)
- **aimock-pytest `_wait_for_ready` hardening.** A background reader thread drains the child's stdout so the method honors its timeout (no hang / pipe-buffer deadlock), tears down the subprocess on a startup failure, and surfaces the captured output for diagnosis. (startup-failure tests added)
- **`DELETE /v1/_requests` now clears journal *entries* only**, preserving fixture match-counts (sequence position) — consistent with `POST /__aimock/reset/journal`. (test added)
- **`docs/sidebar.js`**: single-active-link de-dup for duplicate hrefs, two-pass heading-id reservation (hardcoded ids reserved before auto-slugs), and a `var` shadow fix.
- **`plugin.py`**: pytest fixtures annotated as generators (dropped `# type: ignore[misc]`); `_tmp_fixtures` initialized in `__init__`.

### Reconciliation
- **`engines.node` lowered `>=24.0.0` → `>=20.15.0`.** The `>=24` floor was raised to satisfy npm **OIDC publishing** (a CI/publish-time concern, handled by `publish-release.yml` which pins Node 24). It is not a runtime requirement — the CLI runs on Node 20 (aimock-pytest CI exercises the built `cli.js` on Node 20/22/24). The new floor matches the pytest harness, README, and CI matrix.

## Test plan
- [x] `pnpm test` — 3353 passed, 0 failed
- [x] `pnpm run lint` / `npx tsc --noEmit` / `pnpm run build` — clean
- [x] aimock-pytest — 16 passed (run against the locally-built CLI via `AIMOCK_CLI_PATH`), incl. new option-routing + startup-failure tests
- [x] 7-agent CR converged (bucket-a empty; Procedure 3 bucket-c audit clean)

## Follow-ups (out of scope — pre-existing, untouched files)
- `_node_manager.py`: `lock_fd` is opened before the `try`, so it leaks if `flock` raises.
- At the next release, align `aimock-pytest` `_version.py` `AIMOCK_VERSION` to the published version that contains the reset routes.
- Optional robustness: clamp the `_wait_for_ready` health window to the outer deadline; `stop()` could close `stdout` before joining the reader thread.