### PR TITLE
chore: release v1.32.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "npm",
         "package": "@copilotkit/aimock",
-        "version": "^1.31.0"
+        "version": "^1.32.0"
       },
       "description": "Fixture authoring skill for @copilotkit/aimock — LLM, multimedia (image/TTS/transcription/video), MCP, A2A, AG-UI, vector, embeddings, structured output, sequential responses, streaming physics, record/replay, agent loop patterns, and debugging"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimock",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Fixture authoring guidance for @copilotkit/aimock — LLM, multimedia, MCP, A2A, AG-UI, vector, and service mocking",
   "author": {
     "name": "CopilotKit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.32.0] - 2026-06-22
+
 ### Added
 
 - fal queue `status`/`result` responses now emit `x-fal-request-id`, and a `billableUnits` fixture field (e.g. `onFalQueue(model, json, { billableUnits })`) emits `x-fal-billable-units` on the completed result so adapters like `@tanstack/ai-fal` can surface `usage.unitsBilled` on replay. Record mode captures the upstream `x-fal-billable-units` header automatically, so recorded fixtures round-trip billing with no hand-editing (#269)

--- a/charts/aimock/Chart.yaml
+++ b/charts/aimock/Chart.yaml
@@ -3,4 +3,4 @@ name: aimock
 description: Mock infrastructure for AI application testing (OpenAI, Anthropic, Gemini, MCP, A2A, vector)
 type: application
 version: 0.1.0
-appVersion: "1.31.0"
+appVersion: "1.32.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/packages/aimock-pytest/README.md
+++ b/packages/aimock-pytest/README.md
@@ -73,7 +73,7 @@ aimock.reset()             # alias for reset_fixtures()
 
 ```
 --aimock-node PATH       Path to node binary
---aimock-version VER     aimock npm version (default: 1.31.0)
+--aimock-version VER     aimock npm version (default: 1.32.0)
 ```
 
 ## Environment Variables

--- a/packages/aimock-pytest/src/aimock_pytest/_version.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_version.py
@@ -8,4 +8,4 @@ contains any new server routes/features the client calls (e.g. the reset-split
 control routes ship in the next release). Keep it tracking npm releases.
 """
 
-AIMOCK_VERSION = "1.31.0"
+AIMOCK_VERSION = "1.32.0"


### PR DESCRIPTION
Minor release bumping all 5 version surfaces from 1.31.0 to 1.32.0 and promoting the `[Unreleased]` CHANGELOG section (the #270 fal billing-headers entry) to a dated `[1.32.0] - 2026-06-22` heading.

## Version surfaces bumped (1.31.0 → 1.32.0)

- `package.json` — `version`
- `charts/aimock/Chart.yaml` — `appVersion` (chart `version: 0.1.0` untouched)
- `.claude-plugin/plugin.json` — `version`
- `.claude-plugin/marketplace.json` — `plugins[0].source.version` (`^1.31.0` → `^1.32.0`)
- `packages/aimock-pytest/src/aimock_pytest/_version.py` — `AIMOCK_VERSION` (pytest pyproject `0.4.0` untouched)

## CHANGELOG

Promoted `[Unreleased]` to `## [1.32.0] - 2026-06-22`, leaving an empty `[Unreleased]` at the top. The single Added entry is the #270 fal billing-headers change (`x-fal-request-id` / `x-fal-billable-units`), moved verbatim.

## Quality gates (local, all green)

- `pnpm install --frozen-lockfile` — OK
- `pnpm run format:check` — OK
- `pnpm run lint` — OK
- `pnpm run test` — 3922 passed, 44 skipped, 0 failed
- `pnpm run build` — OK

Note: `publish-release.yml` autopublishes on merge to main.