### PR TITLE
fix: aimock v1.33.0 — proxy buffer cap + stabilization

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "npm",
         "package": "@copilotkit/aimock",
-        "version": "^1.32.0"
+        "version": "^1.33.0"
       },
       "description": "Fixture authoring skill for @copilotkit/aimock — LLM, multimedia (image/TTS/transcription/video), MCP, A2A, AG-UI, vector, embeddings, structured output, sequential responses, streaming physics, record/replay, agent loop patterns, and debugging"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimock",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Fixture authoring guidance for @copilotkit/aimock — LLM, multimedia, MCP, A2A, AG-UI, vector, and service mocking",
   "author": {
     "name": "CopilotKit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-06-23
+
+### Added
+
+- `--max-proxy-buffer-bytes` / `--max-proxy-buffer-frames` flags to cap proxy buffering (#275)
+
+### Fixed
+
+- Proxy path no longer leaks memory on long-lived upstream streams (#275)
+- Oversized proxied responses no longer crash with `Invalid string length` (#275)
+- Sanitize `X-AIMock-Context` to prevent fixture path traversal (#272)
+- Scope one-shot error injection, improve recorder fixture fidelity, fix `matchesPattern` lastIndex (#272)
+
 ## [1.32.0] - 2026-06-22
 
 ### Added

--- a/charts/aimock/Chart.yaml
+++ b/charts/aimock/Chart.yaml
@@ -3,4 +3,4 @@ name: aimock
 description: Mock infrastructure for AI application testing (OpenAI, Anthropic, Gemini, MCP, A2A, vector)
 type: application
 version: 0.1.0
-appVersion: "1.32.0"
+appVersion: "1.33.0"

--- a/docs/error-injection/index.html
+++ b/docs/error-injection/index.html
@@ -179,10 +179,11 @@
         <div class="info-box">
           <p>
             <strong>See also: <a href="/chaos-testing">Chaos Testing</a></strong> &mdash; for
-            probabilistic failure injection. Chaos testing adds configurable error rates, random
-            latency spikes, and stream corruption that trigger based on probability rather than
-            deterministic fixture matching. Use error injection for specific, reproducible failure
-            scenarios; use chaos testing for resilience testing under unpredictable conditions.
+            probabilistic failure injection. Chaos testing adds configurable rates for dropped
+            requests (500), malformed JSON responses, and disconnects that trigger based on
+            probability rather than deterministic fixture matching. Use error injection for
+            specific, reproducible failure scenarios; use chaos testing for resilience testing under
+            unpredictable conditions.
           </p>
         </div>
       </main>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/packages/aimock-pytest/README.md
+++ b/packages/aimock-pytest/README.md
@@ -73,7 +73,7 @@ aimock.reset()             # alias for reset_fixtures()
 
 ```
 --aimock-node PATH       Path to node binary
---aimock-version VER     aimock npm version (default: 1.32.0)
+--aimock-version VER     aimock npm version (default: 1.33.0)
 ```
 
 ## Environment Variables

--- a/packages/aimock-pytest/src/aimock_pytest/_version.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_version.py
@@ -8,4 +8,4 @@ contains any new server routes/features the client calls (e.g. the reset-split
 control routes ship in the next release). Keep it tracking npm releases.
 """
 
-AIMOCK_VERSION = "1.32.0"
+AIMOCK_VERSION = "1.33.0"

--- a/src/__tests__/llmock.test.ts
+++ b/src/__tests__/llmock.test.ts
@@ -37,6 +37,37 @@ function post(url: string, body: object): Promise<{ status: number; data: string
   });
 }
 
+function postTo(
+  url: string,
+  path: string,
+  body: object,
+): Promise<{ status: number; data: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const payload = JSON.stringify(body);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => resolve({ status: res.statusCode!, data }));
+      },
+    );
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
 function chatBody(userMessage: string, stream = true) {
   return {
     model: "gpt-4",
@@ -107,6 +138,11 @@ describe("LLMock", () => {
         },
       ]);
       expect(result).toBe(mock);
+    });
+
+    it("addFixturesFromJSON throws a contextful error on malformed JSON", () => {
+      mock = new LLMock();
+      expect(() => mock.addFixturesFromJSON("{ not valid json")).toThrow(/addFixturesFromJSON/);
     });
 
     it("chaining API works across multiple calls", () => {
@@ -818,6 +854,34 @@ describe("LLMock", () => {
       const res3 = await post(mock.url, chatBody("hello"));
       expect(res3.status).toBe(200);
       expect(res3.data).toContain("Normal response");
+    });
+
+    it("does not let an incompatible (multimedia) endpoint consume a chat-bound one-shot error", async () => {
+      mock = new LLMock();
+      mock.onMessage("hello", { content: "Hi!" });
+      mock.onImage("draw a cat", { image: { b64Json: "aW1n" } });
+      await mock.start();
+
+      // Queue a one-shot error. Conceptually intended for the chat endpoint;
+      // an error response is incompatible with the image endpoint (mirrors the
+      // router's endpoint-compat table, where only `fal` accepts errors).
+      mock.nextRequestError(503, { message: "Overloaded", type: "server_error" });
+
+      // Issue an INCOMPATIBLE image request FIRST. It must NOT consume the
+      // error: the image fixture should serve normally and the error stays
+      // pending for a compatible endpoint.
+      const img = await postTo(mock.url, "/v1/images/generations", {
+        model: "dall-e-3",
+        prompt: "draw a cat",
+      });
+      expect(img.status).toBe(200);
+      expect(img.data).toContain("aW1n");
+
+      // The one-shot error must STILL be pending → the next chat request gets it.
+      const chat = await post(mock.url, chatBody("hello"));
+      expect(chat.status).toBe(503);
+      const body = JSON.parse(chat.data);
+      expect(body.error.message).toBe("Overloaded");
     });
   });
 

--- a/src/__tests__/multimedia-types.test.ts
+++ b/src/__tests__/multimedia-types.test.ts
@@ -4,6 +4,7 @@ import {
   isAudioResponse,
   isTranscriptionResponse,
   isVideoResponse,
+  matchesPattern,
 } from "../helpers.js";
 import { matchFixture } from "../router.js";
 import type { Fixture, ChatCompletionRequest, FixtureResponse } from "../types.js";
@@ -181,5 +182,27 @@ describe("endpoint filtering in matchFixture", () => {
     // The sequence is exhausted: no fixture has a sequenceIndex matching the
     // next shared count, so further requests no longer match.
     expect(resolve()).toBeNull();
+  });
+});
+
+describe("matchesPattern", () => {
+  test("does not mutate the caller's RegExp lastIndex", () => {
+    // A global regex carries mutable `lastIndex` state. matchesPattern must
+    // not leave that state mutated, or callers reusing the same regex object
+    // (e.g. the search/rerank/moderation filter loops) get inconsistent
+    // results on subsequent uses.
+    const re = /guitar/g;
+    expect(matchesPattern("guitar", re)).toBe(true);
+    // After the call, the caller's own use of the same regex must behave as if
+    // matchesPattern never touched it.
+    expect(re.lastIndex).toBe(0);
+    expect(re.test("guitar")).toBe(true);
+  });
+
+  test("is consistent across repeated calls with the same global regex", () => {
+    const re = /g/g;
+    expect(matchesPattern("guitar", re)).toBe(true);
+    expect(matchesPattern("guitar", re)).toBe(true);
+    expect(matchesPattern("guitar", re)).toBe(true);
   });
 });

--- a/src/__tests__/multimedia-types.test.ts
+++ b/src/__tests__/multimedia-types.test.ts
@@ -26,6 +26,11 @@ describe("multimedia type guards", () => {
     expect(isImageResponse(r)).toBe(false);
   });
 
+  test("isImageResponse rejects non-object image value", () => {
+    const r = { image: "not-an-object" } as unknown as FixtureResponse;
+    expect(isImageResponse(r)).toBe(false);
+  });
+
   test("isAudioResponse detects audio (string form)", () => {
     const r: FixtureResponse = { audio: "AAAA", format: "mp3" };
     expect(isAudioResponse(r)).toBe(true);
@@ -149,7 +154,32 @@ describe("endpoint filtering in matchFixture", () => {
       _endpointType: "image",
     };
 
-    const first = matchFixture(fixtures, imageReq, counts);
-    expect(first).toBe(fixtures[0]);
+    // Pin the FULL sequence ordering this test claims to verify. matchFixture
+    // gates a sequenced fixture on its match count equalling sequenceIndex but
+    // does not itself mutate the count — the caller (journal) increments after
+    // consuming a match, and crucially advances ALL sequenced siblings sharing
+    // the same match criteria so the group shares one logical counter. Mimic
+    // that here so each call advances to the next sequenceIndex, proving the
+    // sequence resolves 0 → 1 in order and then exhausts.
+    const advanceSequence = (matched: Fixture): void => {
+      for (const f of fixtures) {
+        if (f.match.sequenceIndex !== undefined) {
+          counts.set(f, (counts.get(f) ?? 0) + 1);
+        }
+      }
+      // (matched is part of the group; the loop above already advanced it)
+      void matched;
+    };
+    const resolve = (): Fixture | null => {
+      const f = matchFixture(fixtures, imageReq, counts);
+      if (f) advanceSequence(f);
+      return f;
+    };
+
+    expect(resolve()).toBe(fixtures[0]);
+    expect(resolve()).toBe(fixtures[1]);
+    // The sequence is exhausted: no fixture has a sequenceIndex matching the
+    // next shared count, so further requests no longer match.
+    expect(resolve()).toBeNull();
   });
 });

--- a/src/__tests__/proxy-buffer-cap-enforcement.test.ts
+++ b/src/__tests__/proxy-buffer-cap-enforcement.test.ts
@@ -1,0 +1,561 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createServer, type ServerInstance } from "../server.js";
+import { Logger } from "../logger.js";
+import { setProxyBufferHardCeilingForTests } from "../recorder.js";
+
+// ---------------------------------------------------------------------------
+// Proxy-path buffer cap ENFORCEMENT (per-frame + binary + non-streamed relay).
+//
+// These tests exercise the REAL proxyAndRecord/makeUpstreamRequest path via a
+// local fake upstream and assert the cap is enforced MID-CHUNK (not just at the
+// top of the data callback) and that the non-streamed over-cap path RELAYS the
+// real body rather than synthesizing a 502.
+// ---------------------------------------------------------------------------
+
+let upstream: http.Server | undefined;
+let recorder: ServerInstance | undefined;
+let tmpDir: string | undefined;
+
+afterEach(async () => {
+  if (recorder) {
+    await new Promise<void>((resolve) => recorder!.server.close(() => resolve()));
+    recorder = undefined;
+  }
+  if (upstream) {
+    await new Promise<void>((resolve) => upstream!.close(() => resolve()));
+    upstream = undefined;
+  }
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+  // Restore the real hard ceiling after any test that lowered it.
+  setProxyBufferHardCeilingForTests(undefined);
+  vi.restoreAllMocks();
+});
+
+/**
+ * Upstream that delivers ALL `frameCount` complete SSE frames in a SINGLE
+ * socket write (one coalesced `data` event from the recorder's perspective).
+ * A2-style coalescing is the crux of the per-frame-cap bug: the top-of-callback
+ * frame guard runs ONCE before the splitter pushes every frame, so a single
+ * chunk overshoots `frameTimestamps` unboundedly unless the cap is checked
+ * per-frame inside the splitter loop.
+ */
+function createCoalescedFrameSseUpstream(frameCount: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      // One giant string: frameCount tiny frames, all in a single write.
+      const frame = 'data: {"d":"a"}\n\n';
+      res.write(frame.repeat(frameCount));
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * Binary EventStream upstream that streams bytes which NEVER complete a frame:
+ * each chunk starts with a 4-byte big-endian totalLen prefix that is larger
+ * than anything that will ever arrive (so `binaryFrameBuffer.length < totalLen`
+ * stays true forever) — modeling a never-completing / malformed binary frame.
+ */
+function createNeverCompletingBinaryUpstream(
+  totalBytes: number,
+  chunkBytes: number,
+): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "application/vnd.amazon.eventstream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      // First 4 bytes: an enormous totalLen so the frame never completes.
+      const header = Buffer.alloc(4);
+      header.writeUInt32BE(0xfffffff0, 0);
+      res.write(header);
+      let sent = 4;
+      const chunk = Buffer.alloc(chunkBytes, 0x41);
+      const writeNext = () => {
+        if (res.writableEnded || res.destroyed) return;
+        if (sent >= totalBytes) {
+          res.end();
+          return;
+        }
+        sent += chunk.length;
+        if (res.write(chunk)) setImmediate(writeNext);
+        else res.once("drain", writeNext);
+      };
+      writeNext();
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * Non-streamed (plain JSON, no SSE/NDJSON) upstream returning a body of
+ * `totalBytes`. The whole body is fully received before the recorder decides
+ * what to do — the over-cap path must RELAY it, not synthesize a 502.
+ */
+function createLargeJsonUpstream(totalBytes: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      const filler = "x".repeat(Math.max(0, totalBytes - 32));
+      const body = JSON.stringify({ id: "resp_1", big: filler });
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(body),
+      });
+      res.end(body);
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * Binary EventStream upstream that emits `frameCount` COMPLETE, well-formed
+ * frames (4-byte big-endian totalLen prefix >= 12) packed into a SINGLE socket
+ * write of exactly `frameCount * frameLen` bytes. Delivering the whole body in
+ * one write means the recorder's `binaryFrameBuffer` concats it once and the
+ * splitter drains every complete frame, leaving binaryFrameBuffer back at 0 —
+ * isolating the byte-cap accounting (`bufferedBytes`) so the redundant
+ * `+ chunk.length` double-count is the ONLY thing that can trip the cap early.
+ */
+function createCompleteBinaryFrameUpstream(frameCount: number, frameLen: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "application/vnd.amazon.eventstream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      const frame = Buffer.alloc(frameLen, 0x41);
+      frame.writeUInt32BE(frameLen, 0); // totalLen prefix == whole frame length
+      // One write of the entire body so the recorder sees a single coalesced
+      // chunk whose binary frames all complete (binaryFrameBuffer drains to 0).
+      res.end(Buffer.concat(Array.from({ length: frameCount }, () => frame)));
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * Non-streamed (plain JSON) upstream returning a body of `totalBytes` with a
+ * caller-chosen status code. Used to prove the over-cap relay normalizes the
+ * upstream status (success→200 / error→502) like every other relay path.
+ */
+function createLargeJsonUpstreamWithStatus(totalBytes: number, status: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      const filler = "x".repeat(Math.max(0, totalBytes - 32));
+      const body = JSON.stringify({ id: "resp_1", big: filler });
+      res.writeHead(status, {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(body),
+      });
+      res.end(body);
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/** Stream a POST and accumulate the relayed body length. */
+function postStreaming(
+  url: string,
+  body: unknown,
+): Promise<{ status: number; bytesReceived: number }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        let bytesReceived = 0;
+        res.on("data", (c: Buffer) => {
+          bytesReceived += c.length;
+        });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, bytesReceived }));
+        // Without a res-side error handler a mid-stream relay error hangs to
+        // timeout — fail fast instead.
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+const CHAT_REQUEST = {
+  model: "gpt-4",
+  stream: true,
+  messages: [{ role: "user", content: "stream me a lot" }],
+};
+
+const NONSTREAM_REQUEST = {
+  model: "gpt-4",
+  messages: [{ role: "user", content: "give me a big json" }],
+};
+
+describe("proxy buffer cap enforcement", () => {
+  // A1 — per-frame cap. A single coalesced chunk carrying many complete frames
+  // must NOT overshoot the frame cap. The SSE/NDJSON splitter calls Date.now()
+  // exactly once per complete frame it timestamps, so counting Date.now()
+  // invocations during the request is a deterministic, GC-immune measure of how
+  // many frames were pushed before truncation stopped the loop.
+  it("A1: bounds per-frame timestamping on a single coalesced chunk of many frames", async () => {
+    const FRAMES = 600_000; // all delivered in ONE coalesced socket write
+    const BYTE_CAP = 256 * 1024 * 1024; // generous: only the frame cap can trip
+    // Tiny frame cap: a single ~64 KB TCP segment holds ~3800 tiny frames, so
+    // ONE coalesced data event already carries far more than the cap. Buggy
+    // (top-of-callback-only) code timestamps every frame in that segment before
+    // re-checking, massively overshooting; per-frame enforcement stops at ~cap.
+    const FRAME_CAP = 100;
+
+    const upstreamUrl = await createCoalescedFrameSseUpstream(FRAMES);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-a1-"));
+
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    // Count Date.now() calls — one per per-frame timestamp push.
+    const realNow = Date.now.bind(Date);
+    let nowCalls = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      nowCalls++;
+      return realNow();
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    // Client still gets every byte.
+    expect(resp.status).toBe(200);
+
+    // The frame cap tripped and recording was skipped.
+    const truncationWarn = warnings.find((w) => /frame cap/i.test(w));
+    expect(truncationWarn).toBeDefined();
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+
+    // RED on the buggy code: the cap is only checked at the TOP of the data
+    // callback, so the single coalesced chunk's splitter loop pushes a
+    // timestamp for ALL 600k frames before the next callback ever runs —
+    // Date.now() is called ~600k times. GREEN: per-frame enforcement stops the
+    // loop at the cap, so Date.now() is called only a few thousand times. Allow
+    // generous slack (startTime + flush + a chunk-boundary's worth).
+
+    console.log(`[A1] Date.now() calls (≈ frames timestamped): ${nowCalls}`);
+    // Bound: cap + one segment's leftover slack + startTime/flush. A single TCP
+    // segment is ~64 KB ≈ 3800 frames; per-frame enforcement caps the timestamp
+    // count near FRAME_CAP, so well under 1000 total.
+    expect(nowCalls).toBeLessThan(FRAME_CAP + 900);
+  });
+
+  // A2 — binary parse buffer must be counted toward the byte cap. On a
+  // never-completing binary frame, `binaryFrameBuffer` is a SECOND, parallel
+  // copy of every byte (Buffer.concat) that the buggy code does NOT count
+  // toward `bufferedBytes`. The raw `chunks` array trips the byte cap, but only
+  // AFTER `binaryFrameBuffer` has independently grown to ~the full cap's worth
+  // of bytes — so peak memory is ~2× the cap. We spy on Buffer.concat to
+  // capture the PEAK `binaryFrameBuffer` length: counting it toward the byte
+  // cap makes truncation trip far sooner, bounding the parallel copy well below
+  // the byte cap.
+  it("A2: counts binaryFrameBuffer toward the byte cap so it cannot grow a full second copy", async () => {
+    const TOTAL = 16 * 1024 * 1024; // 16 MB of bytes, never completing a frame
+    const CHUNK = 64 * 1024;
+    const BYTE_CAP = 512 * 1024; // low byte cap
+    const FRAME_CAP = 5_000_000; // generous: frame cap cannot trip (no frames complete)
+
+    const upstreamUrl = await createNeverCompletingBinaryUpstream(TOTAL, CHUNK);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-a2-"));
+
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    // Capture the peak size of any Buffer.concat result — the binary parse
+    // buffer is rebuilt via Buffer.concat([binaryFrameBuffer, chunk]) each tick.
+    const realConcat = Buffer.concat.bind(Buffer);
+    let peakConcat = 0;
+    vi.spyOn(Buffer, "concat").mockImplementation((list: readonly Uint8Array[], len?: number) => {
+      const out = len === undefined ? realConcat(list) : realConcat(list, len);
+      if (out.length > peakConcat) peakConcat = out.length;
+      return out;
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    expect(resp.status).toBe(200);
+
+    // RED: binaryFrameBuffer grows uncounted to ~BYTE_CAP (512 KB) before the
+    // chunks byte cap trips — a full parallel copy. GREEN: binaryFrameBuffer is
+    // counted toward the byte cap, so truncation trips before it can grow a
+    // full second copy; peak stays well under the byte cap.
+    // RED: binaryFrameBuffer grows uncounted to ~BYTE_CAP (≈488 KB observed)
+    // before the chunks byte cap trips — a near-full parallel copy, so total
+    // peak ≈ 2× cap. GREEN: counting binaryFrameBuffer toward the byte cap
+    // doubles the effective per-chunk accounting, tripping truncation at ~half
+    // the data, so the parallel copy peaks well under half the byte cap.
+
+    console.log(
+      `[A2] peak binaryFrameBuffer (Buffer.concat): ${peakConcat} bytes (cap=${BYTE_CAP})`,
+    );
+    expect(peakConcat).toBeLessThan(BYTE_CAP * 0.6);
+
+    const truncationWarn = warnings.find((w) => /byte cap/i.test(w));
+    expect(truncationWarn).toBeDefined();
+
+    // Recording skipped under truncation: no fixture written.
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+  });
+
+  // A3 — non-streamed over-cap must RELAY the received body, not 502.
+  it("A3: relays the real non-streamed body when it exceeds the cap (no synthetic 502)", async () => {
+    const TOTAL = 2 * 1024 * 1024; // 2 MB JSON
+    const BYTE_CAP = 256 * 1024; // below the body size
+
+    const upstreamUrl = await createLargeJsonUpstream(TOTAL);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-a3-"));
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, NONSTREAM_REQUEST);
+
+    // RED: buggy code returns 502 with a tiny synthetic error body. GREEN:
+    // client gets 200 + the full real body relayed.
+
+    console.log(`[A3] status=${resp.status} bytesReceived=${resp.bytesReceived}`);
+    expect(resp.status).toBe(200);
+    // The full real body is relayed (~TOTAL bytes), NOT a tiny ~129-byte
+    // synthetic 502 JSON. Allow small slack for the JSON envelope overhead.
+    expect(resp.bytesReceived).toBeGreaterThan(TOTAL - 1024);
+
+    // Recording skipped (truncated), so no fixture written.
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+  });
+
+  // R2-B — the binary byte-cap must NOT double-count the current chunk.
+  // `bufferedBytes` already includes `chunk.length` by the time the binary
+  // guard runs, so the original `bufferedBytes + binaryFrameBuffer.length +
+  // chunk.length > maxBufferBytes` trips ONE CHUNK EARLY. With complete frames
+  // (binaryFrameBuffer drains to ~0 each tick) and a total exactly equal to the
+  // cap, the corrected accounting must NOT trip, but the double-count does.
+  //   RED: byte cap trips though total bytes == cap (off by one chunk);
+  //        recording is skipped.
+  //   GREEN: does NOT trip; the stream records normally (no byte-cap warning).
+  it("R2-B: does not trip the binary byte cap one chunk early (no chunk double-count)", async () => {
+    const FRAME_LEN = 64 * 1024; // 64 KiB complete frames
+    const FRAMES = 7; // total == 448 KiB
+    const BYTE_CAP = 512 * 1024; // 512 KiB — total (448 KiB) sits one full frame under the cap
+    const FRAME_CAP = 5_000_000; // generous: frame cap cannot trip
+
+    const upstreamUrl = await createCompleteBinaryFrameUpstream(FRAMES, FRAME_LEN);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-r2b-"));
+
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    console.log(
+      `[R2-B] status=${resp.status} bytesReceived=${resp.bytesReceived} cap=${BYTE_CAP} byteCapTripped=${warnings.some((w) => /byte cap/i.test(w))}`,
+    );
+    expect(resp.status).toBe(200);
+    // RED: double-count trips the byte cap at the last chunk even though total
+    // == cap. GREEN: the configured cap is reached exactly, not exceeded, so no
+    // byte-cap truncation fires.
+    expect(warnings.some((w) => /byte cap/i.test(w))).toBe(false);
+
+    // Frame cap is generous and never trips either.
+    expect(warnings.some((w) => /frame cap/i.test(w))).toBe(false);
+  });
+
+  // R2-A — a non-progressive body LARGER than the hard ceiling must NOT be
+  // relayed as a truncated-but-2xx response. Lower the hard ceiling to a tiny
+  // value so a small JSON body exceeds it (keeping the test fast). The
+  // non-progressive buffer stops growing at the hard ceiling, so the buffered
+  // copy is PARTIAL.
+  //   RED: client receives a 2xx whose body is SHORTER than what upstream sent
+  //        (truncated, presented as success) — the silent-truncation bug.
+  //   GREEN: client receives a loud 502 ("exceeds proxy ceiling"), never a
+  //        truncated 2xx. (A full pass-through relay would be the other
+  //        acceptable outcome, but this fix chose fail-loud.)
+  it("R2-A: never relays a truncated body as 2xx when upstream exceeds the hard ceiling", async () => {
+    const HARD_CEILING = 64 * 1024; // tiny test-only ceiling
+    const TOTAL = 1 * 1024 * 1024; // 1 MB body — far over the ceiling
+    const BYTE_CAP = 16 * 1024; // soft cap below the ceiling too
+
+    setProxyBufferHardCeilingForTests(HARD_CEILING);
+    const upstreamUrl = await createLargeJsonUpstream(TOTAL);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-r2a-"));
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, NONSTREAM_REQUEST);
+
+    console.log(`[R2-A] status=${resp.status} bytesReceived=${resp.bytesReceived} (sent=${TOTAL})`);
+    // GREEN invariant: never a truncated body presented as success. Either the
+    // full body (>= TOTAL) or a loud error status. A 2xx with a body shorter
+    // than upstream sent is the forbidden state.
+    const truncatedAsSuccess =
+      resp.status >= 200 && resp.status < 300 && resp.bytesReceived < TOTAL - 1024;
+    expect(truncatedAsSuccess).toBe(false);
+    // This fix chose fail-loud: a body over the ceiling returns 502.
+    expect(resp.status).toBe(502);
+
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+  });
+
+  // R2-C — over-cap (under-ceiling) relay must NORMALIZE the upstream status
+  // (success→200 / error→502) like every other relay path, not leak the raw
+  // upstream code. Upstream returns a 503 body large enough to trip the soft
+  // cap but small enough to stay under the hard ceiling.
+  //   RED: client receives 503 verbatim.
+  //   GREEN: client receives a normalized 502.
+  it("R2-C: normalizes upstream status on the over-cap relay (503 -> 502)", async () => {
+    const TOTAL = 2 * 1024 * 1024; // 2 MB — over the soft cap, under the ceiling
+    const BYTE_CAP = 256 * 1024;
+
+    const upstreamUrl = await createLargeJsonUpstreamWithStatus(TOTAL, 503);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-r2c-"));
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, NONSTREAM_REQUEST);
+
+    console.log(
+      `[R2-C] upstream=503 relayedStatus=${resp.status} bytesReceived=${resp.bytesReceived}`,
+    );
+    // RED: 503 leaked verbatim. GREEN: normalized to 502.
+    expect(resp.status).toBe(502);
+    // Body is still relayed (full real upstream body, under the ceiling).
+    expect(resp.bytesReceived).toBeGreaterThan(TOTAL - 1024);
+
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+  });
+});
+
+/**
+ * Walk `dir` recursively and return true when NO `.json` fixture exists
+ * anywhere beneath it. persistFixture can write into `slug/` or `context/`
+ * subdirectories, so a non-recursive readdir would go vacuously true even if a
+ * fixture WERE written into a subdir.
+ */
+function noFixtureWritten(dir: string): boolean {
+  if (!fs.existsSync(dir)) return true;
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+      const full = path.join(cur, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.name.endsWith(".json")) {
+        return false;
+      }
+    }
+  }
+  return true;
+}

--- a/src/__tests__/proxy-buffer-cap.test.ts
+++ b/src/__tests__/proxy-buffer-cap.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createServer, type ServerInstance } from "../server.js";
+import { Logger } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// Proxy-path upstream buffer cap.
+//
+// aimock proxies un-matched requests to a real upstream and (on that path)
+// accumulates the entire streaming response in memory to collapse/journal it.
+// With no size cap, a single very large proxied response builds a string that
+// can exceed V8's max string length (~512MB), throwing
+// `RangeError: Invalid string length`, and spikes the heap.
+//
+// These tests exercise the REAL proxyAndRecord/makeUpstreamRequest path via a
+// real local fake-upstream HTTP server streaming a large SSE body, with a
+// low test-only cap so the run stays fast.
+// ---------------------------------------------------------------------------
+
+let upstream: http.Server | undefined;
+let recorder: ServerInstance | undefined;
+let tmpDir: string | undefined;
+
+afterEach(async () => {
+  if (recorder) {
+    await new Promise<void>((resolve) => recorder!.server.close(() => resolve()));
+    recorder = undefined;
+  }
+  if (upstream) {
+    await new Promise<void>((resolve) => upstream!.close(() => resolve()));
+    upstream = undefined;
+  }
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+  vi.restoreAllMocks();
+});
+
+/**
+ * A raw upstream HTTP server that streams `frameCount` tiny complete SSE frames.
+ * Total bytes stay small (each frame is ~tens of bytes) so the BYTE cap is never
+ * the trigger — only the FRAME-COUNT cap can trip. This isolates the per-frame
+ * state leak (`frameTimestamps` grows once per frame regardless of byte size).
+ */
+function createManyFrameSseUpstream(frameCount: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      let sent = 0;
+      const writeNext = () => {
+        if (res.writableEnded || res.destroyed) return;
+        if (sent >= frameCount) {
+          res.write("data: [DONE]\n\n");
+          res.end();
+          return;
+        }
+        // A small batch per tick keeps the run fast while still flowing as
+        // distinct frames through the recorder's delimiter splitter.
+        let ok = true;
+        for (let k = 0; k < 500 && sent < frameCount && ok; k++) {
+          ok = res.write('data: {"delta":"a"}\n\n');
+          sent++;
+        }
+        if (ok) setImmediate(writeNext);
+        else res.once("drain", writeNext);
+      };
+      writeNext();
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * A raw upstream HTTP server that streams an SSE body whose total size is
+ * `totalBytes`, in fixed-size chunks. Each chunk is a valid SSE data frame so
+ * the recorder's frame-splitting logic exercises normally.
+ */
+function createLargeSseUpstream(totalBytes: number, chunkBytes: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      let sent = 0;
+      // Each frame: `data: <payload>\n\n`. Payload is a run of 'x'.
+      const overhead = "data: \n\n".length;
+      const payloadLen = Math.max(1, chunkBytes - overhead);
+      const writeNext = () => {
+        if (sent >= totalBytes) {
+          res.write("data: [DONE]\n\n");
+          res.end();
+          return;
+        }
+        const frame = `data: ${"x".repeat(payloadLen)}\n\n`;
+        sent += Buffer.byteLength(frame);
+        // Use setImmediate to let the client drain — avoids a single huge sync
+        // write and mimics a real progressive stream.
+        if (res.write(frame)) {
+          setImmediate(writeNext);
+        } else {
+          res.once("drain", writeNext);
+        }
+      };
+      writeNext();
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/** Stream a POST and accumulate the relayed body length without buffering huge strings poorly. */
+function postStreaming(
+  url: string,
+  body: unknown,
+): Promise<{ status: number; bytesReceived: number }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        let bytesReceived = 0;
+        res.on("data", (c: Buffer) => {
+          bytesReceived += c.length;
+        });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, bytesReceived }));
+        // A mid-stream relay error must fail fast — without a res-side error
+        // handler the unhandled 'error' would hang the request to timeout.
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+const CHAT_REQUEST = {
+  model: "gpt-4",
+  stream: true,
+  messages: [{ role: "user", content: "stream me a lot" }],
+};
+
+describe("proxy-path upstream buffer cap", () => {
+  it("relays the full streamed body to the client, does not throw, and bounds the in-memory buffer when the response exceeds the cap", async () => {
+    // 4 MB total stream, 64 KB chunks, with a low 256 KB cap so the buffer is
+    // forced to truncate well before the full body is accumulated. The client
+    // must still receive every relayed byte.
+    const TOTAL = 4 * 1024 * 1024;
+    const CHUNK = 64 * 1024;
+    const CAP = 256 * 1024;
+
+    const upstreamUrl = await createLargeSseUpstream(TOTAL, CHUNK);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-bufcap-"));
+
+    // Capture warnings so we can assert the truncation was logged.
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    // Client correctness: full relay regardless of cap.
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThanOrEqual(TOTAL);
+
+    // The server must NOT have crashed with Invalid string length — if it had,
+    // the relay would have been interrupted (already asserted above) and the
+    // truncation warning would be absent. Assert the BYTE cap specifically:
+    // the warning must name the byte cap, not the frame cap (the two are no
+    // longer conflated).
+    const truncationWarn = warnings.find((w) => /byte cap/i.test(w));
+    expect(truncationWarn).toBeDefined();
+    // And the frame cap must NOT be the one reported here.
+    expect(warnings.some((w) => /frame cap/i.test(w))).toBe(false);
+
+    // Recording skipped under proxy-only + truncation: no fixture written.
+    if (fs.existsSync(tmpDir)) {
+      const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith(".json"));
+      expect(files).toHaveLength(0);
+    }
+  });
+
+  it("records normally when the response stays under the cap", async () => {
+    const TOTAL = 64 * 1024;
+    const CHUNK = 8 * 1024;
+    const CAP = 4 * 1024 * 1024;
+
+    const upstreamUrl = await createLargeSseUpstream(TOTAL, CHUNK);
+
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: upstreamUrl },
+        proxyOnly: true,
+        maxProxyBufferBytes: CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThanOrEqual(TOTAL);
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-frame state cap.
+  //
+  // `frameTimestamps` (and the SSE/EventStream parse buffers) accumulate once
+  // PER FRAME for the lifetime of a proxied stream. The byte cap is
+  // count-blind, so a long-lived / never-ending stream of small frames grows
+  // this state UNBOUNDED even when the byte cap is generous. The frame-count
+  // cap bounds it: truncation must trip on frame count even though total bytes
+  // stay far below the byte cap, freeing the accumulated frame state and
+  // skipping recording — while the client still receives every byte.
+  // -------------------------------------------------------------------------
+  it("trips truncation on frame COUNT (not bytes) for a many-frame stream, freeing per-frame state, while still relaying the full body", async () => {
+    // 200k tiny frames (~4 MB total) with a generous 64 MiB byte cap so ONLY
+    // the frame cap can trip, and a low 5k frame cap so it trips early.
+    const FRAMES = 200_000;
+    const BYTE_CAP = 64 * 1024 * 1024;
+    const FRAME_CAP = 5_000;
+
+    const upstreamUrl = await createManyFrameSseUpstream(FRAMES);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-framecap-"));
+
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    // Client correctness: full relay regardless of the frame cap. The total
+    // body is well under the byte cap, so every byte must arrive.
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThan(FRAMES * 10); // ~20 bytes/frame
+
+    // The FRAME cap (not the byte cap) tripped. The previous assertion
+    // (/exceeded.*frames/i) was a tautology — the old conflated warning ALWAYS
+    // contained the word "frames" regardless of which cap fired, so it passed
+    // even if the frame-cap branch were deleted. Assert the specific
+    // cap-tripped indicator instead: the warning must name the FRAME cap, and
+    // the byte cap must NOT be the one reported (total bytes are far under it).
+    const truncationWarn = warnings.find((w) => /frame cap/i.test(w));
+    expect(truncationWarn).toBeDefined();
+    expect(warnings.some((w) => /byte cap/i.test(w))).toBe(false);
+
+    // Recording skipped under proxy-only + truncation: no fixture written
+    // (proves the accumulated frame state was dropped, not journaled).
+    if (fs.existsSync(tmpDir)) {
+      const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith(".json"));
+      expect(files).toHaveLength(0);
+    }
+  });
+
+  it("records normally when the frame count stays under the frame cap", async () => {
+    // A few hundred frames under a generous frame cap records as usual — the
+    // frame cap must NOT break the normal multi-frame streaming/recording path.
+    const FRAMES = 300;
+    const FRAME_CAP = 5_000_000;
+
+    const upstreamUrl = await createManyFrameSseUpstream(FRAMES);
+
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: upstreamUrl },
+        proxyOnly: true,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThan(FRAMES * 10);
+  });
+});

--- a/src/__tests__/recorder-blitz-fid2.test.ts
+++ b/src/__tests__/recorder-blitz-fid2.test.ts
@@ -1,0 +1,793 @@
+import { describe, it, expect, vi } from "vitest";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FixtureFile, RecordProviderKey } from "../types.js";
+import { proxyAndRecord, persistFixture, pickContentType } from "../recorder.js";
+import { slugifyTestId } from "../helpers.js";
+import { Logger } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// HTTP helper — collect status + body + headers.
+// ---------------------------------------------------------------------------
+function post(
+  url: string,
+  body: unknown,
+  opts?: { onDisconnect?: (req: http.ClientRequest) => void },
+): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString(),
+            headers: res.headers,
+          });
+        });
+        res.on("error", reject);
+        if (opts?.onDisconnect) opts.onDisconnect(req);
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Generic JSON-upstream recorder driver (mirrors recorder-deferred-fixes).
+// ---------------------------------------------------------------------------
+async function recordRawUpstream(opts: {
+  provider: RecordProviderKey;
+  endpoint: string;
+  requestBody: Record<string, unknown>;
+  responseJson: unknown;
+  prefix: string;
+}): Promise<{ fixture: FixtureFile; logger: Logger; warnSpy: ReturnType<typeof vi.spyOn> }> {
+  const { provider, endpoint, requestBody, responseJson, prefix } = opts;
+
+  const upstream = http.createServer((_upReq, upRes) => {
+    upRes.writeHead(200, { "Content-Type": "application/json" });
+    upRes.end(JSON.stringify(responseJson));
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
+  const upstreamPort = (upstream.address() as { port: number }).port;
+
+  const fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const logger = new Logger("warn");
+  const warnSpy = vi.spyOn(logger, "warn");
+
+  const recorderServer = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", async () => {
+      const rawBody = Buffer.concat(chunks).toString();
+      await proxyAndRecord(
+        req,
+        res,
+        JSON.parse(rawBody),
+        provider,
+        endpoint,
+        [],
+        {
+          record: {
+            providers: { [provider]: `http://127.0.0.1:${upstreamPort}` },
+            fixturePath,
+          },
+          logger,
+        },
+        rawBody,
+      );
+    });
+  });
+  await new Promise<void>((resolve) => recorderServer.listen(0, "127.0.0.1", () => resolve()));
+  const recorderPort = (recorderServer.address() as { port: number }).port;
+
+  try {
+    const resp = await post(`http://127.0.0.1:${recorderPort}${endpoint}`, requestBody);
+    expect(resp.status).toBe(200);
+
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files).toHaveLength(1);
+    const fixture = JSON.parse(
+      fs.readFileSync(path.join(fixturePath, files[0]), "utf-8"),
+    ) as FixtureFile;
+    return { fixture, logger, warnSpy };
+  } finally {
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    await new Promise<void>((resolve) => recorderServer.close(() => resolve()));
+    fs.rmSync(fixturePath, { recursive: true, force: true });
+  }
+}
+
+// ===========================================================================
+// Finding 3 — Gemini audio filter must key on inlineData.data presence,
+// not mimeType. Audio data with a missing/unexpected mimeType must still be
+// captured into b64Json.
+// ===========================================================================
+describe("fid2 finding 3 — Gemini audio filter keys on inlineData.data", () => {
+  it("captures audio b64Json when inlineData.data present but mimeType is missing", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "gemini",
+      endpoint: "/v1beta/models/gemini-pro:generateContent",
+      requestBody: { contents: [{ role: "user", parts: [{ text: "say hi" }] }] },
+      responseJson: {
+        candidates: [
+          {
+            content: {
+              // inlineData has data but NO mimeType field
+              parts: [{ inlineData: { data: "QUJDREVG" } }],
+            },
+          },
+        ],
+      },
+      prefix: "aimock-fid2-f3-",
+    });
+    const resp = fixture.fixtures[0].response as {
+      audio?: { b64Json?: string; contentType?: string };
+    };
+    expect(resp.audio).toBeDefined();
+    expect(resp.audio!.b64Json).toBe("QUJDREVG");
+  });
+});
+
+// ===========================================================================
+// Finding 4 — OpenAI non-streaming reasoning: read message.reasoning
+// (DeepSeek/OpenRouter) in addition to reasoning_content.
+// ===========================================================================
+describe("fid2 finding 4 — OpenAI reasoning reads message.reasoning", () => {
+  it("captures message.reasoning when reasoning_content is absent", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/chat/completions",
+      requestBody: { model: "deepseek-reasoner", messages: [{ role: "user", content: "2+2?" }] },
+      responseJson: {
+        choices: [
+          {
+            message: {
+              content: "4",
+              // DeepSeek/OpenRouter use `reasoning`, not `reasoning_content`
+              reasoning: "Let me add 2 and 2.",
+            },
+          },
+        ],
+      },
+      prefix: "aimock-fid2-f4-",
+    });
+    const resp = fixture.fixtures[0].response as { content?: string; reasoning?: string };
+    expect(resp.content).toBe("4");
+    expect(resp.reasoning).toBe("Let me add 2 and 2.");
+  });
+});
+
+// ===========================================================================
+// Finding 5 — Cohere v2: capture ALL text blocks (not just first), and
+// route correctly even though it shares `message` with Ollama.
+// ===========================================================================
+describe("fid2 finding 5 — Cohere v2 multi-block + routing", () => {
+  it("captures and joins ALL text blocks, not just the first", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "cohere",
+      endpoint: "/v2/chat",
+      requestBody: { model: "command-r", messages: [{ role: "user", content: "hi" }] },
+      responseJson: {
+        finish_reason: "complete",
+        message: {
+          content: [
+            { type: "text", text: "Hello " },
+            { type: "text", text: "world" },
+          ],
+        },
+      },
+      prefix: "aimock-fid2-f5-multi-",
+    });
+    const resp = fixture.fixtures[0].response as { content?: string };
+    expect(resp.content).toBe("Hello world");
+  });
+
+  it("does not mis-route a Cohere empty-content response to the Ollama path", async () => {
+    // Cohere v2 with empty text content + no tool calls. The Cohere branch must
+    // own this turn and produce a recognized (content:"") fixture, NOT fall
+    // through to Ollama which would re-handle `message.content` array.
+    const { fixture } = await recordRawUpstream({
+      provider: "cohere",
+      endpoint: "/v2/chat",
+      requestBody: { model: "command-r", messages: [{ role: "user", content: "hi" }] },
+      responseJson: {
+        finish_reason: "complete",
+        message: { content: [{ type: "text", text: "" }] },
+      },
+      prefix: "aimock-fid2-f5-empty-",
+    });
+    const resp = fixture.fixtures[0].response as { content?: string; error?: unknown };
+    expect(resp.error).toBeUndefined();
+    expect(resp.content).toBe("");
+  });
+});
+
+// ===========================================================================
+// Finding 9 — Transcription detector too loose. A non-transcription chat-ish
+// response that merely has a string `text` + a `duration`-like field must NOT
+// be misclassified as a transcription.
+// ===========================================================================
+describe("fid2 finding 9 — transcription detector tightened", () => {
+  it("does not misclassify a non-transcription response as transcription", async () => {
+    // No `task: transcribe`, no language; only an incidental `duration` number
+    // alongside a `text` string, plus a clearly-chat marker (`object`).
+    const { fixture } = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/chat/completions",
+      requestBody: { model: "gpt-4", messages: [{ role: "user", content: "hi" }] },
+      responseJson: {
+        object: "some.event",
+        text: "incidental text field",
+        duration: 12,
+      },
+      prefix: "aimock-fid2-f9-",
+    });
+    const resp = fixture.fixtures[0].response as { transcription?: unknown };
+    expect(resp.transcription).toBeUndefined();
+  });
+
+  it("still classifies a genuine transcription (task=transcribe)", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/audio/transcriptions",
+      requestBody: { model: "whisper-1" },
+      responseJson: { task: "transcribe", text: "hello there", language: "english" },
+      prefix: "aimock-fid2-f9-ok-",
+    });
+    const resp = fixture.fixtures[0].response as { transcription?: { text?: string } };
+    expect(resp.transcription).toBeDefined();
+    expect(resp.transcription!.text).toBe("hello there");
+  });
+});
+
+// ===========================================================================
+// Finding 10 — Image batch: an empty-string b64_json item must not silently
+// vanish, and an all-empty batch must log a warning on fallthrough.
+// ===========================================================================
+describe("fid2 finding 10 — image batch empty-string handling", () => {
+  it("logs a warning when items are dropped from an image batch (empty-string b64_json)", async () => {
+    // A batch where one item carries valid media and another carries an
+    // empty-string b64_json. The empty item is dropped from the persisted
+    // fixture; that drop must be logged (silent fidelity loss otherwise).
+    const { warnSpy, fixture } = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/images/generations",
+      requestBody: { model: "dall-e-3", prompt: "x" },
+      responseJson: {
+        created: 1,
+        data: [{ b64_json: "VkFMSUQ=" }, { b64_json: "" }],
+      },
+      prefix: "aimock-fid2-f10-",
+    });
+    // The valid item is preserved.
+    const resp = fixture.fixtures[0].response as {
+      images?: Array<Record<string, unknown>>;
+      image?: Record<string, unknown>;
+    };
+    const entries = resp.images ?? (resp.image ? [resp.image] : []);
+    expect(entries.some((e) => e.b64Json === "VkFMSUQ=")).toBe(true);
+    // The dropped empty item must be logged with a specific drop message
+    // (NOT merely the incidental "proxying to .../images/..." URL log).
+    const warned = warnSpy.mock.calls.some((args) =>
+      args.some(
+        (a) =>
+          typeof a === "string" && /dropp(ed|ing)|skipp(ed|ing)|empty/i.test(a) && /image/i.test(a),
+      ),
+    );
+    expect(warned).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Finding 12 — Ollama /api/generate detection too broad. A response that has
+// a `response` string and a `done`-like field but is clearly NOT Ollama must
+// not be captured by the Ollama generate branch when other markers exist.
+// (Tighten: require done to be a boolean, the Ollama contract.)
+// ===========================================================================
+describe("fid2 finding 12 — Ollama /api/generate detection narrowed", () => {
+  it("does not capture a non-Ollama response whose `done` is not a boolean", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/chat/completions",
+      requestBody: { model: "gpt-4", messages: [{ role: "user", content: "hi" }] },
+      // `response` string + `done` present but `done` is a string, not the
+      // boolean Ollama always sends. Should NOT be treated as Ollama generate.
+      responseJson: { response: "not ollama", done: "nope" },
+      prefix: "aimock-fid2-f12-",
+    });
+    const resp = fixture.fixtures[0].response as { content?: string; error?: unknown };
+    expect(resp.content).not.toBe("not ollama");
+    expect(resp.error).toBeDefined();
+  });
+
+  it("still captures a genuine Ollama /api/generate response (done boolean)", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "ollama",
+      endpoint: "/api/generate",
+      requestBody: { model: "llama3", prompt: "hi" },
+      responseJson: { response: "hello from ollama", done: true },
+      prefix: "aimock-fid2-f12-ok-",
+    });
+    const resp = fixture.fixtures[0].response as { content?: string };
+    expect(resp.content).toBe("hello from ollama");
+  });
+});
+
+// ===========================================================================
+// Finding 1 — Mid-stream upstream error during streaming relay must be
+// surfaced, not delivered as a silent truncated 200.
+// ===========================================================================
+describe("fid2 finding 1 — mid-stream upstream error surfaced", () => {
+  it("does not persist a truncated fixture when the upstream stream errors mid-flight", async () => {
+    // Upstream sends SSE headers + one frame, then destroys the socket
+    // abruptly (simulating a mid-stream network failure).
+    const upstream = http.createServer((_upReq, upRes) => {
+      upRes.writeHead(200, { "Content-Type": "text/event-stream" });
+      upRes.write('data: {"choices":[{"delta":{"content":"par"}}]}\n\n');
+      // Abruptly destroy the underlying socket mid-stream.
+      setTimeout(() => upRes.socket?.destroy(), 20);
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-fid2-f1-"));
+    const logger = new Logger("warn");
+
+    const recorderServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", async () => {
+        const rawBody = Buffer.concat(chunks).toString();
+        await proxyAndRecord(
+          req,
+          res,
+          JSON.parse(rawBody),
+          "openai",
+          "/v1/chat/completions",
+          [],
+          {
+            record: {
+              providers: { openai: `http://127.0.0.1:${upstreamPort}` },
+              fixturePath,
+            },
+            logger,
+          },
+          rawBody,
+        );
+      });
+    });
+    await new Promise<void>((resolve) => recorderServer.listen(0, "127.0.0.1", () => resolve()));
+    const recorderPort = (recorderServer.address() as { port: number }).port;
+
+    try {
+      // Drive a raw client so we can observe whether the relay terminates with
+      // a clean EOF (silent truncation — bug) or an aborted connection (correct
+      // surfacing of the upstream failure).
+      const clientOutcome = await new Promise<"clean_end" | "aborted">((resolve) => {
+        const req = http.request(
+          {
+            hostname: "127.0.0.1",
+            port: recorderPort,
+            path: "/v1/chat/completions",
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          },
+          (res) => {
+            let settled = false;
+            res.on("data", () => {});
+            res.on("end", () => {
+              if (!settled) {
+                settled = true;
+                resolve("clean_end");
+              }
+            });
+            res.on("aborted", () => {
+              if (!settled) {
+                settled = true;
+                resolve("aborted");
+              }
+            });
+            res.on("error", () => {
+              if (!settled) {
+                settled = true;
+                resolve("aborted");
+              }
+            });
+          },
+        );
+        req.on("error", () => resolve("aborted"));
+        req.end(
+          JSON.stringify({
+            model: "gpt-4",
+            stream: true,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        );
+      });
+
+      // A mid-stream upstream failure must be surfaced to the client as an
+      // aborted connection, NOT a clean EOF that masquerades as a complete
+      // (but truncated) 200 response.
+      expect(clientOutcome).toBe("aborted");
+
+      // And the truncated stream must NOT be persisted as a clean fixture.
+      const files = fs.existsSync(fixturePath)
+        ? fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"))
+        : [];
+      expect(files).toHaveLength(0);
+    } finally {
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+      await new Promise<void>((resolve) => recorderServer.close(() => resolve()));
+      fs.rmSync(fixturePath, { recursive: true, force: true });
+    }
+  });
+});
+
+// ===========================================================================
+// Finding 7 — Array content-type must not be join(", ")-ed into a malformed
+// Content-Type relayed to the client; pick the first.
+// ===========================================================================
+describe("fid2 finding 7 — array content-type resolved to a single value", () => {
+  it("picks the first element of an array content-type rather than join(', ')-ing it", () => {
+    // Node normally collapses duplicate Content-Type response headers to a
+    // single string, but `http.IncomingHttpHeaders` types content-type as
+    // string | string[], and constructed/proxied header objects CAN be arrays.
+    // join(', ') yields a malformed `Content-Type: application/json, text/html`
+    // header — pick the first instead.
+    const result = pickContentType(["application/json", "text/html; charset=utf-8"]);
+    expect(result).toBe("application/json");
+    // Must NOT be the malformed comma-joined value.
+    expect(result).not.toContain(", ");
+  });
+
+  it("passes a plain string through and tolerates undefined/empty arrays", () => {
+    expect(pickContentType("text/event-stream")).toBe("text/event-stream");
+    expect(pickContentType(undefined)).toBe("");
+    expect(pickContentType([])).toBe("");
+  });
+});
+
+// ===========================================================================
+// Finding 8 — empty-body audio response must not become a proxy_error fixture.
+// ===========================================================================
+describe("fid2 finding 8 — empty-body audio handled as audio shape", () => {
+  it("does not record an empty audio response as a proxy_error", async () => {
+    const upstream = http.createServer((_upReq, upRes) => {
+      upRes.writeHead(200, { "Content-Type": "audio/mpeg" });
+      upRes.end(); // zero-length audio body
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-fid2-f8-"));
+    const logger = new Logger("warn");
+
+    const recorderServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", async () => {
+        const rawBody = Buffer.concat(chunks).toString();
+        await proxyAndRecord(
+          req,
+          res,
+          JSON.parse(rawBody),
+          "openai",
+          "/v1/audio/speech",
+          [],
+          {
+            record: { providers: { openai: `http://127.0.0.1:${upstreamPort}` }, fixturePath },
+            logger,
+          },
+          rawBody,
+        );
+      });
+    });
+    await new Promise<void>((resolve) => recorderServer.listen(0, "127.0.0.1", () => resolve()));
+    const recorderPort = (recorderServer.address() as { port: number }).port;
+
+    try {
+      const resp = await post(`http://127.0.0.1:${recorderPort}/v1/audio/speech`, {
+        model: "tts-1",
+        input: "hi",
+        voice: "alloy",
+      });
+      expect(resp.status).toBe(200);
+      const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+      expect(files).toHaveLength(1);
+      const fixture = JSON.parse(
+        fs.readFileSync(path.join(fixturePath, files[0]), "utf-8"),
+      ) as FixtureFile;
+      const r = fixture.fixtures[0].response as { error?: { type?: string }; audio?: unknown };
+      // An empty audio body must NOT be classified as a proxy_error.
+      expect(r.error?.type).not.toBe("proxy_error");
+    } finally {
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+      await new Promise<void>((resolve) => recorderServer.close(() => resolve()));
+      fs.rmSync(fixturePath, { recursive: true, force: true });
+    }
+  });
+});
+
+// ===========================================================================
+// Finding 11 — `_warning` must not fragment a warning containing "; ".
+// ===========================================================================
+describe("fid2 finding 11 — _warning does not fragment on embedded '; '", () => {
+  it("round-trips a snapshot merge without fragmenting an embedded-semicolon warning", async () => {
+    // We exercise persistFixture indirectly: first capture an over-cap warning
+    // into a snapshot file, then verify the structure round-trips. Since the
+    // existing join("; ") + split("; ") fragments any warning text containing
+    // "; ", we assert that a single logical warning survives as one element.
+    const fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-fid2-f11-"));
+    const logger = new Logger("silent");
+    const testId = "fid2-f11-snapshot";
+    const warnA = "captured A; then B happened";
+    const warnB = "second warning";
+    try {
+      // First write with a warning that itself contains "; ".
+      persistFixture({
+        record: { providers: {}, fixturePath },
+        providerKey: "openai",
+        testId,
+        fixture: { match: { userMessage: "one" }, response: { content: "x" } },
+        fixtures: [],
+        warnings: [warnA],
+        logger,
+      });
+      // Second write (snapshot merge) with a DISTINCT new warning — the prior
+      // semicolon-bearing warning must be carried forward as ONE logical entry,
+      // not fragmented into "captured A" + "then B happened" which would then
+      // mingle with warnB.
+      persistFixture({
+        record: { providers: {}, fixturePath },
+        providerKey: "openai",
+        testId,
+        fixture: { match: { userMessage: "two" }, response: { content: "y" } },
+        fixtures: [],
+        warnings: [warnB],
+        logger,
+      });
+      const file = path.join(fixturePath, slugifyTestId(testId), "openai.json");
+      const parsed = JSON.parse(fs.readFileSync(file, "utf-8")) as {
+        _warning?: string;
+        _warnings?: string[];
+      };
+      // The contract: each logical warning survives intact as its own element.
+      // A join("; ")/split("; ") round-trip fragments warnA into two entries.
+      const stored: string[] = Array.isArray(parsed._warnings)
+        ? parsed._warnings
+        : typeof parsed._warning === "string"
+          ? parsed._warning.split("; ")
+          : [];
+      expect(stored).toContain(warnA);
+      expect(stored).toContain(warnB);
+      // The fragments must NOT appear as standalone entries.
+      expect(stored).not.toContain("captured A");
+      expect(stored).not.toContain("then B happened");
+    } finally {
+      fs.rmSync(fixturePath, { recursive: true, force: true });
+    }
+  });
+});
+
+// ===========================================================================
+// Finding 6 — ttftMs must be based on request-send time, not headers-received
+// time. An upstream that delays its headers (TTFB) before streaming the first
+// frame must have that latency reflected in ttftMs.
+// ===========================================================================
+describe("fid2 finding 6 — ttftMs measured from request send", () => {
+  it("includes pre-headers latency in ttftMs", async () => {
+    const HEADER_DELAY_MS = 120;
+    // Upstream waits HEADER_DELAY_MS before sending SSE headers + frames.
+    const upstream = http.createServer((_upReq, upRes) => {
+      setTimeout(() => {
+        upRes.writeHead(200, { "Content-Type": "text/event-stream" });
+        upRes.write('data: {"choices":[{"delta":{"content":"a"}}]}\n\n');
+        setTimeout(() => {
+          upRes.write('data: {"choices":[{"delta":{"content":"b"}}]}\n\n');
+          upRes.write("data: [DONE]\n\n");
+          upRes.end();
+        }, 10);
+      }, HEADER_DELAY_MS);
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-fid2-f6-"));
+    const logger = new Logger("silent");
+
+    const recorderServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", async () => {
+        const rawBody = Buffer.concat(chunks).toString();
+        await proxyAndRecord(
+          req,
+          res,
+          JSON.parse(rawBody),
+          "openai",
+          "/v1/chat/completions",
+          [],
+          {
+            record: { providers: { openai: `http://127.0.0.1:${upstreamPort}` }, fixturePath },
+            logger,
+          },
+          rawBody,
+        );
+      });
+    });
+    await new Promise<void>((resolve) => recorderServer.listen(0, "127.0.0.1", () => resolve()));
+    const recorderPort = (recorderServer.address() as { port: number }).port;
+
+    try {
+      const resp = await post(`http://127.0.0.1:${recorderPort}/v1/chat/completions`, {
+        model: "gpt-4",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(resp.status).toBe(200);
+      const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+      expect(files).toHaveLength(1);
+      const fixture = JSON.parse(
+        fs.readFileSync(path.join(fixturePath, files[0]), "utf-8"),
+      ) as FixtureFile;
+      const timings = (fixture.fixtures[0] as { recordedTimings?: { ttftMs?: number } })
+        .recordedTimings;
+      expect(timings).toBeDefined();
+      // ttft must reflect the time-to-first-token from request send, which
+      // includes the upstream's pre-headers latency. Computing it from
+      // headers-received time would understate it to near-zero.
+      expect(timings!.ttftMs!).toBeGreaterThanOrEqual(HEADER_DELAY_MS * 0.7);
+    } finally {
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+      await new Promise<void>((resolve) => recorderServer.close(() => resolve()));
+      fs.rmSync(fixturePath, { recursive: true, force: true });
+    }
+  });
+});
+
+// ===========================================================================
+// Finding 2 — client disconnect mid-relay must not persist a fixture and must
+// not leave corrupt/partial journal state.
+// ===========================================================================
+describe("fid2 finding 2 — client disconnect leaves no fixture", () => {
+  it("persists no fixture when the client disconnects mid-stream", async () => {
+    // Upstream streams slowly; client disconnects after the first frame.
+    const upstream = http.createServer((_upReq, upRes) => {
+      upRes.writeHead(200, { "Content-Type": "text/event-stream" });
+      upRes.write('data: {"choices":[{"delta":{"content":"x"}}]}\n\n');
+      const iv = setInterval(() => {
+        if (!upRes.writableEnded) {
+          try {
+            upRes.write('data: {"choices":[{"delta":{"content":"y"}}]}\n\n');
+          } catch {
+            clearInterval(iv);
+          }
+        }
+      }, 25);
+      upRes.on("close", () => clearInterval(iv));
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
+    const upstreamPort = (upstream.address() as { port: number }).port;
+    const fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-fid2-f2-"));
+    const logger = new Logger("silent");
+
+    const recorderServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", async () => {
+        const rawBody = Buffer.concat(chunks).toString();
+        await proxyAndRecord(
+          req,
+          res,
+          JSON.parse(rawBody),
+          "openai",
+          "/v1/chat/completions",
+          [],
+          {
+            record: { providers: { openai: `http://127.0.0.1:${upstreamPort}` }, fixturePath },
+            logger,
+          },
+          rawBody,
+        );
+      });
+    });
+    await new Promise<void>((resolve) => recorderServer.listen(0, "127.0.0.1", () => resolve()));
+    const recorderPort = (recorderServer.address() as { port: number }).port;
+
+    try {
+      await new Promise<void>((resolve) => {
+        const req = http.request(
+          {
+            hostname: "127.0.0.1",
+            port: recorderPort,
+            path: "/v1/chat/completions",
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          },
+          (res) => {
+            res.once("data", () => {
+              // Abruptly disconnect after the first frame.
+              req.destroy();
+              resolve();
+            });
+            res.on("error", () => resolve());
+          },
+        );
+        req.on("error", () => resolve());
+        req.end(
+          JSON.stringify({
+            model: "gpt-4",
+            stream: true,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        );
+      });
+
+      // Give the recorder a moment to settle its end/close handlers.
+      await new Promise<void>((resolve) => setTimeout(resolve, 120));
+
+      // A client disconnect must NOT leave a persisted (truncated) fixture, and
+      // there must be no leftover .tmp half-written journal file.
+      const all = fs.existsSync(fixturePath) ? fs.readdirSync(fixturePath) : [];
+      const jsons = all.filter((f) => f.endsWith(".json"));
+      const tmps = all.filter((f) => f.includes(".tmp."));
+      expect(jsons).toHaveLength(0);
+      expect(tmps).toHaveLength(0);
+    } finally {
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+      await new Promise<void>((resolve) => recorderServer.close(() => resolve()));
+      fs.rmSync(fixturePath, { recursive: true, force: true });
+    }
+  });
+});
+
+// ===========================================================================
+// Finding 13 — dead encodingFormat param removed (pure cleanup). This pins the
+// behavior the dead param never affected: base64 embeddings decode identically
+// WITH and WITHOUT `encoding_format` echoed in the request body.
+// ===========================================================================
+describe("fid2 finding 13 — base64 embedding decode unaffected by encoding_format", () => {
+  // Float32Array([0.1, 0.2, 0.3]) base64-encoded.
+  const VALID_B64 = "zczMPc3MTD6amZk+";
+
+  it("decodes identically whether or not encoding_format is echoed", async () => {
+    const withEcho = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/embeddings",
+      requestBody: { model: "text-embedding-3-small", input: "x", encoding_format: "base64" },
+      responseJson: { data: [{ embedding: VALID_B64 }] },
+      prefix: "aimock-fid2-f13-echo-",
+    });
+    const withoutEcho = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/embeddings",
+      requestBody: { model: "text-embedding-3-small", input: "x" },
+      responseJson: { data: [{ embedding: VALID_B64 }] },
+      prefix: "aimock-fid2-f13-noecho-",
+    });
+    const a = withEcho.fixture.fixtures[0].response as { embedding?: number[] };
+    const b = withoutEcho.fixture.fixtures[0].response as { embedding?: number[] };
+    expect(a.embedding).toBeDefined();
+    expect(b.embedding).toBeDefined();
+    expect(a.embedding).toEqual(b.embedding);
+    expect(a.embedding).toHaveLength(3);
+    expect(a.embedding![0]).toBeCloseTo(0.1, 5);
+  });
+});

--- a/src/__tests__/recorder-deferred-fixes.test.ts
+++ b/src/__tests__/recorder-deferred-fixes.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi } from "vitest";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FixtureFile, RecordProviderKey } from "../types.js";
+import { proxyAndRecord } from "../recorder.js";
+import { Logger } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// HTTP helper
+// ---------------------------------------------------------------------------
+
+function post(url: string, body: unknown): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Generic: drive a RAW upstream that returns exactly `responseJson`, record
+// through proxyAndRecord, and return the persisted fixture file (+ logger).
+// This exercises the REAL recorder path (proxyAndRecord -> buildFixtureResponse
+// -> persistFixture), not buildFixtureResponse in isolation.
+// ---------------------------------------------------------------------------
+
+async function recordRawUpstream(opts: {
+  provider: RecordProviderKey;
+  endpoint: string;
+  requestBody: Record<string, unknown>;
+  responseJson: unknown;
+  prefix: string;
+}): Promise<{ fixture: FixtureFile; logger: Logger; warnSpy: ReturnType<typeof vi.spyOn> }> {
+  const { provider, endpoint, requestBody, responseJson, prefix } = opts;
+
+  const upstream = http.createServer((_upReq, upRes) => {
+    upRes.writeHead(200, { "Content-Type": "application/json" });
+    upRes.end(JSON.stringify(responseJson));
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
+  const upstreamPort = (upstream.address() as { port: number }).port;
+
+  const fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const logger = new Logger("warn");
+  const warnSpy = vi.spyOn(logger, "warn");
+
+  const recorderServer = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", async () => {
+      const rawBody = Buffer.concat(chunks).toString();
+      await proxyAndRecord(
+        req,
+        res,
+        JSON.parse(rawBody),
+        provider,
+        endpoint,
+        [],
+        {
+          record: {
+            providers: { [provider]: `http://127.0.0.1:${upstreamPort}` },
+            fixturePath,
+          },
+          logger,
+        },
+        rawBody,
+      );
+    });
+  });
+  await new Promise<void>((resolve) => recorderServer.listen(0, "127.0.0.1", () => resolve()));
+  const recorderPort = (recorderServer.address() as { port: number }).port;
+
+  try {
+    const resp = await post(`http://127.0.0.1:${recorderPort}${endpoint}`, requestBody);
+    expect(resp.status).toBe(200);
+
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files).toHaveLength(1);
+    const fixture = JSON.parse(
+      fs.readFileSync(path.join(fixturePath, files[0]), "utf-8"),
+    ) as FixtureFile;
+    return { fixture, logger, warnSpy };
+  } finally {
+    // NOTE: do not mockRestore() here — the caller still needs to inspect
+    // warnSpy.mock.calls after this helper returns. The Logger instance is
+    // local and discarded, so the spy needs no cleanup.
+    await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    await new Promise<void>((resolve) => recorderServer.close(() => resolve()));
+    fs.rmSync(fixturePath, { recursive: true, force: true });
+  }
+}
+
+type ToolCallResp = { toolCalls?: Array<{ name: string; arguments: unknown }> };
+
+// ===========================================================================
+// Fix 1: tool-call `arguments` must ALWAYS be a string ("{}" when missing)
+// ===========================================================================
+
+describe("recorder fix #1 — tool-call arguments coalesce to string", () => {
+  it("Gemini functionCall with missing args persists arguments as a string", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "gemini",
+      endpoint: "/v1beta/models/gemini-pro:generateContent",
+      requestBody: { contents: [{ role: "user", parts: [{ text: "weather?" }] }] },
+      responseJson: {
+        candidates: [
+          {
+            content: {
+              parts: [
+                // functionCall with NO `args` field at all
+                { functionCall: { name: "get_weather" } },
+              ],
+            },
+          },
+        ],
+      },
+      prefix: "aimock-fix1-gemini-",
+    });
+    const resp = fixture.fixtures[0].response as ToolCallResp;
+    expect(resp.toolCalls).toBeDefined();
+    expect(resp.toolCalls).toHaveLength(1);
+    // CONTRACT: arguments is always a string (types.ts ToolCall.arguments: string)
+    expect(typeof resp.toolCalls![0].arguments).toBe("string");
+    expect(resp.toolCalls![0].arguments).toBe("{}");
+  });
+
+  it("Cohere v2 message-level tool_call with no args/parameters persists arguments as a string", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "cohere",
+      endpoint: "/v2/chat",
+      requestBody: { model: "command-r", messages: [{ role: "user", content: "weather?" }] },
+      responseJson: {
+        finish_reason: "tool_call",
+        message: {
+          content: [],
+          // message-level tool_calls with a function carrying NO arguments
+          tool_calls: [{ id: "tc1", type: "function", function: { name: "get_weather" } }],
+        },
+      },
+      prefix: "aimock-fix1-cohere-",
+    });
+    const resp = fixture.fixtures[0].response as ToolCallResp;
+    expect(resp.toolCalls).toBeDefined();
+    expect(resp.toolCalls).toHaveLength(1);
+    expect(typeof resp.toolCalls![0].arguments).toBe("string");
+    expect(resp.toolCalls![0].arguments).toBe("{}");
+  });
+
+  it("Gemini Interactions function_call with missing arguments persists arguments as a string", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "gemini",
+      endpoint: "/v1beta/models/gemini-pro:generateContent",
+      requestBody: { contents: [{ role: "user", parts: [{ text: "weather?" }] }] },
+      responseJson: {
+        id: "resp1",
+        status: "completed",
+        outputs: [{ type: "function_call", name: "get_weather", id: "fc1" }],
+      },
+      prefix: "aimock-fix1-gemini-interactions-",
+    });
+    const resp = fixture.fixtures[0].response as ToolCallResp;
+    expect(resp.toolCalls).toBeDefined();
+    expect(resp.toolCalls).toHaveLength(1);
+    expect(typeof resp.toolCalls![0].arguments).toBe("string");
+    expect(resp.toolCalls![0].arguments).toBe("{}");
+  });
+
+  it("Bedrock Converse toolUse with missing input persists arguments as a string", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "bedrock",
+      endpoint: "/model/anthropic.claude-3/converse",
+      requestBody: { messages: [{ role: "user", content: [{ text: "weather?" }] }] },
+      responseJson: {
+        output: {
+          message: {
+            role: "assistant",
+            content: [{ toolUse: { name: "get_weather", toolUseId: "tu1" } }],
+          },
+        },
+      },
+      prefix: "aimock-fix1-bedrock-",
+    });
+    const resp = fixture.fixtures[0].response as ToolCallResp;
+    expect(resp.toolCalls).toBeDefined();
+    expect(resp.toolCalls).toHaveLength(1);
+    expect(typeof resp.toolCalls![0].arguments).toBe("string");
+    expect(resp.toolCalls![0].arguments).toBe("{}");
+  });
+});
+
+// ===========================================================================
+// Fix 2: base64 embeddings decoded regardless of request `encoding_format`,
+// and malformed base64 handled (not silently dropped to {embedding:[]})
+// ===========================================================================
+
+describe("recorder fix #2 — base64 embedding decode gating", () => {
+  // Float32Array([0.1, 0.2, 0.3]) encoded to base64 (12 bytes, %4 == 0)
+  const VALID_B64 = "zczMPc3MTD6amZk+";
+
+  it("decodes a base64 embedding even when request did not echo encoding_format", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/embeddings",
+      // NOTE: no encoding_format in the request
+      requestBody: { model: "text-embedding-3-small", input: "hello world" },
+      responseJson: { data: [{ embedding: VALID_B64 }] },
+      prefix: "aimock-fix2-noecho-",
+    });
+    const resp = fixture.fixtures[0].response as { embedding?: number[]; error?: unknown };
+    expect(resp.error).toBeUndefined();
+    expect(resp.embedding).toBeDefined();
+    expect(resp.embedding).toHaveLength(3);
+    expect(resp.embedding![0]).toBeCloseTo(0.1, 5);
+    expect(resp.embedding![1]).toBeCloseTo(0.2, 5);
+    expect(resp.embedding![2]).toBeCloseTo(0.3, 5);
+  });
+
+  it("warns and does not silently emit a zero-dim embedding for malformed base64", async () => {
+    // "AQIDBAU=" decodes to 5 bytes (byteLength % 4 !== 0)
+    const MALFORMED_B64 = "AQIDBAU=";
+    const { fixture, warnSpy } = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/embeddings",
+      requestBody: { model: "text-embedding-3-small", input: "hello world" },
+      responseJson: { data: [{ embedding: MALFORMED_B64 }] },
+      prefix: "aimock-fix2-malformed-",
+    });
+    // A malformed base64 embedding must be diagnosed (logged), not silently
+    // collapsed into a valid-looking zero-dimension embedding fixture.
+    const warned = warnSpy.mock.calls.some((args) =>
+      args.some((a) => typeof a === "string" && /embedding/i.test(a)),
+    );
+    expect(warned).toBe(true);
+    const resp = fixture.fixtures[0].response as {
+      embedding?: number[];
+      error?: { message?: string; type?: string };
+    };
+    // CONTRACT: a malformed base64 embedding must NOT produce ANY embedding
+    // field — not an empty array, and not a misleadingly-populated one. The
+    // previous assertion (`not.toEqual([])`) passed trivially even when
+    // `embedding` was `undefined`, so it never actually pinned this contract.
+    expect(resp.embedding).toBeUndefined();
+    // It must instead be recorded as a diagnosable error fixture.
+    expect(resp.error).toBeDefined();
+    expect(typeof resp.error!.message).toBe("string");
+  });
+});
+
+// ===========================================================================
+// Fix 3: OpenAI image `data` mapping must skip items lacking url + b64_json
+// ===========================================================================
+
+describe("recorder fix #3 — OpenAI image data multi-item mapping", () => {
+  it("does not emit empty {} image entries for items lacking url and b64_json", async () => {
+    const { fixture } = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/images/generations",
+      requestBody: { model: "dall-e-3", prompt: "a cat", n: 2 },
+      responseJson: {
+        created: 123,
+        data: [
+          { url: "https://example.com/a.png", revised_prompt: "a fluffy cat" },
+          // second item lacks BOTH url and b64_json
+          { revised_prompt: "discarded" },
+        ],
+      },
+      prefix: "aimock-fix3-images-",
+    });
+    const resp = fixture.fixtures[0].response as {
+      images?: Array<Record<string, unknown>>;
+      image?: Record<string, unknown>;
+    };
+    const entries = resp.images ?? (resp.image ? [resp.image] : []);
+    // No entry may be an empty object: every recorded image must carry a url or b64Json.
+    for (const e of entries) {
+      const hasMedia = "url" in e || "b64Json" in e;
+      expect(hasMedia).toBe(true);
+    }
+    // The single valid item is preserved.
+    expect(entries.some((e) => e.url === "https://example.com/a.png")).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Fix 4: unknown upstream shape must log the raw body/shape for diagnosability
+// ===========================================================================
+
+describe("recorder fix #4 — unknown upstream shape logging", () => {
+  it("logs a warning with the object shape when the upstream shape is unrecognized", async () => {
+    const { fixture, warnSpy } = await recordRawUpstream({
+      provider: "openai",
+      endpoint: "/v1/chat/completions",
+      requestBody: { model: "gpt-4", messages: [{ role: "user", content: "hi" }] },
+      // An object that matches NONE of the known provider shapes.
+      responseJson: { weird_unknown_field: "value", another: 42 },
+      prefix: "aimock-fix4-unknown-",
+    });
+    const resp = fixture.fixtures[0].response as { error?: { message?: string } };
+    // Still becomes the generic error fixture...
+    expect(resp.error).toBeDefined();
+    // ...but now the unknown shape is logged for diagnosability.
+    const warned = warnSpy.mock.calls.some((args) =>
+      args.some(
+        (a) =>
+          typeof a === "string" &&
+          (/unknown|unrecognized|could not detect/i.test(a) || a.includes("weird_unknown_field")),
+      ),
+    );
+    expect(warned).toBe(true);
+  });
+});

--- a/src/__tests__/recorder-path-traversal.test.ts
+++ b/src/__tests__/recorder-path-traversal.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Fixture, RecordConfig } from "../types.js";
+import { persistFixture } from "../recorder.js";
+import { Logger } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// Security: the X-AIMock-Context header value becomes a directory segment in
+// the recorded-fixture path (recorder.ts ~209-211). An attacker-controlled
+// context containing `../` (or absolute paths / separators) must NOT let the
+// written fixture escape the configured fixtures base directory.
+// ---------------------------------------------------------------------------
+
+describe("recorder context path traversal", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeBaseDir(): string {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-ptrav-"));
+    tmpDirs.push(base);
+    return base;
+  }
+
+  function buildFixture(context: string): Fixture {
+    return {
+      match: {
+        userMessage: "hello",
+        endpoint: "/v1/chat/completions",
+        context,
+      },
+      response: { content: "hi" },
+    };
+  }
+
+  function persistWithContext(base: string, context: string): string {
+    const fixture = buildFixture(context);
+    const result = persistFixture({
+      record: { providers: {}, fixturePath: base } as RecordConfig,
+      providerKey: "openai",
+      testId: "__default__", // non-snapshot mode → timestamp layout uses context dir
+      fixture,
+      fixtures: [],
+      logger: new Logger("silent"),
+    });
+    expect(result.kind).toBe("written");
+    return (result as { kind: "written"; filepath: string }).filepath;
+  }
+
+  it("keeps a traversal context inside the fixtures base dir", () => {
+    const base = makeBaseDir();
+    // Where an unsanitized `../../../tmp/aimock-escape` context would land its
+    // fixture directory. Clear any leftover so this assertion reflects THIS run.
+    const escapeTarget = path.resolve(os.tmpdir(), "aimock-escape");
+    fs.rmSync(escapeTarget, { recursive: true, force: true });
+
+    const written = persistWithContext(base, "../../../tmp/aimock-escape");
+
+    const resolvedBase = path.resolve(base);
+    const resolvedWritten = path.resolve(written);
+
+    expect(resolvedWritten.startsWith(resolvedBase + path.sep)).toBe(true);
+    // The escaped path must not have been created outside the base.
+    expect(fs.existsSync(escapeTarget)).toBe(false);
+  });
+
+  it("strips path separators and absolute-path prefixes from context", () => {
+    const base = makeBaseDir();
+    const written = persistWithContext(base, "/etc/passwd-dir/sub");
+
+    const resolvedBase = path.resolve(base);
+    const resolvedWritten = path.resolve(written);
+
+    expect(resolvedWritten.startsWith(resolvedBase + path.sep)).toBe(true);
+    // Exactly one directory level under base (the sanitized segment), plus file.
+    const rel = path.relative(resolvedBase, resolvedWritten);
+    expect(rel.split(path.sep).length).toBe(2);
+  });
+
+  it("still routes a legitimate context into its own subdirectory", () => {
+    const base = makeBaseDir();
+    const written = persistWithContext(base, "my-feature");
+
+    const resolvedBase = path.resolve(base);
+    const rel = path.relative(resolvedBase, path.resolve(written));
+    const segments = rel.split(path.sep);
+    expect(segments.length).toBe(2);
+    expect(segments[0]).toBe("my-feature");
+  });
+});

--- a/src/__tests__/recorder.test.ts
+++ b/src/__tests__/recorder.test.ts
@@ -449,6 +449,88 @@ describe("recorder integration", () => {
     expect(savedResponse.toolCalls).toHaveLength(1);
   });
 
+  it('coalesces missing tool-call arguments to "{}" in recorded fixture', async () => {
+    // Real record path: a raw upstream returns an OpenAI non-streaming
+    // chat-completions tool call whose `function.arguments` field is ABSENT
+    // (a no-arg tool call). The recorder must persist `arguments: "{}"` so the
+    // OpenAI replay path's `JSON.parse(args || "{}")` does not crash. Before the
+    // fix, `String(fn.arguments)` persisted the literal string "undefined".
+    const rawUpstream = http.createServer((_upReq, upRes) => {
+      upRes.writeHead(200, { "Content-Type": "application/json" });
+      upRes.end(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    id: "call_abc",
+                    type: "function",
+                    function: { name: "get_time" }, // no `arguments` field
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => rawUpstream.listen(0, "127.0.0.1", () => resolve()));
+    const upstreamPort = (rawUpstream.address() as { port: number }).port;
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-record-noarg-"));
+
+    const recorderServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", async () => {
+        const rawBody = Buffer.concat(chunks).toString();
+        await proxyAndRecord(
+          req,
+          res,
+          JSON.parse(rawBody),
+          "openai",
+          "/v1/chat/completions",
+          [],
+          {
+            record: {
+              providers: { openai: `http://127.0.0.1:${upstreamPort}` },
+              fixturePath: tmpDir!,
+            },
+            logger: new Logger("silent"),
+          },
+          rawBody,
+        );
+      });
+    });
+    await new Promise<void>((resolve) => recorderServer.listen(0, "127.0.0.1", () => resolve()));
+    const recorderPort = (recorderServer.address() as { port: number }).port;
+
+    try {
+      await post(`http://127.0.0.1:${recorderPort}/v1/chat/completions`, {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "What time is it?" }],
+        tools: [{ type: "function", function: { name: "get_time", parameters: {} } }],
+      });
+
+      const files = fs.readdirSync(tmpDir!).filter((f) => f.endsWith(".json"));
+      expect(files).toHaveLength(1);
+      const fixtureContent = JSON.parse(
+        fs.readFileSync(path.join(tmpDir!, files[0]), "utf-8"),
+      ) as FixtureFile;
+      const savedResponse = fixtureContent.fixtures[0].response as {
+        toolCalls: Array<{ arguments: string }>;
+      };
+      expect(savedResponse.toolCalls).toHaveLength(1);
+      expect(savedResponse.toolCalls[0].arguments).toBe("{}");
+    } finally {
+      await new Promise<void>((resolve) => rawUpstream.close(() => resolve()));
+      await new Promise<void>((resolve) => recorderServer.close(() => resolve()));
+    }
+  });
+
   it("records embedding response from upstream", async () => {
     const { recorderUrl, fixturePath } = await setupUpstreamAndRecorder(
       [
@@ -4152,8 +4234,11 @@ describe("buildFixtureResponse format detection", () => {
     expect(fixtureContent.fixtures[0].response.embedding).toEqual([0.5, 1, -0.25]);
   });
 
-  it("does not decode base64 embedding when encoding_format is not set", async () => {
-    // Same base64 string but no encoding_format in request — should NOT decode
+  it("decodes a base64 embedding even when encoding_format is not echoed in the request", async () => {
+    // Some providers return a base64-packed Float32 embedding even when the
+    // client did not request encoding_format: "base64". The recorder must decode
+    // it regardless of the request echo, rather than silently dropping a valid
+    // embedding into the proxy_error fixture. base64 of Float32Array([0.5,1,-0.25]).
     const base64Embedding = "AAAAPwAAgD8AAIC+";
     const { url: upstreamUrl } = await createRawUpstreamWithStatus({
       object: "list",
@@ -4183,12 +4268,11 @@ describe("buildFixtureResponse format detection", () => {
       fs.readFileSync(path.join(tmpDir, fixtureFiles[0]), "utf-8"),
     ) as {
       fixtures: Array<{
-        response: { error?: { type: string } };
+        response: { embedding?: number[]; error?: { type: string } };
       }>;
     };
-    // Without encoding_format, base64 string embedding is not an array →
-    // falls through to proxy_error
-    expect(fixtureContent.fixtures[0].response.error?.type).toBe("proxy_error");
+    expect(fixtureContent.fixtures[0].response.error).toBeUndefined();
+    expect(fixtureContent.fixtures[0].response.embedding).toEqual([0.5, 1, -0.25]);
   });
 
   it("still detects array embeddings when encoding_format is base64", async () => {
@@ -4229,8 +4313,11 @@ describe("buildFixtureResponse format detection", () => {
     expect(fixtureContent.fixtures[0].response.embedding).toEqual([0.5, 1, -0.25]);
   });
 
-  it("handles truncated base64 embedding gracefully (odd byte count)", async () => {
-    // 2 bytes decodes to 0 float32 elements — produces empty embedding, not a crash
+  it("does not silently emit a zero-dim embedding for truncated base64 (odd byte count)", async () => {
+    // 2 bytes is not a whole number of Float32s (byteLength % 4 !== 0). The
+    // recorder must NOT silently produce a valid-looking empty embedding — it
+    // logs the malformed input and falls through to the proxy_error fixture so
+    // the loss is diagnosable rather than masquerading as a valid 0-dim vector.
     const shortBase64 = Buffer.from([0x00, 0x01]).toString("base64");
     const { url: upstreamUrl } = await createRawUpstreamWithStatus({
       object: "list",
@@ -4261,11 +4348,12 @@ describe("buildFixtureResponse format detection", () => {
       fs.readFileSync(path.join(tmpDir, fixtureFiles[0]), "utf-8"),
     ) as {
       fixtures: Array<{
-        response: { embedding?: number[] };
+        response: { embedding?: number[]; error?: { type: string } };
       }>;
     };
-    // Truncated base64 decodes to empty array rather than crashing
-    expect(fixtureContent.fixtures[0].response.embedding).toEqual([]);
+    // Must not be a silent valid-looking zero-dimension embedding.
+    expect(fixtureContent.fixtures[0].response.embedding).toBeUndefined();
+    expect(fixtureContent.fixtures[0].response.error?.type).toBe("proxy_error");
   });
 
   it("preserves error code field from upstream error response", async () => {
@@ -6723,5 +6811,113 @@ describe("sanitizeHeaderValue", () => {
     );
     expect(sanitizeHeaderValue("line1\nline2\x7f")).toBe("line1?line2?");
     expect(sanitizeHeaderValue("plain ascii\twith tab")).toBe("plain ascii\twith tab");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAI image-generation branch entry gate (regression)
+//
+// The image branch's entry gate keyed on `data[0]` carrying media (url/b64_json).
+// An image batch whose FIRST element lacks both — but a LATER element HAS one —
+// skipped the whole branch and fell through to the generic error fixture,
+// silently dropping every captured image. The gate must enter when ANY item
+// carries media. Driven against the real record path: a raw OpenAI image
+// upstream fronted by a real recorder, posting to /v1/images/generations, then
+// asserting the persisted fixture retains the image(s).
+// ---------------------------------------------------------------------------
+
+describe("recorder OpenAI image-branch entry gate", () => {
+  let rawServer: http.Server | undefined;
+
+  afterEach(async () => {
+    if (rawServer) {
+      await new Promise<void>((resolve) => rawServer!.close(() => resolve()));
+      rawServer = undefined;
+    }
+  });
+
+  // Raw OpenAI image-generation upstream emitting a fixed JSON body, fronted by a
+  // real recorder configured with the `openai` provider key so buildFixtureResponse
+  // runs over the upstream image response.
+  async function recordOpenAiImage(responseJson: unknown): Promise<{
+    fixturePath: string;
+    response: { status: number; body: string };
+  }> {
+    rawServer = http.createServer((_upReq, upRes) => {
+      upRes.writeHead(200, { "Content-Type": "application/json" });
+      upRes.end(JSON.stringify(responseJson));
+    });
+    await new Promise<void>((resolve) => rawServer!.listen(0, "127.0.0.1", () => resolve()));
+    const upstreamPort = (rawServer!.address() as { port: number }).port;
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-openai-image-"));
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: `http://127.0.0.1:${upstreamPort}` },
+        fixturePath: tmpDir,
+      },
+    });
+
+    const response = await post(`${recorder.url}/v1/images/generations`, {
+      model: "gpt-image-1",
+      prompt: "a red cube and a blue sphere",
+      n: 2,
+    });
+
+    return { fixturePath: tmpDir, response };
+  }
+
+  it("captures images when data[0] lacks media but a later item carries a url", async () => {
+    // OpenAI batch where the FIRST element has neither url nor b64_json (e.g. a
+    // partial/placeholder entry), but the SECOND element carries a real url.
+    const { fixturePath } = await recordOpenAiImage({
+      created: 1_700_000_000,
+      data: [
+        { revised_prompt: "a red cube and a blue sphere" },
+        { url: "https://example.com/image-2.png", revised_prompt: "blue sphere" },
+      ],
+    });
+
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files).toHaveLength(1);
+    const fixtureContent = JSON.parse(
+      fs.readFileSync(path.join(fixturePath, files[0]), "utf-8"),
+    ) as FixtureFile;
+    const saved = fixtureContent.fixtures[0].response as {
+      image?: { url?: string; b64Json?: string; revisedPrompt?: string };
+      images?: Array<{ url?: string; b64Json?: string; revisedPrompt?: string }>;
+      error?: { message: string };
+    };
+
+    // RED (pre-fix): the gate keyed on data[0] (no media) skipped the branch and
+    // the response fell through to the generic error fixture, dropping the image.
+    expect(saved.error).toBeUndefined();
+    // GREEN: the single media-bearing item is captured. The within-branch filter
+    // drops the media-less first element, leaving exactly one image — which the
+    // branch collapses to `{ image }`.
+    expect(saved.image).toBeDefined();
+    expect(saved.image!.url).toBe("https://example.com/image-2.png");
+  });
+
+  it("captures b64_json when data[0] lacks media but a later item carries b64_json", async () => {
+    const { fixturePath } = await recordOpenAiImage({
+      created: 1_700_000_001,
+      data: [{ revised_prompt: "placeholder" }, { b64_json: "aGVsbG8=", revised_prompt: "real" }],
+    });
+
+    const files = fs.readdirSync(fixturePath).filter((f) => f.endsWith(".json"));
+    expect(files).toHaveLength(1);
+    const fixtureContent = JSON.parse(
+      fs.readFileSync(path.join(fixturePath, files[0]), "utf-8"),
+    ) as FixtureFile;
+    const saved = fixtureContent.fixtures[0].response as {
+      image?: { url?: string; b64Json?: string };
+      error?: { message: string };
+    };
+
+    expect(saved.error).toBeUndefined();
+    expect(saved.image).toBeDefined();
+    expect(saved.image!.b64Json).toBe("aGVsbG8=");
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,8 @@ Options:
       --provider-openrouter <url> Upstream URL for OpenRouter (video record proxy)
       --upstream-timeout-ms <ms>  Idle timeout (ms) on upstream socket before response (default: 30000)
       --body-timeout-ms <ms>      Idle timeout (ms) on upstream response body between chunks (default: 30000)
+      --max-proxy-buffer-bytes <n> Cap (bytes) on in-memory proxy-path buffer; full body still relayed (default: 67108864)
+      --max-proxy-buffer-frames <n> Cap (frames) on in-memory proxy-path per-frame state; full body still relayed (default: 5000000)
       --agui-record              Enable AG-UI recording (proxy unmatched AG-UI requests)
       --agui-upstream <url>      Upstream AG-UI agent URL (used with --agui-record)
       --agui-proxy-only          AG-UI proxy mode: forward without saving
@@ -78,6 +80,8 @@ const { values } = parseArgs({
     "provider-openrouter": { type: "string" },
     "upstream-timeout-ms": { type: "string" },
     "body-timeout-ms": { type: "string" },
+    "max-proxy-buffer-bytes": { type: "string" },
+    "max-proxy-buffer-frames": { type: "string" },
     "agui-record": { type: "boolean", default: false },
     "agui-upstream": { type: "string" },
     "agui-proxy-only": { type: "boolean", default: false },
@@ -175,6 +179,30 @@ if (bodyTimeoutMsStr !== undefined) {
   }
 }
 
+const maxProxyBufferBytesStr = values["max-proxy-buffer-bytes"];
+let maxProxyBufferBytes: number | undefined;
+if (maxProxyBufferBytesStr !== undefined) {
+  maxProxyBufferBytes = Number(maxProxyBufferBytesStr);
+  if (!Number.isFinite(maxProxyBufferBytes) || maxProxyBufferBytes <= 0) {
+    console.error(
+      `Invalid max-proxy-buffer-bytes: ${maxProxyBufferBytesStr} (must be a positive finite number)`,
+    );
+    process.exit(1);
+  }
+}
+
+const maxProxyBufferFramesStr = values["max-proxy-buffer-frames"];
+let maxProxyBufferFrames: number | undefined;
+if (maxProxyBufferFramesStr !== undefined) {
+  maxProxyBufferFrames = Number(maxProxyBufferFramesStr);
+  if (!Number.isFinite(maxProxyBufferFrames) || maxProxyBufferFrames <= 0) {
+    console.error(
+      `Invalid max-proxy-buffer-frames: ${maxProxyBufferFramesStr} (must be a positive finite number)`,
+    );
+    process.exit(1);
+  }
+}
+
 const logger = new Logger(logLevel);
 
 // Parse chaos config from CLI flags
@@ -256,6 +284,8 @@ if (values.record || values["proxy-only"]) {
     recordFullModelVersion: values["record-full-model-version"],
     upstreamTimeoutMs,
     bodyTimeoutMs,
+    maxProxyBufferBytes,
+    maxProxyBufferFrames,
   };
 } else {
   // These flags configure upstream proxying — without --record or
@@ -279,9 +309,14 @@ if (values.record || values["proxy-only"]) {
       `--${droppedProviderFlags.join("/--")} only apply to --record/--proxy-only upstream proxying — ignored without one of those flags.`,
     );
   }
-  if (upstreamTimeoutMs !== undefined || bodyTimeoutMs !== undefined) {
+  if (
+    upstreamTimeoutMs !== undefined ||
+    bodyTimeoutMs !== undefined ||
+    maxProxyBufferBytes !== undefined ||
+    maxProxyBufferFrames !== undefined
+  ) {
     logger.warn(
-      "--upstream-timeout-ms/--body-timeout-ms only apply to --record/--proxy-only upstream proxying — ignored without one of those flags.",
+      "--upstream-timeout-ms/--body-timeout-ms/--max-proxy-buffer-bytes/--max-proxy-buffer-frames only apply to --record/--proxy-only upstream proxying — ignored without one of those flags.",
     );
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1033,6 +1033,24 @@ export function slugifyTestId(testId: string): string {
     .toLowerCase();
 }
 
+/**
+ * Make a request context (the `X-AIMock-Context` header value) safe to use as
+ * a single directory segment in a recorded-fixture path. The header is
+ * attacker-controllable, so a raw value containing `../`, path separators, or
+ * an absolute-path prefix would let the written fixture escape the configured
+ * fixtures base directory. Mirrors `slugifyTestId`: non-word characters
+ * (including `/`, `\`, and `.`) collapse to dashes, so the result is always a
+ * single flat segment with no traversal semantics. Returns "" when the value
+ * sanitizes to nothing (caller treats that as "no context segment").
+ */
+export function slugifyContext(context: string): string {
+  return context
+    .replace(/[^\w-]/g, "-") // non-word chars (incl. / \ . :) → dash
+    .replace(/-{3,}/g, "--") // collapse 3+ dashes to double
+    .replace(/^-+|-+$/g, "") // trim leading/trailing dashes
+    .toLowerCase();
+}
+
 // ─── Embedding helpers ─────────────────────────────────────────────────────
 
 const DEFAULT_EMBEDDING_DIMENSIONS = 1536;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -310,7 +310,7 @@ export function isEmbeddingResponse(r: FixtureResponse): r is EmbeddingResponse 
 
 export function isImageResponse(r: FixtureResponse): r is ImageResponse {
   return (
-    ("image" in r && r.image != null) ||
+    ("image" in r && typeof r.image === "object" && r.image != null) ||
     ("images" in r && Array.isArray((r as ImageResponse).images))
   );
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -984,8 +984,15 @@ export function matchesPattern(text: string, pattern: string | RegExp): boolean 
   if (typeof pattern === "string") {
     return text.toLowerCase().includes(pattern.toLowerCase());
   }
+  // A global/sticky RegExp carries mutable `lastIndex` state that `.test()`
+  // advances. Save and restore it so callers reusing the same regex object
+  // (search/rerank/moderation filter loops) are not left with mutated state
+  // and get consistent results across repeated calls.
+  const savedLastIndex = pattern.lastIndex;
   pattern.lastIndex = 0;
-  return pattern.test(text);
+  const result = pattern.test(text);
+  pattern.lastIndex = savedLastIndex;
+  return result;
 }
 
 export function getTestId(req: http.IncomingMessage): string {

--- a/src/llmock.ts
+++ b/src/llmock.ts
@@ -81,7 +81,18 @@ export class LLMock {
    * Validates all fixtures and throws if any have severity "error".
    */
   addFixturesFromJSON(input: string | FixtureFileEntry[]): this {
-    const entries: FixtureFileEntry[] = typeof input === "string" ? JSON.parse(input) : input;
+    let entries: FixtureFileEntry[];
+    if (typeof input === "string") {
+      try {
+        entries = JSON.parse(input);
+      } catch (err) {
+        throw new Error(
+          `addFixturesFromJSON: invalid JSON — ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } else {
+      entries = input;
+    }
     const converted = entries.map((e) => entryToFixture(e));
     const issues = validateFixtures(converted);
     const errors = issues.filter((i) => i.severity === "error");
@@ -299,13 +310,38 @@ export class LLMock {
       },
       status,
     };
+    // An injected error is only a valid response for endpoints that can carry
+    // an error envelope. Mirror the router's endpoint-compat table
+    // (matchFixtureDiagnostic in router.ts): error responses are compatible
+    // with chat / embedding / realtime* / fal and with requests that carry no
+    // endpoint type, but NOT with multimedia endpoints (image, speech, video,
+    // transcription, …). Gating consumption on this prevents an incompatible
+    // request from matching the predicate and splicing — and thereby
+    // destroying — a one-shot error intended for a different endpoint before
+    // the router's own compat check would have skipped it.
+    const errorEndpointCompatible = (req: import("./types.js").ChatCompletionRequest) => {
+      const reqEndpoint = req._endpointType as string | undefined;
+      if (
+        reqEndpoint === undefined ||
+        reqEndpoint === "chat" ||
+        reqEndpoint === "embedding" ||
+        reqEndpoint.startsWith("realtime") ||
+        reqEndpoint === "fal"
+      ) {
+        return true;
+      }
+      return false;
+    };
     const fixture: Fixture = {
-      match: { predicate: () => true },
+      match: { predicate: errorEndpointCompatible },
       response: errorResponse,
     };
     // Insert at front so it matches before everything else
     this.fixtures.unshift(fixture);
-    // Remove after first match — the journal records it so tests can assert
+    // Remove after first match — the journal records it so tests can assert.
+    // Only consume (and splice) when the request endpoint is compatible; an
+    // incompatible request returns false here, falls through to other
+    // fixtures, and leaves this error pending for its intended endpoint.
     const original = fixture.match.predicate!;
     fixture.match.predicate = (req) => {
       const result = original(req);

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -24,6 +24,62 @@ import { getTestId, slugifyTestId, slugifyContext } from "./helpers.js";
 import { DEFAULT_TEST_ID } from "./constants.js";
 
 /** Headers to strip when proxying — hop-by-hop (RFC 2616 §13.5.1) + client-set. */
+/**
+ * Default ceiling (bytes) for the in-memory proxy-path buffer. Chosen well
+ * under V8's ~512 MiB max string length so `rawBuffer.toString()` /
+ * stream-collapse never throws `RangeError: Invalid string length`, and so a
+ * single huge proxied response cannot spike the heap unbounded. Overridable
+ * via `RecordConfig.maxProxyBufferBytes` / `--max-proxy-buffer-bytes`.
+ */
+export const DEFAULT_MAX_PROXY_BUFFER_BYTES = 64 * 1024 * 1024; // 64 MiB
+
+/**
+ * Default ceiling for the number of SSE/NDJSON/EventStream frames whose
+ * per-frame state (`frameTimestamps`, parse buffers) aimock retains for a
+ * single proxied response. Frame state is count-indexed, not byte-sized, so a
+ * long-lived / never-ending stream accumulates `frameTimestamps` entries (and,
+ * if a frame never completes, parse-buffer bytes) UNBOUNDED even when the byte
+ * cap is generous — observed as multi-GB heap growth over many hours from a few
+ * long nested-sub-agent streams. Tripping truncation on EITHER bytes OR frame
+ * count bounds both. 5M frames is generous for any real response (a normal
+ * completion is hundreds-to-thousands of frames) while still bounding a runaway
+ * stream to ~tens of MB of frame state. Overridable via
+ * `RecordConfig.maxProxyBufferFrames` / `--max-proxy-buffer-frames`.
+ */
+export const DEFAULT_MAX_PROXY_BUFFER_FRAMES = 5_000_000;
+
+/**
+ * Absolute hard ceiling (bytes) for any in-memory proxy buffer, independent of
+ * the configurable `maxProxyBufferBytes`. V8's maximum STRING length on 64-bit
+ * is 2^29 - 1 (~512 MiB of UTF-16 code units), and the proxy buffer is
+ * eventually stringified via `rawBuffer.toString()` for collapse/relay — so the
+ * BYTE buffer must stay safely under that string limit or the toString throws
+ * `RangeError: Invalid string length`. 256 MiB of bytes is well under the
+ * ~512 MiB string-length boundary (these are different units — bytes vs UTF-16
+ * code units — but 256 MiB of bytes can never decode to more than 256 Mi code
+ * units, comfortably below 2^29 - 1). Used to clamp the configurable cap AND to
+ * bound the non-progressive relay buffer that must be retained past a cap trip.
+ */
+export const PROXY_BUFFER_HARD_CEILING = 256 * 1024 * 1024; // 256 MiB
+
+/**
+ * Test-only override of the effective hard ceiling. Lets the proxy-buffer
+ * enforcement suite exercise the >hard-ceiling fail-loud path with a small
+ * body instead of streaming 256 MiB. `undefined` (the default) uses the real
+ * `PROXY_BUFFER_HARD_CEILING`. NEVER set from production code.
+ */
+let proxyBufferHardCeilingOverride: number | undefined;
+
+/** @internal test-only — see `proxyBufferHardCeilingOverride`. */
+export function setProxyBufferHardCeilingForTests(value: number | undefined): void {
+  proxyBufferHardCeilingOverride = value;
+}
+
+/** Effective hard ceiling, honoring any active test-only override. */
+function effectiveHardCeiling(): number {
+  return proxyBufferHardCeilingOverride ?? PROXY_BUFFER_HARD_CEILING;
+}
+
 const STRIP_HEADERS = new Set([
   // Hop-by-hop (RFC 2616 §13.5.1)
   "connection",
@@ -382,6 +438,10 @@ export async function proxyAndRecord(
   let upstreamHeaders: http.IncomingHttpHeaders;
   let upstreamBody: string;
   let rawBuffer: Buffer;
+  let bufferTruncated = false;
+  let truncationCap: "byte" | "frame" | undefined;
+  let totalBytes = 0;
+  let hardCeilingExceeded = false;
 
   // Track whether we streamed SSE progressively to the client; if so,
   // skip the final res.writeHead/res.end relay at the bottom of this fn.
@@ -389,6 +449,8 @@ export async function proxyAndRecord(
   let clientDisconnected = false;
   let frameTimestamps: number[] = [];
   let streamStartTime = 0;
+  const maxProxyBufferBytes = clampMaxBufferBytes(record.maxProxyBufferBytes);
+  const maxProxyBufferFrames = clampMaxBufferFrames(record.maxProxyBufferFrames);
   try {
     const result = await makeUpstreamRequest(
       target,
@@ -398,6 +460,8 @@ export async function proxyAndRecord(
       req.method,
       defaults.logger,
       { upstreamTimeoutMs: record.upstreamTimeoutMs, bodyTimeoutMs: record.bodyTimeoutMs },
+      maxProxyBufferBytes,
+      maxProxyBufferFrames,
     );
     upstreamStatus = result.status;
     upstreamHeaders = result.headers;
@@ -407,6 +471,10 @@ export async function proxyAndRecord(
     clientDisconnected = result.clientDisconnected;
     frameTimestamps = result.frameTimestamps;
     streamStartTime = result.streamStartTime;
+    bufferTruncated = result.bufferTruncated;
+    truncationCap = result.truncationCap;
+    totalBytes = result.totalBytes;
+    hardCeilingExceeded = result.hardCeilingExceeded;
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Unknown proxy error";
     defaults.logger.error(`Proxy request failed: ${msg}`);
@@ -428,11 +496,66 @@ export async function proxyAndRecord(
     return "relayed";
   }
 
+  // Buffer cap tripped: skip collapse + recording (the in-memory buffer can't
+  // be safely/faithfully journaled), but ALWAYS deliver a faithful response to
+  // the client. The cap means "don't journal", not "don't answer".
+  //  - PROGRESSIVE stream: the bytes were already teed to the client live, so
+  //    nothing more to write — just end if still open.
+  //  - NON-progressive response, UNDER the hard ceiling: makeUpstreamRequest
+  //    kept the FULL body (bounded by PROXY_BUFFER_HARD_CEILING) precisely so we
+  //    can relay it here. Relay the real body so a large single-shot JSON
+  //    (embeddings / fal / image-b64) reaches the client intact — but NORMALIZE
+  //    the status (success→200 / error→502) exactly like every other relay path
+  //    so upstream provider details don't leak through this branch alone.
+  //  - NON-progressive response, OVER the hard ceiling: the retained buffer is
+  //    PARTIAL (we stopped buffering at the ceiling and there is no live tee),
+  //    so relaying it would present a truncated body as success. FAIL LOUD with
+  //    a 502 instead — never deliver a silently-truncated body as 2xx.
+  if (bufferTruncated) {
+    const capDetail =
+      truncationCap === "frame"
+        ? `the ${maxProxyBufferFrames}-frame cap`
+        : `the ${maxProxyBufferBytes}-byte cap`;
+    if (!streamedToClient && hardCeilingExceeded && !res.headersSent) {
+      const ceilingMiB = Math.round(PROXY_BUFFER_HARD_CEILING / (1024 * 1024));
+      defaults.logger.error(
+        `Upstream response exceeded the ${ceilingMiB} MiB proxy hard ceiling (saw ${totalBytes} bytes) on a non-progressive body — cannot relay the full body and refusing to relay a truncated one; returning 502`,
+      );
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: {
+            message: `Upstream response exceeds ${ceilingMiB}MiB proxy ceiling`,
+            type: "proxy_error",
+          },
+        }),
+      );
+      return "relayed";
+    }
+    defaults.logger.warn(
+      `Upstream response exceeded ${capDetail} (saw ${totalBytes} bytes) — relayed to client, recording skipped`,
+    );
+    if (!streamedToClient && !res.headersSent) {
+      // Normalize the relayed status like the under-cap relay paths
+      // (success→200, error→502) so this branch does not leak a raw upstream
+      // 429/503/etc. The full real body (under the hard ceiling) is relayed.
+      const clientStatus = upstreamStatus >= 200 && upstreamStatus < 300 ? 200 : 502;
+      const relayHeaders: Record<string, string> = {};
+      const ct = upstreamHeaders["content-type"];
+      const ctStr = Array.isArray(ct) ? ct.join(", ") : (ct ?? "");
+      relayHeaders["Content-Type"] = ctStr || "application/json";
+      res.writeHead(clientStatus, relayHeaders);
+      res.end(rawBuffer);
+    } else if (!res.writableEnded) {
+      res.end();
+    }
+    return "relayed";
+  }
+
   // Detect streaming response and collapse if necessary.
-  // NOTE: collapse buffers the entire upstream body in memory. Fine for
-  // current chat-completions traffic (responses are small), but revisit if
-  // this path ever proxies long-lived or large streams — both the buffer
-  // here and the hook below receive the full payload.
+  // NOTE: collapse buffers the upstream body in memory up to maxProxyBufferBytes
+  // (see makeUpstreamRequest). Over-cap responses short-circuit above, so the
+  // buffer reaching here is bounded and safe to stringify/collapse.
   const contentType = upstreamHeaders["content-type"];
   const ctString = pickContentType(contentType);
   const isBinaryStream = ctString.toLowerCase().includes("application/vnd.amazon.eventstream");
@@ -796,6 +919,37 @@ export function clampTimeout(value: number | undefined, fallback: number): numbe
   return value;
 }
 
+/**
+ * Sanitize the configured proxy-buffer cap: non-finite or non-positive values
+ * fall back to the default. Also hard-clamps to just under V8's max string
+ * length so a misconfigured large value can never permit an over-string-limit
+ * buffer to reach `.toString()`.
+ */
+export function clampMaxBufferBytes(value: number | undefined): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MAX_PROXY_BUFFER_BYTES;
+  }
+  return Math.min(value, PROXY_BUFFER_HARD_CEILING);
+}
+
+/**
+ * Sanitize the configured proxy-buffer frame cap: non-finite or non-positive
+ * values fall back to the default. Bounds the count-indexed per-frame state
+ * (`frameTimestamps` + parse buffers) that the byte cap cannot bound on its own.
+ */
+export function clampMaxBufferFrames(value: number | undefined): number {
+  // INTENTIONAL DIVERGENCE from journal-max's `0 = unbounded` convention: here
+  // 0 (and any non-positive / non-finite value) maps to the DEFAULT cap, never
+  // "unbounded". The frame cap exists as leak-safety for never-ending proxy
+  // streams; allowing 0 to disable it would reintroduce the exact unbounded
+  // per-frame-state growth this cap guards against. Do NOT make 0 mean
+  // unbounded.
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MAX_PROXY_BUFFER_FRAMES;
+  }
+  return Math.floor(value);
+}
+
 function makeUpstreamRequest(
   target: URL,
   headers: Record<string, string>,
@@ -804,6 +958,8 @@ function makeUpstreamRequest(
   method: string = "POST",
   logger?: Logger,
   timeouts?: Pick<RecordConfig, "upstreamTimeoutMs" | "bodyTimeoutMs">,
+  maxBufferBytes: number = DEFAULT_MAX_PROXY_BUFFER_BYTES,
+  maxBufferFrames: number = DEFAULT_MAX_PROXY_BUFFER_FRAMES,
 ): Promise<{
   status: number;
   headers: http.IncomingHttpHeaders;
@@ -813,6 +969,27 @@ function makeUpstreamRequest(
   clientDisconnected: boolean;
   frameTimestamps: number[];
   streamStartTime: number;
+  /**
+   * True when the upstream response exceeded `maxBufferBytes`. The client still
+   * received every byte (the relay is independent of this buffer), but the
+   * in-memory buffer was capped, so `body`/`rawBuffer` are partial and the
+   * caller MUST skip collapse/recording.
+   */
+  bufferTruncated: boolean;
+  /**
+   * Which cap tripped truncation (`"byte"` or `"frame"`), or `undefined` when
+   * not truncated. Lets the caller log accurately which budget was exceeded
+   * rather than conflating the two.
+   */
+  truncationCap?: "byte" | "frame";
+  /** Total bytes seen from upstream (may exceed the buffered amount when capped). */
+  totalBytes: number;
+  /**
+   * True when a NON-progressive (non-teed) upstream body exceeded the proxy
+   * hard ceiling, so the retained `rawBuffer` is PARTIAL. The caller MUST fail
+   * loud (502) rather than relay this truncated body as a success status.
+   */
+  hardCeilingExceeded: boolean;
 }> {
   return new Promise((resolve, reject) => {
     const transport = target.protocol === "https:" ? https : http;
@@ -890,17 +1067,130 @@ function makeUpstreamRequest(
             if (!clientRes.writableFinished) {
               clientDisconnected = true;
               req.destroy();
+              // Stop in-flight buffering immediately rather than draining the
+              // upstream socket under backpressure: detach the data listener so
+              // no further chunks accumulate, and free what's already buffered.
+              // The promise still settles via the 'end'/'error'/'close' the
+              // destroyed request emits; collapse/recording is skipped because
+              // the client disconnected.
+              res.removeListener("data", onUpstreamData);
+              chunks.length = 0;
+              bufferedBytes = 0;
+              frameTimestamps.length = 0;
+              frameBuffer = "";
+              binaryFrameBuffer = Buffer.alloc(0);
             }
           });
         }
         const chunks: Buffer[] = [];
-        res.on("data", (chunk: Buffer) => {
-          chunks.push(chunk);
+        // Bound the in-memory buffer used to collapse/journal the response so a
+        // single huge proxied stream can neither spike the heap nor build a
+        // string past V8's ~512 MiB limit (RangeError: Invalid string length).
+        // The client relay below is independent of this buffer, so capping it
+        // does NOT truncate what the client receives.
+        let bufferedBytes = 0;
+        let totalBytes = 0;
+        let bufferTruncated = false;
+        /** Which cap tripped truncation — surfaced to the caller for an accurate warning. */
+        let truncationCap: "byte" | "frame" | undefined;
+        // Snapshot the effective hard ceiling once for this request (honors the
+        // test-only override). Bounds the non-progressive relay buffer; when the
+        // body would exceed it we can neither buffer the full copy nor safely
+        // relay the partial one, so the caller fails loud instead of truncating.
+        const hardCeiling = effectiveHardCeiling();
+        /**
+         * True when a NON-progressive upstream body exceeded `hardCeiling`, so
+         * the buffered `rawBuffer` is a PARTIAL copy that must NOT be relayed as
+         * success. Distinct from `bufferTruncated` (which also covers the
+         * under-ceiling over-soft-cap case where the full body IS retained).
+         */
+        let hardCeilingExceeded = false;
+        // Trip truncation: mark the response over-cap so the caller skips
+        // collapse/recording, and eagerly drop the accumulated PARSE state
+        // (frameTimestamps + frame/binary parse buffers) which only ever feeds
+        // recording. Reused by the top-of-callback byte guard AND the per-frame
+        // guards inside the SSE/NDJSON and binary splitter loops, so a single
+        // coalesced chunk carrying many complete frames cannot overshoot the
+        // frame cap before the next data event re-checks.
+        //
+        // The raw `chunks` array is handled differently by stream shape:
+        //  - progressive streams (SSE/NDJSON/binary) are teed to the client
+        //    live, so the bytes are already on the wire — `chunks` is freed
+        //    immediately and the partial buffer is never relayed.
+        //  - non-progressive responses (a single non-stream body) are NOT teed;
+        //    the only copy the client can receive is `chunks`, so we KEEP
+        //    accumulating it (bounded by HARD_CEILING below) and relay it in
+        //    full. We still skip recording — the cap means "don't journal", not
+        //    "don't answer the client".
+        const tripTruncation = (cap: "byte" | "frame") => {
+          bufferTruncated = true;
+          truncationCap = cap;
+          frameTimestamps.length = 0;
+          frameBuffer = "";
+          // Intentional: the returned flush string is discarded (frameBuffer was
+          // just cleared and recording is skipped), but `.end()` releases any
+          // partial-multibyte bytes the StringDecoder is internally holding — so
+          // this frees decoder state rather than being dead cleanup.
+          frameDecoder.end();
+          binaryFrameBuffer = Buffer.alloc(0);
+          if (isProgressiveStream) {
+            chunks.length = 0;
+            bufferedBytes = 0;
+          }
+          // State which cap tripped accurately (do not conflate the two caps),
+          // and report the relay truthfully — the client received every byte on
+          // the streamed path and, post-fix, on the non-streamed path too.
+          const detail =
+            cap === "byte"
+              ? `byte cap (${maxBufferBytes} bytes)`
+              : `frame cap (${maxBufferFrames} frames)`;
+          logger?.warn(
+            `Upstream response exceeded the proxy buffer ${detail} — relaying full body to client, but skipping in-memory collapse/recording to bound memory`,
+          );
+        };
+        const onUpstreamData = (chunk: Buffer) => {
+          totalBytes += chunk.length;
+          // Trip truncation on EITHER bytes OR frame count. The byte cap alone
+          // never bounds `frameTimestamps` (count-indexed, not byte-sized) nor a
+          // never-completing parse buffer, so a long-lived / never-ending stream
+          // would otherwise grow per-frame state forever. `frameTimestamps.length`
+          // is the running complete-frame count. `>=` (not `>`) so we never
+          // retain MORE than `maxBufferFrames` frames — see the "maximum N
+          // frames retained" contract on DEFAULT_MAX_PROXY_BUFFER_FRAMES.
+          if (!bufferTruncated && bufferedBytes + chunk.length > maxBufferBytes) {
+            tripTruncation("byte");
+          } else if (!bufferTruncated && frameTimestamps.length >= maxBufferFrames) {
+            tripTruncation("frame");
+          }
+          // Buffer the raw bytes. Under cap: always. Over cap on a progressive
+          // stream: never (bytes are already teed live; chunks was freed). Over
+          // cap on a NON-progressive response: keep buffering for the relay —
+          // it has no live tee, so `chunks` is the only copy the client can get
+          // — but hard-cap it at HARD_CEILING (well under V8's max string
+          // length) so the eventual rawBuffer.toString() relay can never throw
+          // RangeError: Invalid string length.
+          if (!bufferTruncated) {
+            chunks.push(chunk);
+            bufferedBytes += chunk.length;
+          } else if (!isProgressiveStream) {
+            if (bufferedBytes + chunk.length <= hardCeiling) {
+              chunks.push(chunk);
+              bufferedBytes += chunk.length;
+            } else {
+              // The non-progressive relay copy would exceed the hard ceiling.
+              // We CANNOT relay the full body (it can't be buffered safely) and
+              // MUST NOT relay the partial buffer as a success — flag it so the
+              // caller fails loud (502) instead of presenting a truncated 2xx.
+              hardCeilingExceeded = true;
+            }
+          }
 
-          // Capture per-frame timestamps for SSE/NDJSON streams.
+          // Capture per-frame timestamps for SSE/NDJSON streams. Gated on
+          // !bufferTruncated so per-frame parse/timing state stops growing once
+          // the cap trips (the byte/frame guard above already freed it).
           // TCP data events don't align with SSE frames — buffer and
           // split on the protocol delimiter to timestamp each complete frame.
-          if (isSSE || isNDJSON) {
+          if (!bufferTruncated && (isSSE || isNDJSON)) {
             frameBuffer += frameDecoder.write(chunk);
             // Split on the protocol delimiter, tolerating CRLF line endings.
             // The SSE spec permits CRLF, and some upstreams/proxies emit
@@ -911,26 +1201,60 @@ function makeUpstreamRequest(
             const delimiter = isNDJSON ? /\r?\n/ : /\r?\n\r?\n/;
             const parts = frameBuffer.split(delimiter);
             // All complete frames (everything except the last part which
-            // may be incomplete).
+            // may be incomplete). Enforce the frame cap PER-FRAME: a single
+            // coalesced chunk can carry many complete frames, so checking only
+            // at the top of the callback would let one event push them all and
+            // overshoot the cap unbounded. Trip + bail mid-loop instead.
             for (let fi = 0; fi < parts.length - 1; fi++) {
+              if (frameTimestamps.length >= maxBufferFrames) {
+                tripTruncation("frame");
+                break;
+              }
               if (parts[fi].trim().length > 0) {
                 frameTimestamps.push(Date.now());
               }
             }
-            // Last part stays in buffer (may be incomplete)
-            frameBuffer = parts[parts.length - 1];
+            // Last part stays in buffer (may be incomplete). Skip when the
+            // per-frame guard just tripped — tripTruncation already cleared it.
+            if (!bufferTruncated) {
+              frameBuffer = parts[parts.length - 1];
+            }
           }
 
           // Binary EventStream frame boundary detection — parse the 4-byte
           // total-length prefix to detect complete frames without decoding
           // frame contents (CRC validation happens in stream-collapse).
-          if (isBinaryEventStream) {
-            binaryFrameBuffer = Buffer.concat([binaryFrameBuffer, chunk]);
-            while (binaryFrameBuffer.length >= 4) {
-              const totalLen = binaryFrameBuffer.readUInt32BE(0);
-              if (totalLen < 12 || binaryFrameBuffer.length < totalLen) break;
-              frameTimestamps.push(Date.now());
-              binaryFrameBuffer = binaryFrameBuffer.subarray(totalLen);
+          // Also gated on !bufferTruncated so binaryFrameBuffer stops growing
+          // once the cap trips.
+          if (!bufferTruncated && isBinaryEventStream) {
+            // Count the binary parse buffer's growth toward the byte cap.
+            // binaryFrameBuffer is a SECOND, parallel copy of the bytes (the
+            // raw `chunks` array also holds them), so without this a
+            // never-completing / malformed (`totalLen<12`) frame — which pushes
+            // no frameTimestamps — would let a full second copy accumulate up
+            // to the byte cap, peaking at ~2× the configured cap. Trip on the
+            // COMBINED footprint so the byte cap bounds both copies together.
+            // NOTE: `bufferedBytes` ALREADY includes the current `chunk.length`
+            // (added in the raw-buffer accumulation above), so the combined
+            // footprint is `bufferedBytes + binaryFrameBuffer.length`. Adding
+            // `chunk.length` again would double-count it and trip the cap one
+            // chunk early (matching the L<byte-guard> accounting at the top).
+            if (bufferedBytes + binaryFrameBuffer.length > maxBufferBytes) {
+              tripTruncation("byte");
+            } else {
+              binaryFrameBuffer = Buffer.concat([binaryFrameBuffer, chunk]);
+              while (binaryFrameBuffer.length >= 4) {
+                if (frameTimestamps.length >= maxBufferFrames) {
+                  // Per-frame cap: a single chunk can complete many binary
+                  // frames; trip mid-loop rather than overshoot.
+                  tripTruncation("frame");
+                  break;
+                }
+                const totalLen = binaryFrameBuffer.readUInt32BE(0);
+                if (totalLen < 12 || binaryFrameBuffer.length < totalLen) break;
+                frameTimestamps.push(Date.now());
+                binaryFrameBuffer = binaryFrameBuffer.subarray(totalLen);
+              }
             }
           }
 
@@ -950,15 +1274,18 @@ function makeUpstreamRequest(
               clientDisconnected = true;
             }
           }
-        });
+        };
+        res.on("data", onUpstreamData);
         res.on("error", reject);
         res.on("end", () => {
           if (res.socket) res.setTimeout(0);
           // Flush remaining text frame buffer — captures the last frame if
           // the stream ended without a trailing delimiter. Binary EventStream
           // frames are length-prefixed so partial frames at end-of-stream are
-          // genuinely incomplete and should not be timestamped.
-          if (isSSE || isNDJSON) {
+          // genuinely incomplete and should not be timestamped. Skipped when
+          // truncated: the decoder/parse buffer were already drained+cleared on
+          // the trip, and recording is skipped, so there is nothing to flush.
+          if (!bufferTruncated && (isSSE || isNDJSON)) {
             // Drain any bytes the decoder buffered for an incomplete multibyte
             // sequence so the final frame text is complete before we test it.
             frameBuffer += frameDecoder.end();
@@ -982,15 +1309,29 @@ function makeUpstreamRequest(
               );
             }
           }
+          // Decide the string `body`:
+          //  - not truncated: stringify the full buffer as usual.
+          //  - truncated PROGRESSIVE stream: `chunks` was freed on the trip, so
+          //    rawBuffer is empty; skip toString to keep the path allocation-free
+          //    (the client already got every byte via the live tee).
+          //  - truncated NON-progressive response: we deliberately kept the full
+          //    bytes (bounded by HARD_CEILING) so they can be relayed — stringify
+          //    them so proxyAndRecord can `res.end(body)` the real response.
+          const bodyString =
+            !bufferTruncated || (bufferTruncated && !streamedToClient) ? rawBuffer.toString() : "";
           resolve({
             status: res.statusCode ?? 500,
             headers: res.headers,
-            body: rawBuffer.toString(),
+            body: bodyString,
             rawBuffer,
             streamedToClient,
             clientDisconnected,
             frameTimestamps,
             streamStartTime,
+            bufferTruncated,
+            truncationCap,
+            totalBytes,
+            hardCeilingExceeded,
           });
         });
       },

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -20,7 +20,7 @@ import type { Logger } from "./logger.js";
 import { collapseStreamingResponse, capturedRedactedData } from "./stream-collapse.js";
 import { writeErrorResponse } from "./sse-writer.js";
 import { resolveUpstreamUrl } from "./url.js";
-import { getTestId, slugifyTestId } from "./helpers.js";
+import { getTestId, slugifyTestId, slugifyContext } from "./helpers.js";
 import { DEFAULT_TEST_ID } from "./constants.js";
 
 /** Headers to strip when proxying — hop-by-hop (RFC 2616 §13.5.1) + client-set. */
@@ -146,6 +146,22 @@ export function sanitizeHeaderValue(value: string): string {
 }
 
 /**
+ * Resolve a `content-type` header value to a single string. Node's
+ * `http.IncomingHttpHeaders` types `content-type` as `string | string[]`, and
+ * a constructed/proxied header object CAN carry an array (e.g. duplicated
+ * header lines surfaced by some HTTP stacks). `join(", ")`-ing such an array
+ * produces a malformed `Content-Type: application/json, text/html` value — pick
+ * the FIRST element instead, which is the value the client should act on.
+ * Returns `""` when the header is absent or an empty array.
+ */
+export function pickContentType(contentType: string | string[] | undefined): string {
+  if (Array.isArray(contentType)) {
+    return contentType.length > 0 ? contentType[0] : "";
+  }
+  return contentType ?? "";
+}
+
+/**
  * Write a built fixture to disk (snapshot vs. timestamp file layout) and, when
  * the match is non-empty, register it in the in-memory cache so subsequent
  * identical requests match. Extracted from `proxyAndRecord` so the fal
@@ -206,8 +222,15 @@ export function persistFixture(opts: {
   } else {
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     const timestampFile = `${providerKey}-${timestamp}-${crypto.randomUUID().slice(0, 8)}.json`;
-    filepath = fixture.match.context
-      ? path.join(fixturePath, fixture.match.context, timestampFile)
+    // The context becomes a directory segment, but it originates from the
+    // attacker-controllable `X-AIMock-Context` header — slugify it (mirroring
+    // testId above) so `../`, separators, and absolute prefixes can't escape
+    // the fixtures base dir. An empty slug → no context segment.
+    const contextSegment = fixture.match.context
+      ? slugifyContext(fixture.match.context)
+      : undefined;
+    filepath = contextSegment
+      ? path.join(fixturePath, contextSegment, timestampFile)
       : path.join(fixturePath, timestampFile);
   }
 
@@ -222,7 +245,14 @@ export function persistFixture(opts: {
     // Auth headers are forwarded to upstream but excluded from saved fixtures.
     // The persisted fixture is always the real upstream response, even when
     // chaos later mutates the relay; replay must see what upstream said.
-    let fileContent: { fixtures: unknown[]; _warning?: string };
+    // Warnings are persisted as a `_warnings` JSON array (authoritative,
+    // non-fragmenting) AND a legacy "; "-joined `_warning` string (kept for
+    // backward-compatible readers). The array is the source of truth on a
+    // snapshot merge: a single warning that itself contains "; " (e.g.
+    // "captured A; then B") would be fragmented into two bogus entries if the
+    // joined string were split back apart on merge. Carrying the array forward
+    // avoids that round-trip fragmentation entirely.
+    let fileContent: { fixtures: unknown[]; _warning?: string; _warnings?: string[] };
     if (mergeExisting && fs.existsSync(filepath)) {
       try {
         const existing = JSON.parse(fs.readFileSync(filepath, "utf-8"));
@@ -238,12 +268,18 @@ export function persistFixture(opts: {
           );
         }
         fileContent = { fixtures: [...(existingFixtures ?? []), fixture] };
-        // Carry an existing _warning forward — a later clean capture merging
-        // into the same snapshot file must not erase an earlier capture's
-        // warning (e.g. an over-cap b64 omission). Split the "; "-joined
-        // string back into its elements first so a re-emitted warning dedupes
-        // against them ("A; B" + "A" must stay "A; B", not "A; B; A").
-        if (typeof existing._warning === "string" && existing._warning) {
+        // Carry existing warnings forward — a later clean capture merging into
+        // the same snapshot file must not erase an earlier capture's warning
+        // (e.g. an over-cap b64 omission). Prefer the new `_warnings` array;
+        // fall back to the legacy "; "-joined `_warning` string for files
+        // written before this format change. The legacy split can still
+        // fragment an embedded-"; " warning in a pre-existing file, but new
+        // captures no longer create that hazard.
+        if (Array.isArray(existing._warnings)) {
+          fileWarnings.unshift(
+            ...(existing._warnings as unknown[]).filter((w): w is string => typeof w === "string"),
+          );
+        } else if (typeof existing._warning === "string" && existing._warning) {
           fileWarnings.unshift(...existing._warning.split("; "));
         }
       } catch (mergeErr) {
@@ -256,8 +292,11 @@ export function persistFixture(opts: {
     }
     if (fileWarnings.length > 0) {
       // Exact-duplicate warnings (e.g. repeated over-cap captures merging into
-      // the same snapshot file) collapse to one entry.
-      fileContent._warning = [...new Set(fileWarnings)].join("; ");
+      // the same snapshot file) collapse to one entry. Emit BOTH the
+      // authoritative array and the legacy joined string.
+      const dedupedWarnings = [...new Set(fileWarnings)];
+      fileContent._warnings = dedupedWarnings;
+      fileContent._warning = dedupedWarnings.join("; ");
     }
     // Atomic write: write to temp file then rename to avoid read-modify-write
     // races. Keep synchronous — for streamed responses the HTTP reply is
@@ -379,8 +418,12 @@ export async function proxyAndRecord(
         }),
       );
     } else {
-      // SSE headers already sent — gracefully close the connection
-      res.end();
+      // Streaming headers (200) are already on the wire, so we cannot change the
+      // status — but we MUST NOT call res.end(), which the client reads as a
+      // clean EOF and treats as a complete (silently truncated) response.
+      // Destroy the connection instead so the client sees an aborted stream and
+      // can surface the upstream failure rather than acting on partial data.
+      res.destroy();
     }
     return "relayed";
   }
@@ -391,7 +434,7 @@ export async function proxyAndRecord(
   // this path ever proxies long-lived or large streams — both the buffer
   // here and the hook below receive the full payload.
   const contentType = upstreamHeaders["content-type"];
-  const ctString = Array.isArray(contentType) ? contentType.join(", ") : (contentType ?? "");
+  const ctString = pickContentType(contentType);
   const isBinaryStream = ctString.toLowerCase().includes("application/vnd.amazon.eventstream");
   const collapsed = collapseStreamingResponse(
     ctString,
@@ -402,9 +445,15 @@ export async function proxyAndRecord(
 
   let fixtureResponse: FixtureResponse;
 
-  // TTS response — binary audio, not JSON
+  // TTS response — binary audio, not JSON. Classify on the audio content-type
+  // when upstream succeeded (2xx), regardless of body length: a zero-length
+  // audio body is still an audio response (empty audio), NOT an opaque
+  // proxy_error — letting it fall through to the JSON path would mis-record it.
+  // A non-2xx audio response (error JSON in the body) is left to the JSON/error
+  // path below.
   const isAudioResponse = ctString.toLowerCase().startsWith("audio/");
-  if (isAudioResponse && rawBuffer.length > 0) {
+  const isAudioSuccess = upstreamStatus >= 200 && upstreamStatus < 300;
+  if (isAudioResponse && isAudioSuccess) {
     // Derive format from Content-Type (audio/mpeg→mp3, audio/opus→opus, etc.)
     const audioFormat = ctString
       .toLowerCase()
@@ -412,6 +461,11 @@ export async function proxyAndRecord(
       .replace("mpeg", "mp3")
       .split(";")[0]
       .trim();
+    if (rawBuffer.length === 0) {
+      defaults.logger.warn(
+        "Audio response had a zero-length body — recording an empty audio fixture",
+      );
+    }
     fixtureResponse = {
       audio: rawBuffer.toString("base64"),
       ...(audioFormat && audioFormat !== "mp3" ? { format: audioFormat } : {}),
@@ -584,20 +638,10 @@ export async function proxyAndRecord(
         fixtureResponse = { json: parsedResponse, status: upstreamStatus };
       }
     } else {
-      let encodingFormat: string | undefined;
-      try {
-        encodingFormat = rawBody ? JSON.parse(rawBody).encoding_format : undefined;
-      } catch (err) {
-        defaults.logger.debug(
-          `Could not parse encoding_format from raw body: ${err instanceof Error ? err.message : "unknown error"}`,
-        );
-      }
-      fixtureResponse = buildFixtureResponse(
-        parsedResponse,
-        upstreamStatus,
-        encodingFormat,
-        defaults.logger,
-      );
+      // NOTE: base64 embeddings are decoded unconditionally inside
+      // buildFixtureResponse regardless of the request's `encoding_format`, so
+      // there is no need to re-parse it here — it was a dead param.
+      fixtureResponse = buildFixtureResponse(parsedResponse, upstreamStatus, defaults.logger);
     }
   }
 
@@ -774,6 +818,12 @@ function makeUpstreamRequest(
     const transport = target.protocol === "https:" ? https : http;
     const UPSTREAM_TIMEOUT_MS = clampTimeout(timeouts?.upstreamTimeoutMs, 30_000);
     const BODY_TIMEOUT_MS = clampTimeout(timeouts?.bodyTimeoutMs, 30_000);
+    // Capture the moment the request is dispatched (set just before
+    // `req.write` below). ttft/total durations are measured from request SEND,
+    // not from when upstream HEADERS arrive — basing them on headers-received
+    // time would exclude the upstream's time-to-first-byte and understate the
+    // recorded time-to-first-token.
+    let requestSendTime = 0;
     const req = transport.request(
       target,
       {
@@ -795,7 +845,7 @@ function makeUpstreamRequest(
         // which defeats progressive rendering in downstream consumers and
         // can trip HTTP idle timeouts on slow calls.
         const ct = res.headers["content-type"];
-        const ctStr = Array.isArray(ct) ? ct.join(", ") : (ct ?? "");
+        const ctStr = pickContentType(ct);
         const ctLower = ctStr.toLowerCase();
         const isSSE = ctLower.includes("text/event-stream");
         const isNDJSON = ctLower.includes("application/x-ndjson");
@@ -804,7 +854,9 @@ function makeUpstreamRequest(
         // SSE/NDJSON frame timing capture — timestamps each complete frame
         // so proxyAndRecord can build RecordedTimings for the fixture.
         const frameTimestamps: number[] = [];
-        const streamStartTime = Date.now();
+        // Measure from request send (see requestSendTime above), falling back to
+        // now only if it was somehow not set before the response callback fired.
+        const streamStartTime = requestSendTime || Date.now();
         let frameBuffer = "";
         // Decode chunks through a streaming-aware decoder so a multibyte UTF-8
         // character split across a TCP chunk boundary buffers across chunks
@@ -951,6 +1003,9 @@ function makeUpstreamRequest(
       );
     });
     req.on("error", reject);
+    // Stamp the send time immediately before dispatching the body so ttft and
+    // total-duration are measured from request send, not headers-received.
+    requestSendTime = Date.now();
     req.write(body);
     req.end();
   });
@@ -973,15 +1028,24 @@ function logDroppedReasoningSignature(
 }
 
 /**
+ * Coerce a tool call's `arguments` field into the string the fixture contract
+ * requires (types.ts `ToolCall.arguments: string`). When the upstream omits the
+ * arguments field entirely, `JSON.stringify(undefined)` yields the JS value
+ * `undefined` (not a string), which then gets dropped on disk-write and breaks
+ * cross-provider replay through the OpenAI streaming path. Coalesce to "{}" so
+ * `arguments` is ALWAYS a string, matching the streaming recorder's behavior.
+ */
+function toToolCallArguments(raw: unknown): string {
+  if (typeof raw === "string") return raw;
+  if (raw === undefined || raw === null) return "{}";
+  return JSON.stringify(raw);
+}
+
+/**
  * Detect the response format from the parsed upstream JSON and convert
  * it into an aimock FixtureResponse.
  */
-function buildFixtureResponse(
-  parsed: unknown,
-  status: number,
-  encodingFormat?: string,
-  logger?: Logger,
-): FixtureResponse {
+function buildFixtureResponse(parsed: unknown, status: number, logger?: Logger): FixtureResponse {
   if (parsed === null || parsed === undefined) {
     // Raw / unparseable response — save as error
     return {
@@ -1016,25 +1080,53 @@ function buildFixtureResponse(
     if (Array.isArray(first.embedding)) {
       return { embedding: first.embedding as number[] };
     }
-    if (typeof first.embedding === "string" && encodingFormat === "base64") {
+    // A string embedding is a base64-packed Float32 array. Decode it regardless
+    // of whether the request echoed `encoding_format: "base64"` — some providers
+    // return base64 without the client having asked for it, and gating on the
+    // request echo silently drops a valid embedding into the error fixture.
+    if (typeof first.embedding === "string") {
       const buf = Buffer.from(first.embedding, "base64");
-      if (buf.byteLength % 4 !== 0) {
-        // Malformed embedding — return a zero-dimension embedding fixture
-        return { embedding: [] };
+      if (buf.byteLength === 0 || buf.byteLength % 4 !== 0) {
+        // Malformed base64 (not a whole number of Float32s). Don't silently
+        // return a valid-looking zero-dimension embedding — log it and fall
+        // through to the generic error fixture so the loss is diagnosable.
+        logger?.warn(
+          `Could not decode base64 embedding (byteLength=${buf.byteLength} is not a positive multiple of 4) — saving as error fixture`,
+        );
+      } else {
+        // Uint8Array constructor copies Buffer data to a fresh ArrayBuffer at offset 0,
+        // guaranteeing the alignment Float32Array requires.
+        const copied = new Uint8Array(buf);
+        const floats = new Float32Array(copied.buffer, 0, buf.byteLength / 4);
+        return { embedding: Array.from(floats) };
       }
-      // Uint8Array constructor copies Buffer data to a fresh ArrayBuffer at offset 0,
-      // guaranteeing the alignment Float32Array requires.
-      const copied = new Uint8Array(buf);
-      const floats = new Float32Array(copied.buffer, 0, buf.byteLength / 4);
-      return { embedding: Array.from(floats) };
     }
     // OpenAI image generation: { created, data: [{ url, b64_json, revised_prompt }] }
-    if (first.url || first.b64_json) {
-      const images = (obj.data as Array<Record<string, unknown>>).map((item) => ({
-        ...(item.url ? { url: String(item.url) } : {}),
-        ...(item.b64_json ? { b64Json: String(item.b64_json) } : {}),
-        ...(item.revised_prompt ? { revisedPrompt: String(item.revised_prompt) } : {}),
-      }));
+    // Enter the branch when ANY item carries media — not just data[0]. A batch
+    // whose first element lacks both url and b64_json (e.g. a partial/placeholder
+    // entry) but whose later element HAS one would otherwise skip the branch and
+    // fall through to the error fixture, silently dropping every captured image.
+    if ((obj.data as Array<Record<string, unknown>>).some((item) => item.url || item.b64_json)) {
+      // Map only items that actually carry media (url or b64_json). A later item
+      // lacking both — including one whose `b64_json` is an empty string — would
+      // otherwise produce an empty {} image entry (all the conditional spreads
+      // are skipped) — silent fidelity loss.
+      const dataItems = obj.data as Array<Record<string, unknown>>;
+      const images = dataItems
+        .filter((item) => item.url || item.b64_json)
+        .map((item) => ({
+          ...(item.url ? { url: String(item.url) } : {}),
+          ...(item.b64_json ? { b64Json: String(item.b64_json) } : {}),
+          ...(item.revised_prompt ? { revisedPrompt: String(item.revised_prompt) } : {}),
+        }));
+      // Surface any dropped items (e.g. empty-string b64_json placeholders) so
+      // the fidelity loss is diagnosable rather than silent.
+      const droppedCount = dataItems.length - images.length;
+      if (droppedCount > 0) {
+        logger?.warn(
+          `Dropped ${droppedCount} image item(s) from batch lacking a non-empty url or b64_json`,
+        );
+      }
       if (images.length === 1) {
         return { image: images[0] };
       }
@@ -1055,10 +1147,21 @@ function buildFixtureResponse(
   }
 
   // OpenAI transcription: { text: "...", ... }
-  if (
+  // Tightened: a bare `text` string alongside a single incidental `language` or
+  // `duration` field is too weak — many non-transcription payloads carry a
+  // `text` plus a `duration`-like number. Require an explicit
+  // `task: "transcribe"`, OR BOTH `language` and `duration` (the verbose
+  // transcription shape). Also reject anything carrying clear non-transcription
+  // markers (chat completions, events, etc.) so they route to their own branch.
+  const looksLikeTranscription =
     typeof obj.text === "string" &&
-    (obj.task === "transcribe" || obj.language !== undefined || obj.duration !== undefined)
-  ) {
+    (obj.task === "transcribe" || (obj.language !== undefined && obj.duration !== undefined)) &&
+    !("choices" in obj) &&
+    !("candidates" in obj) &&
+    !("object" in obj) &&
+    !("message" in obj) &&
+    !("outputs" in obj);
+  if (looksLikeTranscription) {
     return {
       transcription: {
         text: obj.text as string,
@@ -1088,7 +1191,7 @@ function buildFixtureResponse(
     if (hasToolCalls) {
       const toolCalls: ToolCall[] = fnCallOutputs.map((o) => ({
         name: String(o.name),
-        arguments: typeof o.arguments === "string" ? o.arguments : JSON.stringify(o.arguments),
+        arguments: toToolCallArguments(o.arguments),
         ...(o.id ? { id: String(o.id) } : {}),
       }));
       if (hasContent) {
@@ -1154,10 +1257,16 @@ function buildFixtureResponse(
       const hasToolCalls = Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
       const hasContent = typeof message.content === "string" && message.content.length > 0;
 
+      // Reasoning is exposed under different keys across OpenAI-compatible
+      // providers: OpenAI/vLLM use `reasoning_content`, while DeepSeek and
+      // OpenRouter use `reasoning`. Read both (preferring `reasoning_content`)
+      // so a reasoning turn is not silently dropped on the latter providers.
       const openaiReasoning =
         typeof message.reasoning_content === "string" && message.reasoning_content.length > 0
           ? message.reasoning_content
-          : undefined;
+          : typeof message.reasoning === "string" && message.reasoning.length > 0
+            ? message.reasoning
+            : undefined;
 
       if (hasToolCalls) {
         const toolCalls: ToolCall[] = (message.tool_calls as Array<Record<string, unknown>>).map(
@@ -1165,7 +1274,7 @@ function buildFixtureResponse(
             const fn = tc.function as Record<string, unknown>;
             return {
               name: String(fn.name),
-              arguments: String(fn.arguments),
+              arguments: toToolCallArguments(fn.arguments),
               ...(tc.id ? { id: String(tc.id) } : {}),
             };
           },
@@ -1246,7 +1355,7 @@ function buildFixtureResponse(
     if (hasToolCalls) {
       const toolCalls: ToolCall[] = toolUseBlocks.map((b) => ({
         name: String(b.name),
-        arguments: typeof b.input === "string" ? b.input : JSON.stringify(b.input),
+        arguments: toToolCallArguments(b.input),
         ...(b.id ? { id: String(b.id) } : {}),
       }));
       if (hasContent) {
@@ -1302,19 +1411,39 @@ function buildFixtureResponse(
     if (content && Array.isArray(content.parts)) {
       const parts = content.parts as Array<Record<string, unknown>>;
 
-      // Audio inlineData parts take priority over text
-      const audioParts = parts.filter(
-        (p: Record<string, unknown>) =>
-          p.inlineData &&
-          typeof (p.inlineData as Record<string, unknown>).mimeType === "string" &&
-          ((p.inlineData as Record<string, unknown>).mimeType as string).startsWith("audio/"),
-      );
+      // Audio inlineData parts take priority over text. Key on the PRESENCE of
+      // `inlineData.data` rather than solely on the mimeType: an audio part can
+      // arrive with a missing or unexpected mimeType, and filtering strictly on
+      // an `audio/` prefix would then drop a part that genuinely carries audio
+      // bytes, producing an empty b64Json. A NON-audio mimeType (e.g. `image/`)
+      // still routes elsewhere, so image inlineData is not misclassified — only
+      // an explicit `audio/` prefix OR a missing/blank mimeType counts as audio.
+      const audioParts = parts.filter((p: Record<string, unknown>) => {
+        const inline = p.inlineData as Record<string, unknown> | undefined;
+        if (
+          inline === undefined ||
+          inline === null ||
+          typeof inline.data !== "string" ||
+          inline.data.length === 0
+        ) {
+          return false;
+        }
+        const mt = inline.mimeType;
+        if (typeof mt === "string" && mt.length > 0) {
+          return mt.startsWith("audio/");
+        }
+        // Missing/blank mimeType but data present → treat as audio.
+        return true;
+      });
       if (audioParts.length > 0) {
         const inlineData = audioParts[0].inlineData as Record<string, unknown>;
         return {
           audio: {
             b64Json: String(inlineData.data ?? ""),
-            contentType: String(inlineData.mimeType),
+            contentType:
+              typeof inlineData.mimeType === "string" && inlineData.mimeType.length > 0
+                ? inlineData.mimeType
+                : "audio/mpeg",
           },
         };
       }
@@ -1335,7 +1464,7 @@ function buildFixtureResponse(
           const fc = p.functionCall as Record<string, unknown>;
           return {
             name: String(fc.name),
-            arguments: typeof fc.args === "string" ? fc.args : JSON.stringify(fc.args),
+            arguments: toToolCallArguments(fc.args),
           };
         });
         if (hasContent) {
@@ -1386,7 +1515,7 @@ function buildFixtureResponse(
           const tu = b.toolUse as Record<string, unknown>;
           return {
             name: String(tu.name ?? ""),
-            arguments: typeof tu.input === "string" ? tu.input : JSON.stringify(tu.input),
+            arguments: toToolCallArguments(tu.input),
             ...(tu.toolUseId ? { id: String(tu.toolUseId) } : {}),
           };
         });
@@ -1421,8 +1550,13 @@ function buildFixtureResponse(
   ) {
     const msg = obj.message as Record<string, unknown>;
     const contentBlocks = msg.content as Array<Record<string, unknown>>;
-    const textBlock = contentBlocks.find((b) => b.type === "text" && typeof b.text === "string");
-    const hasContent = textBlock && typeof textBlock.text === "string" && textBlock.text.length > 0;
+    // Join ALL text blocks, not just the first — a multi-block Cohere response
+    // would otherwise be truncated to its leading segment.
+    const joinedText = contentBlocks
+      .filter((b) => b.type === "text" && typeof b.text === "string")
+      .map((b) => String(b.text ?? ""))
+      .join("");
+    const hasContent = joinedText.length > 0;
     const toolCallBlocks = contentBlocks.filter((b) => b.type === "tool_call");
 
     // Also check message-level tool_calls (Cohere v2 puts tool calls here, not in content blocks)
@@ -1440,11 +1574,11 @@ function buildFixtureResponse(
               ? JSON.stringify(b.parameters)
               : typeof (b.function as Record<string, unknown>)?.arguments === "string"
                 ? String((b.function as Record<string, unknown>).arguments)
-                : JSON.stringify((b.function as Record<string, unknown>)?.arguments),
+                : toToolCallArguments((b.function as Record<string, unknown>)?.arguments),
         ...(b.id ? { id: String(b.id) } : {}),
       }));
       if (hasContent) {
-        return { content: textBlock.text as string, toolCalls };
+        return { content: joinedText, toolCalls };
       }
       return { toolCalls };
     }
@@ -1460,18 +1594,23 @@ function buildFixtureResponse(
                 ? JSON.stringify(tc.parameters)
                 : typeof fn?.arguments === "string"
                   ? String(fn.arguments)
-                  : JSON.stringify(fn?.arguments),
+                  : toToolCallArguments(fn?.arguments),
           ...(tc.id ? { id: String(tc.id) } : {}),
         };
       });
       if (hasContent) {
-        return { content: textBlock.text as string, toolCalls };
+        return { content: joinedText, toolCalls };
       }
       return { toolCalls };
     }
     if (hasContent) {
-      return { content: textBlock.text as string };
+      return { content: joinedText };
     }
+    // Recognized Cohere v2 shape (finish_reason + message.content array) with
+    // no text and no tool calls. Own the empty turn here and return an
+    // empty-content fixture rather than falling through to the Ollama branch
+    // below, which would re-handle `message.content` and mis-route it.
+    return { content: "" };
   }
 
   // Ollama: { message: { content: "...", tool_calls: [...] } }
@@ -1487,8 +1626,7 @@ function buildFixtureResponse(
           const fn = tc.function as Record<string, unknown>;
           return {
             name: String(fn.name ?? ""),
-            arguments:
-              typeof fn.arguments === "string" ? fn.arguments : JSON.stringify(fn.arguments),
+            arguments: toToolCallArguments(fn.arguments),
           };
         });
       if (hasOllamaContent) {
@@ -1509,11 +1647,21 @@ function buildFixtureResponse(
   }
 
   // Ollama /api/generate: { response: "...", done: true/false }
-  if (typeof obj.response === "string" && "done" in obj) {
+  // Narrowed: require `done` to be a boolean — Ollama always sends a boolean
+  // here, and gating merely on `"done" in obj` would capture unrelated payloads
+  // that happen to carry a `response` string and some other `done`-keyed value.
+  if (typeof obj.response === "string" && typeof obj.done === "boolean") {
     return { content: obj.response };
   }
 
-  // Fallback: unknown format — save as error
+  // Fallback: unknown format — save as error. Log the observed top-level shape
+  // so an unrecognized/new provider response is diagnosable instead of silently
+  // becoming an opaque error fixture.
+  logger?.warn(
+    `Could not detect response format from upstream (status=${status}) — saving as error fixture; top-level keys: [${Object.keys(
+      obj,
+    ).join(", ")}]`,
+  );
   return {
     error: {
       message: "Could not detect response format from upstream",

--- a/src/types.ts
+++ b/src/types.ts
@@ -669,6 +669,28 @@ export interface RecordConfig {
    * downloading multi-minute video never times out — only a silent stall does.
    */
   bodyTimeoutMs?: number;
+  /**
+   * Maximum number of bytes aimock will accumulate in memory from a single
+   * proxied upstream response on the record/proxy path. The full response is
+   * still relayed to the client byte-for-byte; this cap only bounds the
+   * in-memory buffer used to collapse/journal the response. Once the cap is
+   * exceeded aimock stops appending to the buffer, marks the response as
+   * truncated, and skips collapse/recording — preventing both unbounded heap
+   * growth and the `RangeError: Invalid string length` that a >512MB string
+   * would otherwise throw. Default: 64 MiB.
+   */
+  maxProxyBufferBytes?: number;
+  /**
+   * Maximum number of SSE/NDJSON/EventStream frames whose per-frame state
+   * (`frameTimestamps`, parse buffers) aimock retains for a single proxied
+   * response. Frame state is count-indexed, not byte-sized, so a long-lived or
+   * never-ending stream accumulates it unbounded even when `maxProxyBufferBytes`
+   * is generous. Tripping truncation on EITHER bytes OR frame count bounds both;
+   * on the trip the accumulated frame state is freed and collapse/recording is
+   * skipped (the full response is still relayed to the client byte-for-byte).
+   * Default: 5,000,000 frames.
+   */
+  maxProxyBufferFrames?: number;
 }
 
 export interface OpenRouterVideoRecordConfig {


### PR DESCRIPTION
Combined release **v1.33.0** — folds the proxy-buffer-cap memory-leak fix (formerly #275) into this stabilization branch so a single version ships both. `src/recorder.ts` auto-merged cleanly (disjoint regions); combined test suite green (3968 pass / 0 fail).

## Added
- `--max-proxy-buffer-bytes` / `--max-proxy-buffer-frames` to bound proxy-record buffering

## Fixed
- **Proxy memory leak:** the proxy/record path accumulated per-frame state (`frameTimestamps`, frame buffers, `chunks`) for a stream's whole lifetime — long-lived proxied SSE streams drove ~8.4 GB/25 h → OOM. Now byte+frame-capped per-frame (incl. binary EventStream), cleared on trip, with disconnect cleanup; relay preserved (fail-loud 502 above the 256 MiB hard ceiling). (was #275)
- **`Invalid string length` crash:** oversized proxied responses no longer build a >512 MB string. (was #275)
- Sanitize `X-AIMock-Context` to prevent fixture path traversal.
- Scope one-shot error injection to compatible endpoints.
- Improve recorder fixture fidelity across providers.
- `matchesPattern` no longer mutates the caller's RegExp `lastIndex`.

## Release
Merging this PR autopublishes `@copilotkit/aimock` **v1.33.0** (publish-release.yml: push-to-main gated by "version not yet on npm"). Supersedes #275.

## Verification
- Buffer-cap fix: 3 CR rounds to zero; local red-green (never-ending stream heap flat after cap); staging heap bounded (oscillates+reclaims, no OOM trajectory).
- Combined: tsc clean, full suite 3968 pass / 0 fail, build OK.