### PR TITLE
chore(release): 1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.29.0] - 2026-06-04
+
 ### Added
 
 - `POST /__aimock/reset/fixtures` — full reset (clears fixtures, generation state, and journal).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, text-to-speech, transcription, audio generation, video generation, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Release 1.29.0

Cuts the accumulated `[Unreleased]` changes as **1.29.0** (semver minor — there are `Added` + `Deprecated` entries). Bumps `package.json` `1.28.0 → 1.29.0` and moves the CHANGELOG `[Unreleased]` section under `## [1.29.0] - 2026-06-04`.

**Merging to `main` triggers the Release workflow to publish `1.29.0` to npm** (the workflow publishes when `package.json`'s version isn't yet on the registry).

### What ships in 1.29.0

**Added**
- `POST /__aimock/reset/fixtures` and `POST /__aimock/reset/journal`
- `aimock-pytest`: `reset_fixtures()` / `reset_journal()`
- Control API reference docs

**Changed**
- `engines.node` lowered to `>=20.15.0`

**Deprecated**
- `POST /__aimock/reset` (alias for `/reset/fixtures`)

**Fixed**
- **Video** — `POST /v1/videos` now parses `multipart/form-data` bodies (OpenAI SDK ≥6.28 sends video-create as multipart) — #247
- `aimock-pytest` per-fixture option forwarding + startup-timeout/teardown hardening
- `DELETE /v1/_requests` clears only journal entries (preserves fixture match-counts)

### Downstream
Unblocks **TanStack/ai#695**, which pins `@copilotkit/aimock: ^1.28.1` and drops its temporary local video-multipart patch — once 1.29.0 is on npm, that PR's E2E goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)