### PR TITLE
fix: un-rot aimock-pytest default aimock version (1.21.0 → 1.28.0)

### DIFF
--- a/packages/aimock-pytest/src/aimock_pytest/_version.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_version.py
@@ -1,3 +1,11 @@
-"""Single source of truth for the aimock package version."""
+"""Default `@copilotkit/aimock` npm version that aimock-pytest downloads and runs.
 
-AIMOCK_VERSION = "1.21.0"
+This is NOT the version of this Python package (see pyproject.toml for that) and
+is NOT auto-synced — it is a hard pin to a published npm release. NodeManager
+downloads exactly this version when AIMOCK_CLI_PATH is not set, so it must point
+at a published `@copilotkit/aimock` release and be bumped to the release that
+contains any new server routes/features the client calls (e.g. the reset-split
+control routes ship in the next release). Keep it tracking npm releases.
+"""
+
+AIMOCK_VERSION = "1.28.0"


### PR DESCRIPTION
## Summary

`packages/aimock-pytest/src/aimock_pytest/_version.py` pinned `AIMOCK_VERSION = "1.21.0"` — **7 releases behind** the published npm package (`1.28.0`). `NodeManager` downloads *exactly* this version when `AIMOCK_CLI_PATH` is unset, so default-download PyPI users have been running a stale aimock server. `_version.py` was last bumped 2026-05-11; ~11 `chore: release vX` commits since never touched it.

This bumps it to the current published version and rewrites the misleading docstring (it called itself "the aimock package version" — it is actually a hard pin to a published npm release, not this package's own version, and is not auto-synced).

Note: this is the interim un-rot. The next aimock release that ships the reset-split control routes must bump this to that version (1.29.0+) so `reset_fixtures()`/`reset_journal()` work on the default-download path — tracked separately via a release-SOP fix.

## Test plan
- [x] No behavior change in CI (the pytest suite runs against the local build via `AIMOCK_CLI_PATH`, not the pinned download).
- [x] One-line value + docstring change; `npx tsc`/tests unaffected.