### PR TITLE
Enrich drift Slack alert and harden it against transient API blips

### DIFF
--- a/.github/workflows/test-drift.yml
+++ b/.github/workflows/test-drift.yml
@@ -40,6 +40,10 @@ jobs:
       # what changed. Consumed by the `notify` job (which runs in a separate
       # workspace and so cannot read drift-report.json directly).
       summary: ${{ steps.summary.outputs.drift_summary }}
+      # How many collector runs confirmed the drift (only set when drift
+      # persisted across every retry). Lets the alert say "confirmed across N
+      # runs". Empty on the common green/transient path.
+      runs: ${{ steps.drift.outputs.drift_runs }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
@@ -50,6 +54,14 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
+      # Run the collector behind a "retry before alert" wrapper. A single
+      # critical run can be a transient real-API hiccup (a streaming call
+      # failing mid-flight), NOT a format change — so the wrapper re-runs the
+      # collector and only reports critical drift (exit 2) if it PERSISTS
+      # across every attempt. Any clean retry = transient = exit 0, no alert.
+      # The common green path stays fast (no extra runs when the first is
+      # clean). Exit codes mirror the collector contract so the steps below
+      # are unchanged.
       - name: Run drift tests
         id: drift
         env:
@@ -58,15 +70,15 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: |
           set +e
-          npx tsx scripts/drift-report-collector.ts
+          npx tsx scripts/drift-retry.ts
           EXIT_CODE=$?
           set -e
-          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
           if [ "$EXIT_CODE" -eq 2 ]; then
-            : # critical drift found, continue
+            : # critical drift persisted across retries, continue
           elif [ "$EXIT_CODE" -ne 0 ]; then
             echo "::error::Collector script crashed with exit code $EXIT_CODE"
-            exit $EXIT_CODE
+            exit "$EXIT_CODE"
           fi
 
       - name: Upload drift report
@@ -116,6 +128,7 @@ jobs:
           DRIFT_RESULT: ${{ needs.drift.result }}
           AGUI_RESULT: ${{ needs.agui-schema-drift.result }}
           DRIFT_SUMMARY: ${{ needs.drift.outputs.summary }}
+          DRIFT_RUNS: ${{ needs.drift.outputs.runs }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
@@ -153,14 +166,23 @@ jobs:
             DETAIL="${NL}${DRIFT_SUMMARY}"
           fi
 
+          # When HTTP API drift fired, it only alerts after the drift PERSISTED
+          # across every retry of the collector. Note that confirmation so the
+          # reader knows this was not a one-off transient blip. DRIFT_RUNS is
+          # the count of runs that confirmed the drift (set by drift-retry.ts).
+          CONFIRMED=""
+          if [ "$DRIFT_RESULT" = "failure" ] && [ -n "$DRIFT_RUNS" ] && [ "$DRIFT_RUNS" -gt 1 ] 2>/dev/null; then
+            CONFIRMED="${NL}_(confirmed across ${DRIFT_RUNS} runs)_"
+          fi
+
           # Both types of drift
           if [ "$HTTP_DRIFT" = "true" ] && [ "$AGUI_DRIFT" = "true" ]; then
             EMOJI="🚨"
-            MSG="*Drift detected* in aimock — HTTP API drift + AG-UI schema drift.${DETAIL}${NL}${RUN_URL}"
+            MSG="*Drift detected* in aimock — HTTP API drift + AG-UI schema drift.${DETAIL}${CONFIRMED}${NL}${RUN_URL}"
           # HTTP API drift only
           elif [ "$HTTP_DRIFT" = "true" ]; then
             EMOJI="🚨"
-            MSG="*HTTP API drift detected* in aimock — providers changed response formats.${DETAIL}${NL}${RUN_URL}"
+            MSG="*HTTP API drift detected* in aimock — providers changed response formats.${DETAIL}${CONFIRMED}${NL}${RUN_URL}"
           # AG-UI schema drift only
           elif [ "$AGUI_DRIFT" = "true" ]; then
             EMOJI="🚨"

--- a/.github/workflows/test-drift.yml
+++ b/.github/workflows/test-drift.yml
@@ -35,6 +35,11 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      # Short, scannable Slack mrkdwn summary of which providers drifted and
+      # what changed. Consumed by the `notify` job (which runs in a separate
+      # workspace and so cannot read drift-report.json directly).
+      summary: ${{ steps.summary.outputs.drift_summary }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with: { persist-credentials: false }
@@ -73,6 +78,15 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+      # Distill drift-report.json into a short Slack summary and expose it as a
+      # job output so the separate `notify` job can include it in the alert.
+      # Runs before the failure step below so the summary is captured even when
+      # critical drift is present.
+      - name: Summarize drift for Slack
+        id: summary
+        if: always()
+        run: npx tsx scripts/drift-slack-summary.ts
+
       - name: Fail if critical drift detected
         if: steps.drift.outputs.exit_code == '2'
         run: exit 1
@@ -101,6 +115,7 @@ jobs:
           PREV: ${{ steps.prev.outputs.conclusion }}
           DRIFT_RESULT: ${{ needs.drift.result }}
           AGUI_RESULT: ${{ needs.agui-schema-drift.result }}
+          DRIFT_SUMMARY: ${{ needs.drift.outputs.summary }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
@@ -125,18 +140,31 @@ jobs:
 
           RUN_URL="<https://github.com/${REPO}/actions/runs/${RUN_ID}|View run>"
 
+          # Build the "what drifted" detail block from the drift job's summary
+          # output. DRIFT_SUMMARY already contains real newlines (one bullet per
+          # provider); we prepend a real newline so the detail sits on its own
+          # lines under the headline. jq's --arg encodes these newlines into the
+          # JSON payload correctly, so Slack renders real line breaks.
+          # (No literal "\n" in any format() expression — that GitHub Actions
+          # gotcha renders a visible backslash-n; here we use bash newlines.)
+          NL=$'\n'
+          DETAIL=""
+          if [ -n "$DRIFT_SUMMARY" ]; then
+            DETAIL="${NL}${DRIFT_SUMMARY}"
+          fi
+
           # Both types of drift
           if [ "$HTTP_DRIFT" = "true" ] && [ "$AGUI_DRIFT" = "true" ]; then
             EMOJI="🚨"
-            MSG="*Drift detected* in aimock — HTTP API drift + AG-UI schema drift. ${RUN_URL}"
+            MSG="*Drift detected* in aimock — HTTP API drift + AG-UI schema drift.${DETAIL}${NL}${RUN_URL}"
           # HTTP API drift only
           elif [ "$HTTP_DRIFT" = "true" ]; then
             EMOJI="🚨"
-            MSG="*HTTP API drift detected* in aimock — providers changed response formats. ${RUN_URL}"
+            MSG="*HTTP API drift detected* in aimock — providers changed response formats.${DETAIL}${NL}${RUN_URL}"
           # AG-UI schema drift only
           elif [ "$AGUI_DRIFT" = "true" ]; then
             EMOJI="🚨"
-            MSG="*AG-UI schema drift detected* in aimock — canonical ag-ui types changed. ${RUN_URL}"
+            MSG="*AG-UI schema drift detected* in aimock — canonical ag-ui types changed.${DETAIL}${NL}${RUN_URL}"
           # Infra failure — always notify
           elif [ "$INFRA_ERROR" = "true" ]; then
             EMOJI="❌"

--- a/scripts/drift-retry.ts
+++ b/scripts/drift-retry.ts
@@ -1,0 +1,202 @@
+/// <reference types="node" />
+
+/**
+ * Drift Retry Wrapper — "retry before alert"
+ *
+ * Wraps `drift-report-collector.ts` so a TRANSIENT real-API hiccup no longer
+ * pages the team. Real LLM provider APIs occasionally fail a single streaming
+ * call mid-flight (e.g. emit `error` + `response.failed` with no terminal
+ * `response.completed`). That looks identical to a "critical diff" to the
+ * collector — but it is NOT a format change, and clears on a re-run a moment
+ * later. Alerting on it produces false alarms.
+ *
+ * Policy (matches the owner directive — "if it ran the collector/detector a
+ * second time and it passed, it should not have emitted the warning"):
+ *
+ *   - collector exit 0 → no critical drift → SUCCESS, no further runs (fast
+ *     common green path).
+ *   - collector exit 2 → critical drift → retry up to `maxAttempts` total runs
+ *     with a short backoff between attempts. As soon as ANY attempt returns 0
+ *     critical → transient → SUCCESS, no alert.
+ *   - Only when EVERY attempt (all `maxAttempts`) shows critical drift do we
+ *     declare a real failure (exit 2) → the `notify` job alerts.
+ *   - collector exit 1 (or any other non-0/2 code) → script/infra crash, NOT
+ *     drift → propagate immediately without retrying (the collector already
+ *     distinguishes infra errors from drift internally; a crash here is a real
+ *     break worth surfacing, and retrying won't help).
+ *
+ * Retries hit real provider APIs, so `maxAttempts` is kept small.
+ *
+ * The retry decision is implemented as a pure function (`retryUntilStable`)
+ * with injected collector-runner / sleep / log, so it is unit-testable without
+ * spawning subprocesses or sleeping. `main()` wires the real collector
+ * subprocess and emits a `drift_runs` marker via GITHUB_OUTPUT recording how
+ * many attempts confirmed the drift (so the alert can say "confirmed across N
+ * runs").
+ *
+ * CLI usage (in CI):
+ *   npx tsx scripts/drift-retry.ts [-- <args forwarded to collector>]
+ *
+ * Exit codes mirror the collector's contract so downstream YAML logic is
+ * unchanged: 0 = clean (or transient), 2 = persistent critical drift, other =
+ * collector crash.
+ */
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Collector exit-code contract (see drift-report-collector.ts header).
+export const EXIT_CLEAN = 0;
+export const EXIT_CRITICAL_DRIFT = 2;
+
+// Defaults: keep the fleet of real-API calls small. 3 total attempts with a
+// ~45s backoff mirrors the observed transient window (the Fix Drift workflow
+// re-ran the collector ~1 minute later and saw 0 critical).
+export const DEFAULT_MAX_ATTEMPTS = 3;
+export const DEFAULT_BACKOFF_MS = 45_000;
+
+export interface RetryAttempt {
+  /** 1-based attempt number. */
+  attempt: number;
+  /** The collector process exit code for this attempt. */
+  exitCode: number;
+}
+
+export interface RetryOptions {
+  /** Total number of collector runs to attempt before giving up. */
+  maxAttempts: number;
+  /** Milliseconds to wait between attempts after a critical run. */
+  backoffMs: number;
+  /** Runs the collector once and returns its exit code. */
+  runCollector: () => number;
+  /** Sleeps synchronously for the given milliseconds (injected for tests). */
+  sleep: (ms: number) => void;
+  /** Logger (injected so tests stay quiet). */
+  log: (msg: string) => void;
+}
+
+export interface RetryResult {
+  /** Final exit code to propagate (0 = clean/transient, 2 = persistent, other = crash). */
+  exitCode: number;
+  /** True when at least one critical run was seen but a later run cleared it. */
+  transient: boolean;
+  /** Number of attempts that reported critical drift. */
+  criticalRuns: number;
+  /** Per-attempt record, in order. */
+  attempts: RetryAttempt[];
+}
+
+/**
+ * Core "retry before alert" decision loop. Pure given its injected
+ * dependencies — no subprocesses, no real sleeping.
+ */
+export function retryUntilStable(opts: RetryOptions): RetryResult {
+  const attempts: RetryAttempt[] = [];
+  let criticalRuns = 0;
+
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    if (attempt > 1) {
+      opts.log(
+        `Critical drift on attempt ${attempt - 1}; re-running collector ` +
+          `(attempt ${attempt}/${opts.maxAttempts}) after ${opts.backoffMs}ms backoff ` +
+          `to confirm it is not a transient API hiccup...`,
+      );
+      opts.sleep(opts.backoffMs);
+    }
+
+    const exitCode = opts.runCollector();
+    attempts.push({ attempt, exitCode });
+
+    if (exitCode === EXIT_CLEAN) {
+      const transient = criticalRuns > 0;
+      if (transient) {
+        opts.log(
+          `Attempt ${attempt} returned 0 critical — earlier critical drift was ` +
+            `transient (cleared on retry). No alert.`,
+        );
+      }
+      return { exitCode: EXIT_CLEAN, transient, criticalRuns, attempts };
+    }
+
+    if (exitCode === EXIT_CRITICAL_DRIFT) {
+      criticalRuns++;
+      continue;
+    }
+
+    // Any other code = collector crash / infra error. Do not retry — surface it.
+    opts.log(`Collector exited ${exitCode} (not drift) — propagating without retry.`);
+    return { exitCode, transient: false, criticalRuns, attempts };
+  }
+
+  // Exhausted all attempts and every one showed critical drift → persistent.
+  opts.log(
+    `Critical drift persisted across all ${opts.maxAttempts} attempts — treating as ` +
+      `real drift and alerting.`,
+  );
+  return {
+    exitCode: EXIT_CRITICAL_DRIFT,
+    transient: false,
+    criticalRuns,
+    attempts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI wiring
+// ---------------------------------------------------------------------------
+
+/** Run the collector subprocess once, inheriting stdio, returning its exit code. */
+function runCollectorSubprocess(forwardArgs: string[]): number {
+  const result = spawnSync("npx", ["tsx", "scripts/drift-report-collector.ts", ...forwardArgs], {
+    stdio: "inherit",
+    encoding: "utf-8",
+  });
+  if (result.error) {
+    // Failed to even spawn — treat as a crash (non-0/2) so it is not retried.
+    console.error(`Failed to run collector: ${result.error.message}`);
+    return 1;
+  }
+  // A signal kill has null status; map to 1 (crash).
+  return result.status ?? 1;
+}
+
+function writeGithubOutput(name: string, value: string): void {
+  const outPath = process.env.GITHUB_OUTPUT;
+  if (!outPath) return;
+  appendFileSync(outPath, `${name}=${value}\n`, "utf-8");
+}
+
+function main(): void {
+  // Forward anything after a literal `--` to the collector (e.g. --out).
+  const argv = process.argv.slice(2);
+  const sepIndex = argv.indexOf("--");
+  const forwardArgs = sepIndex !== -1 ? argv.slice(sepIndex + 1) : [];
+
+  const result = retryUntilStable({
+    maxAttempts: DEFAULT_MAX_ATTEMPTS,
+    backoffMs: DEFAULT_BACKOFF_MS,
+    runCollector: () => runCollectorSubprocess(forwardArgs),
+    sleep: (ms: number) => {
+      // Synchronous busy-free sleep via Atomics so the CLI can stay sync.
+      const sab = new Int32Array(new SharedArrayBuffer(4));
+      Atomics.wait(sab, 0, 0, ms);
+    },
+    log: (msg: string) => console.log(`[drift-retry] ${msg}`),
+  });
+
+  // Expose how many runs confirmed the drift so the alert can note
+  // "confirmed across N runs". Only meaningful when we actually alert.
+  if (result.exitCode === EXIT_CRITICAL_DRIFT) {
+    writeGithubOutput("drift_runs", String(result.criticalRuns));
+  }
+
+  process.exit(result.exitCode);
+}
+
+// Only run as a CLI — guard so importing this module (e.g. from tests) does
+// not execute main().
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/drift-slack-summary.ts
+++ b/scripts/drift-slack-summary.ts
@@ -1,0 +1,171 @@
+/// <reference types="node" />
+
+/**
+ * Drift Slack Summary
+ *
+ * Reads the `drift-report.json` produced by `drift-report-collector.ts` and
+ * distills it into a short, scannable Slack mrkdwn summary describing WHICH
+ * providers drifted and a brief sense of WHAT changed (severity counts +
+ * a few example field paths). The full detail still lives in the uploaded
+ * `drift-report` artifact and the "View run" link in the Slack message.
+ *
+ * The summary is intentionally compact: it lists each drifted provider on its
+ * own line with a severity tally and up to a few representative changed paths,
+ * capped so the message stays readable in Slack. It is NOT a full dump.
+ *
+ * CLI usage (in CI):
+ *   npx tsx scripts/drift-slack-summary.ts [--in drift-report.json]
+ *
+ * When `GITHUB_OUTPUT` is set, the summary is emitted as a multiline step
+ * output named `drift_summary` (using a randomized heredoc delimiter so the
+ * value's own newlines survive). Otherwise it is printed to stdout.
+ */
+
+import { randomBytes } from "node:crypto";
+import { appendFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readDriftReport } from "./fix-drift.js";
+import type { DriftEntry, DriftReport, DriftSeverity } from "./drift-types.js";
+
+// Keep the message scannable: cap how many example paths we list per provider
+// and how many total providers we enumerate before collapsing to a count.
+const MAX_PATHS_PER_PROVIDER = 3;
+const MAX_PROVIDERS_LISTED = 8;
+
+const SEVERITY_ORDER: DriftSeverity[] = ["critical", "warning", "info"];
+
+interface ProviderSummary {
+  provider: string;
+  counts: Record<DriftSeverity, number>;
+  paths: string[];
+}
+
+/**
+ * Group drift entries by provider, tallying severities and collecting a small,
+ * de-duplicated set of representative changed paths.
+ */
+function summarizeByProvider(entries: DriftEntry[]): ProviderSummary[] {
+  const byProvider = new Map<string, ProviderSummary>();
+
+  for (const entry of entries) {
+    let summary = byProvider.get(entry.provider);
+    if (!summary) {
+      summary = {
+        provider: entry.provider,
+        counts: { critical: 0, warning: 0, info: 0 },
+        paths: [],
+      };
+      byProvider.set(entry.provider, summary);
+    }
+    for (const diff of entry.diffs) {
+      summary.counts[diff.severity]++;
+      if (diff.path && !summary.paths.includes(diff.path)) {
+        summary.paths.push(diff.path);
+      }
+    }
+  }
+
+  // Stable, deterministic order: most-severe providers first, then by name.
+  return [...byProvider.values()].sort((a, b) => {
+    if (b.counts.critical !== a.counts.critical) return b.counts.critical - a.counts.critical;
+    if (b.counts.warning !== a.counts.warning) return b.counts.warning - a.counts.warning;
+    return a.provider.localeCompare(b.provider);
+  });
+}
+
+/** Format a severity tally like "2 critical, 1 warning" (omitting zeroes). */
+function formatCounts(counts: Record<DriftSeverity, number>): string {
+  const parts: string[] = [];
+  for (const sev of SEVERITY_ORDER) {
+    if (counts[sev] > 0) parts.push(`${counts[sev]} ${sev}`);
+  }
+  return parts.length > 0 ? parts.join(", ") : "0 changes";
+}
+
+/**
+ * Build the Slack mrkdwn summary lines for the drifted providers.
+ *
+ * Returns a single string with real `\n` line breaks. Each provider gets a
+ * bullet line: `• *Provider* — 2 critical: \`path.a\`, \`path.b\``.
+ * Returns an empty string when there are no entries (caller decides fallback).
+ */
+export function summarizeDriftReport(report: DriftReport): string {
+  const summaries = summarizeByProvider(report.entries);
+  if (summaries.length === 0) return "";
+
+  const shown = summaries.slice(0, MAX_PROVIDERS_LISTED);
+  const lines: string[] = [];
+
+  for (const s of shown) {
+    const examplePaths = s.paths.slice(0, MAX_PATHS_PER_PROVIDER).map((p) => `\`${p}\``);
+    const extraPaths = s.paths.length - examplePaths.length;
+    let pathStr = examplePaths.join(", ");
+    if (extraPaths > 0) pathStr += `, +${extraPaths} more`;
+
+    const counts = formatCounts(s.counts);
+    lines.push(
+      pathStr ? `• *${s.provider}* — ${counts}: ${pathStr}` : `• *${s.provider}* — ${counts}`,
+    );
+  }
+
+  const hiddenProviders = summaries.length - shown.length;
+  if (hiddenProviders > 0) {
+    lines.push(`• …and ${hiddenProviders} more provider${hiddenProviders === 1 ? "" : "s"}`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Emit a (possibly multiline) value as a step output via GITHUB_OUTPUT using a
+ * randomized heredoc delimiter, per the GitHub Actions multiline-output spec.
+ */
+function writeGithubOutput(name: string, value: string): void {
+  const outPath = process.env.GITHUB_OUTPUT;
+  if (!outPath) return;
+  const delimiter = `EOF_${randomBytes(16).toString("hex")}`;
+  // Guard against the (astronomically unlikely) delimiter colliding with content.
+  if (value.includes(delimiter)) {
+    throw new Error("GITHUB_OUTPUT delimiter collision — refusing to write");
+  }
+  appendFileSync(outPath, `${name}<<${delimiter}\n${value}\n${delimiter}\n`, "utf-8");
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const inIndex = args.indexOf("--in");
+  const inPath = resolve(
+    inIndex !== -1 && args[inIndex + 1] ? args[inIndex + 1] : "drift-report.json",
+  );
+
+  let summary = "";
+  if (existsSync(inPath)) {
+    try {
+      const report = readDriftReport(inPath);
+      summary = summarizeDriftReport(report);
+    } catch (err: unknown) {
+      // Never let a malformed/missing report break the notify step — the
+      // generic Slack message + "View run" link is the safe fallback.
+      console.warn(
+        `drift-slack-summary: could not summarize ${inPath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  } else {
+    console.warn(`drift-slack-summary: ${inPath} not found — emitting empty summary`);
+  }
+
+  writeGithubOutput("drift_summary", summary);
+  if (summary) {
+    console.log(summary);
+  } else {
+    console.log("(no drift detail available)");
+  }
+}
+
+// Only run as a CLI — guard so importing this module (e.g. from tests) does
+// not execute main().
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/src/__tests__/drift-retry.test.ts
+++ b/src/__tests__/drift-retry.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+
+import { retryUntilStable } from "../../scripts/drift-retry.js";
+import type { RetryAttempt, RetryOptions, RetryResult } from "../../scripts/drift-retry.js";
+
+// ---------------------------------------------------------------------------
+// retryUntilStable
+//
+// Wraps the drift collector with a "retry before alert" policy:
+//   - collector exit 0 → no critical drift → SUCCESS (no further runs)
+//   - collector exit 2 → critical drift → retry (up to maxAttempts) with backoff
+//   - collector exit 1 (or other non-0/2) → script/infra crash → propagate now
+//
+// A run is only treated as a real failure (alert) if EVERY attempt reports
+// critical drift. Any single clean attempt → transient → SUCCESS, no alert.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fake collector runner that returns the given exit codes in sequence
+ * and records how many times it was invoked.
+ */
+function fakeRunner(exitCodes: number[]): { run: () => number; calls: () => number } {
+  let i = 0;
+  let calls = 0;
+  return {
+    run: () => {
+      calls++;
+      const code = exitCodes[Math.min(i, exitCodes.length - 1)];
+      i++;
+      return code;
+    },
+    calls: () => calls,
+  };
+}
+
+function makeOptions(overrides: Partial<RetryOptions> = {}): RetryOptions {
+  return {
+    maxAttempts: 3,
+    backoffMs: 1000,
+    runCollector: () => 0,
+    sleep: () => {},
+    log: () => {},
+    ...overrides,
+  };
+}
+
+describe("retryUntilStable", () => {
+  it("returns success after a single clean run (exit 0), no retries", () => {
+    const runner = fakeRunner([0]);
+    const opts = makeOptions({ runCollector: runner.run });
+    const result: RetryResult = retryUntilStable(opts);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.transient).toBe(false);
+    expect(runner.calls()).toBe(1);
+  });
+
+  it("treats critical-then-clean as transient SUCCESS (no alert)", () => {
+    const runner = fakeRunner([2, 0]);
+    const opts = makeOptions({ runCollector: runner.run });
+    const result = retryUntilStable(opts);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.transient).toBe(true);
+    expect(result.attempts.length).toBe(2);
+    // Stops as soon as a clean run is seen — does not exhaust maxAttempts
+    expect(runner.calls()).toBe(2);
+  });
+
+  it("alerts (exit 2) only when EVERY attempt shows critical drift", () => {
+    const runner = fakeRunner([2, 2, 2]);
+    const opts = makeOptions({ runCollector: runner.run, maxAttempts: 3 });
+    const result = retryUntilStable(opts);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.transient).toBe(false);
+    expect(result.attempts.length).toBe(3);
+    expect(runner.calls()).toBe(3);
+    // Persistent drift is confirmed across all attempts
+    expect(result.criticalRuns).toBe(3);
+  });
+
+  it("propagates a collector crash (exit 1) immediately without retrying", () => {
+    const runner = fakeRunner([1, 0, 0]);
+    const opts = makeOptions({ runCollector: runner.run });
+    const result = retryUntilStable(opts);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.transient).toBe(false);
+    expect(runner.calls()).toBe(1);
+  });
+
+  it("propagates an unexpected non-0/2 exit code immediately", () => {
+    const runner = fakeRunner([7, 0]);
+    const opts = makeOptions({ runCollector: runner.run });
+    const result = retryUntilStable(opts);
+
+    expect(result.exitCode).toBe(7);
+    expect(runner.calls()).toBe(1);
+  });
+
+  it("backs off between critical attempts but not before the first or after the last", () => {
+    const sleeps: number[] = [];
+    const runner = fakeRunner([2, 2, 2]);
+    const opts = makeOptions({
+      runCollector: runner.run,
+      maxAttempts: 3,
+      backoffMs: 1234,
+      sleep: (ms: number) => {
+        sleeps.push(ms);
+      },
+    });
+    retryUntilStable(opts);
+
+    // 3 attempts → 2 inter-attempt sleeps (no sleep before #1, none after the last)
+    expect(sleeps).toEqual([1234, 1234]);
+  });
+
+  it("does not sleep when the first run is clean", () => {
+    const sleeps: number[] = [];
+    const runner = fakeRunner([0]);
+    const opts = makeOptions({
+      runCollector: runner.run,
+      sleep: (ms: number) => {
+        sleeps.push(ms);
+      },
+    });
+    retryUntilStable(opts);
+
+    expect(sleeps).toEqual([]);
+  });
+
+  it("records each attempt's exit code in order", () => {
+    const runner = fakeRunner([2, 2, 0]);
+    const opts = makeOptions({ runCollector: runner.run });
+    const result = retryUntilStable(opts);
+
+    expect(result.attempts.map((a: RetryAttempt) => a.exitCode)).toEqual([2, 2, 0]);
+  });
+});

--- a/src/__tests__/drift-scripts.test.ts
+++ b/src/__tests__/drift-scripts.test.ts
@@ -17,7 +17,9 @@ import {
   todayStamp,
 } from "../../scripts/fix-drift.js";
 
-import type { DriftReport } from "../../scripts/drift-types.js";
+import { summarizeDriftReport } from "../../scripts/drift-slack-summary.js";
+
+import type { DriftEntry, DriftReport } from "../../scripts/drift-types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -315,5 +317,125 @@ describe("parsePorcelainLine", () => {
 describe("todayStamp", () => {
   it("returns an ISO date string", () => {
     expect(todayStamp()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeDriftReport (Slack detail)
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides?: Partial<DriftEntry>): DriftEntry {
+  return {
+    provider: "OpenAI Chat",
+    scenario: "non-streaming text",
+    builderFile: "src/helpers.ts",
+    builderFunctions: ["buildTextCompletion"],
+    typesFile: "src/types.ts",
+    sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
+    diffs: [
+      {
+        severity: "critical",
+        issue: "field missing from mock",
+        path: "choices[0].message.refusal",
+        expected: "null",
+        real: "null",
+        mock: "<absent>",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("summarizeDriftReport", () => {
+  it("returns an empty string when there are no entries", () => {
+    expect(summarizeDriftReport({ timestamp: "t", entries: [] })).toBe("");
+  });
+
+  it("names the drifted provider, severity tally, and a changed path", () => {
+    const summary = summarizeDriftReport({ timestamp: "t", entries: [makeEntry()] });
+    expect(summary).toContain("*OpenAI Chat*");
+    expect(summary).toContain("1 critical");
+    expect(summary).toContain("`choices[0].message.refusal`");
+    expect(summary.startsWith("•")).toBe(true);
+  });
+
+  it("merges multiple entries for the same provider into one line with combined counts", () => {
+    const summary = summarizeDriftReport({
+      timestamp: "t",
+      entries: [
+        makeEntry(),
+        makeEntry({
+          scenario: "streaming text",
+          diffs: [
+            {
+              severity: "warning",
+              issue: "type changed",
+              path: "choices[0].delta.role",
+              expected: "string",
+              real: "string",
+              mock: "number",
+            },
+          ],
+        }),
+      ],
+    });
+    // One bullet line for the single provider
+    expect(summary.split("\n").filter((l) => l.startsWith("• *OpenAI Chat*"))).toHaveLength(1);
+    expect(summary).toContain("1 critical, 1 warning");
+  });
+
+  it("lists multiple providers on separate lines, critical-first", () => {
+    const summary = summarizeDriftReport({
+      timestamp: "t",
+      entries: [
+        makeEntry({
+          provider: "Anthropic",
+          diffs: [
+            {
+              severity: "warning",
+              issue: "x",
+              path: "content[0].type",
+              expected: "a",
+              real: "a",
+              mock: "b",
+            },
+          ],
+        }),
+        makeEntry(), // OpenAI Chat with a critical
+      ],
+    });
+    const lines = summary.split("\n");
+    expect(lines).toHaveLength(2);
+    // Provider with a critical diff sorts before the warning-only provider
+    expect(lines[0]).toContain("*OpenAI Chat*");
+    expect(lines[1]).toContain("*Anthropic*");
+  });
+
+  it("caps example paths per provider and reports the remainder", () => {
+    const manyPaths = Array.from({ length: 6 }, (_, i) => ({
+      severity: "critical" as const,
+      issue: "x",
+      path: `field.${i}`,
+      expected: "a",
+      real: "a",
+      mock: "b",
+    }));
+    const summary = summarizeDriftReport({
+      timestamp: "t",
+      entries: [makeEntry({ diffs: manyPaths })],
+    });
+    expect(summary).toContain("`field.0`");
+    expect(summary).toContain("`field.2`");
+    expect(summary).not.toContain("`field.3`");
+    expect(summary).toContain("+3 more");
+  });
+
+  it("uses real newlines (not literal backslash-n) between providers", () => {
+    const summary = summarizeDriftReport({
+      timestamp: "t",
+      entries: [makeEntry(), makeEntry({ provider: "Anthropic" })],
+    });
+    expect(summary).toContain("\n");
+    expect(summary).not.toContain("\\n");
   });
 });


### PR DESCRIPTION
## Summary

Two improvements to the scheduled drift-detection workflow (`.github/workflows/test-drift.yml`), both on the same file and theme:

1. **Retry-before-alert (transient-blip hardening).** A single critical run from the collector can be a transient real-API hiccup (a streaming call failing mid-flight, no terminal event) rather than a genuine format change — and it pages the team with a false alarm. The `drift` job now runs the collector behind a wrapper that re-runs on critical drift and only alerts if the drift **persists** across every attempt.
2. **Per-provider Slack detail (original enrichment).** The alert now carries a short, scannable summary of **which** providers drifted and **what** changed, instead of forcing a click-through.

### 1. Retry-before-alert

**The problem.** On 2026-06-08 the `Drift Tests` workflow posted a 🚨 false alarm: a single OpenAI Responses `/v1/responses` streaming call failed mid-flight (emitted `error` + `response.failed`, no content events, no terminal `response.completed`). That looks identical to a critical diff to the collector, but it was OpenAI's API hiccuping, not a format change. Proof it was transient: the separate `Fix Drift` workflow re-ran the SAME collector ~1 minute later and got `Critical diffs: 0`. 11 straight green days preceded it.

**The fix.** New **`scripts/drift-retry.ts`** wraps `scripts/drift-report-collector.ts` with a "retry before alert" policy:

- Collector exit 0 → no critical drift → **SUCCESS**, no further runs (the common green path stays fast — zero extra real-API calls).
- Collector exit 2 → critical drift → retry up to **3 total attempts** with a **~45s backoff** between attempts. As soon as ANY attempt returns 0 critical → **transient → SUCCESS, no alert**.
- Only when **every** attempt shows critical drift → propagate exit 2 → the `drift` job fails → the `notify` job alerts.
- Collector exit 1 (or any other non-0/2 code) → script/infra crash, not drift → **propagate immediately, no retry** (retrying won't help; it's a real break worth surfacing).

The retry decision lives in a **pure, dependency-injected function** (`retryUntilStable`) — collector-runner, sleep, and logger are all injected — so it is unit-tested without spawning subprocesses or sleeping. `main()` wires the real collector subprocess (via `spawnSync`, stdio inherited) and a synchronous `Atomics.wait` backoff, and emits a `drift_runs` GITHUB_OUTPUT marker recording how many runs confirmed the drift. The `drift` job exposes that as a job output so the alert can note **"(confirmed across N runs)"** when it does fire. The wrapper preserves the collector's exit-code contract (0 / 2 / other), so the surrounding YAML is unchanged.

**Fix Drift interaction.** `Fix Drift` triggers on `workflow_run` when `Drift Tests` concludes `failure`. Because transient blips no longer fail `Drift Tests`, `Fix Drift` no longer runs needlessly on a one-off hiccup — it only runs after persistent drift has already been confirmed. The interaction is preserved, not broken or duplicated: `Fix Drift` still runs the collector directly (it's gated on `exit_code == 2` for the actual fix), which is correct because by the time it runs the drift was already confirmed persistent.

### 2. Per-provider Slack detail (enrichment)

- **`scripts/drift-slack-summary.ts`** reads the `drift-report.json` the collector produces, groups diffs by provider, and emits a compact Slack mrkdwn summary: one bullet per provider with a severity tally and a few representative changed field paths (capped for readability; full detail stays in the uploaded `drift-report` artifact + the **View run** link). Degrades gracefully to a generic message if the report is missing/malformed.
- The `drift` job exposes the summary as a job output (`outputs.summary`); the `notify` job inserts it as a detail block in all three drift headlines. The persistent-drift alert carries this enriched detail **plus** the "confirmed across N runs" note.

#### Example enriched + confirmed message

```
🚨 *HTTP API drift detected* in aimock — providers changed response formats.
• *OpenAI Chat* — 1 critical, 1 warning: `choices[0].message.refusal`, `choices[0].message.role`
• *Anthropic* — 1 critical: `content[0].thinking`
_(confirmed across 3 runs)_
<https://github.com/CopilotKit/aimock/actions/runs/123456|View run>
```

### Newline correctness (the GHA gotcha)

The Slack payload is built in bash and encoded with `jq -n --arg`, using real bash LF (`$'\n'`) which jq encodes as proper JSON `\n`. There is **no literal `\n` inside any `format()`/`toJSON()` expression** (the GitHub Actions trap that renders a visible backslash-n).

## Test plan

- [x] **Red-green** unit tests for `retryUntilStable` in `src/__tests__/drift-retry.test.ts` (8 tests): single clean run = no retry; critical→clean = transient success; all-critical = exit 2 with `criticalRuns` count; collector crash (exit 1) and unexpected codes propagate immediately without retry; backoff fires only between attempts (not before first / after last); per-attempt exit codes recorded in order. Verified the suite goes red when the clean-exit early-return is mutated out.
- [x] Red-green unit tests for `summarizeDriftReport` in `src/__tests__/drift-scripts.test.ts` (provider naming, severity tally, multi-entry merge, multi-provider ordering, path capping, real-newline assertion).
- [x] `pnpm test` — full suite green (3367 tests, 94 files).
- [x] `pnpm build` green; `npx tsc --noEmit` clean.
- [x] `prettier --check` and `eslint` clean on changed files.
- [x] `actionlint` introduces **no new findings** (one pre-existing info-level SC2086 on the untouched `prev` step remains; the step I edited is now fully quoted); `zizmor --min-severity medium` clean.
- [x] Verified `retryUntilStable` end-to-end via tsx: transient → exit 0, persistent → exit 2 with `criticalRuns=3`, real `Atomics.wait` backoff timing.

## Notes / limitations

- CI-workflow + tooling only: **no version bump, no CHANGELOG entry, no release.**
- Retries hit real provider APIs, so `maxAttempts` is kept small (3). A persistent format change costs at most 3 collector runs before alerting (~1.5 min extra); transient blips clear on the 2nd run.
- The "confirmed across N runs" note appears only on HTTP API drift headlines (the path that goes through the retry wrapper). AG-UI-only schema drift is deterministic (no real-API call) and does not carry the note.