### PR TITLE
fix: bound proxy buffer to stop long-stream heap leak + Invalid string length crash

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "npm",
         "package": "@copilotkit/aimock",
-        "version": "^1.32.0"
+        "version": "^1.33.0"
       },
       "description": "Fixture authoring skill for @copilotkit/aimock — LLM, multimedia (image/TTS/transcription/video), MCP, A2A, AG-UI, vector, embeddings, structured output, sequential responses, streaming physics, record/replay, agent loop patterns, and debugging"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimock",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Fixture authoring guidance for @copilotkit/aimock — LLM, multimedia, MCP, A2A, AG-UI, vector, and service mocking",
   "author": {
     "name": "CopilotKit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-06-23
+
+### Added
+
+- `--max-proxy-buffer-bytes` / `--max-proxy-buffer-frames` flags to cap proxy buffering (#275)
+
+### Fixed
+
+- Proxy path no longer leaks memory on long-lived upstream streams (#275)
+- Oversized proxied responses no longer crash with `RangeError: Invalid string length` (#275)
+
 ## [1.32.0] - 2026-06-22
 
 ### Added

--- a/charts/aimock/Chart.yaml
+++ b/charts/aimock/Chart.yaml
@@ -3,4 +3,4 @@ name: aimock
 description: Mock infrastructure for AI application testing (OpenAI, Anthropic, Gemini, MCP, A2A, vector)
 type: application
 version: 0.1.0
-appVersion: "1.32.0"
+appVersion: "1.33.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/packages/aimock-pytest/src/aimock_pytest/_version.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_version.py
@@ -8,4 +8,4 @@ contains any new server routes/features the client calls (e.g. the reset-split
 control routes ship in the next release). Keep it tracking npm releases.
 """
 
-AIMOCK_VERSION = "1.32.0"
+AIMOCK_VERSION = "1.33.0"

--- a/src/__tests__/proxy-buffer-cap-enforcement.test.ts
+++ b/src/__tests__/proxy-buffer-cap-enforcement.test.ts
@@ -1,0 +1,561 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createServer, type ServerInstance } from "../server.js";
+import { Logger } from "../logger.js";
+import { setProxyBufferHardCeilingForTests } from "../recorder.js";
+
+// ---------------------------------------------------------------------------
+// Proxy-path buffer cap ENFORCEMENT (per-frame + binary + non-streamed relay).
+//
+// These tests exercise the REAL proxyAndRecord/makeUpstreamRequest path via a
+// local fake upstream and assert the cap is enforced MID-CHUNK (not just at the
+// top of the data callback) and that the non-streamed over-cap path RELAYS the
+// real body rather than synthesizing a 502.
+// ---------------------------------------------------------------------------
+
+let upstream: http.Server | undefined;
+let recorder: ServerInstance | undefined;
+let tmpDir: string | undefined;
+
+afterEach(async () => {
+  if (recorder) {
+    await new Promise<void>((resolve) => recorder!.server.close(() => resolve()));
+    recorder = undefined;
+  }
+  if (upstream) {
+    await new Promise<void>((resolve) => upstream!.close(() => resolve()));
+    upstream = undefined;
+  }
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+  // Restore the real hard ceiling after any test that lowered it.
+  setProxyBufferHardCeilingForTests(undefined);
+  vi.restoreAllMocks();
+});
+
+/**
+ * Upstream that delivers ALL `frameCount` complete SSE frames in a SINGLE
+ * socket write (one coalesced `data` event from the recorder's perspective).
+ * A2-style coalescing is the crux of the per-frame-cap bug: the top-of-callback
+ * frame guard runs ONCE before the splitter pushes every frame, so a single
+ * chunk overshoots `frameTimestamps` unboundedly unless the cap is checked
+ * per-frame inside the splitter loop.
+ */
+function createCoalescedFrameSseUpstream(frameCount: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      // One giant string: frameCount tiny frames, all in a single write.
+      const frame = 'data: {"d":"a"}\n\n';
+      res.write(frame.repeat(frameCount));
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * Binary EventStream upstream that streams bytes which NEVER complete a frame:
+ * each chunk starts with a 4-byte big-endian totalLen prefix that is larger
+ * than anything that will ever arrive (so `binaryFrameBuffer.length < totalLen`
+ * stays true forever) — modeling a never-completing / malformed binary frame.
+ */
+function createNeverCompletingBinaryUpstream(
+  totalBytes: number,
+  chunkBytes: number,
+): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "application/vnd.amazon.eventstream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      // First 4 bytes: an enormous totalLen so the frame never completes.
+      const header = Buffer.alloc(4);
+      header.writeUInt32BE(0xfffffff0, 0);
+      res.write(header);
+      let sent = 4;
+      const chunk = Buffer.alloc(chunkBytes, 0x41);
+      const writeNext = () => {
+        if (res.writableEnded || res.destroyed) return;
+        if (sent >= totalBytes) {
+          res.end();
+          return;
+        }
+        sent += chunk.length;
+        if (res.write(chunk)) setImmediate(writeNext);
+        else res.once("drain", writeNext);
+      };
+      writeNext();
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * Non-streamed (plain JSON, no SSE/NDJSON) upstream returning a body of
+ * `totalBytes`. The whole body is fully received before the recorder decides
+ * what to do — the over-cap path must RELAY it, not synthesize a 502.
+ */
+function createLargeJsonUpstream(totalBytes: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      const filler = "x".repeat(Math.max(0, totalBytes - 32));
+      const body = JSON.stringify({ id: "resp_1", big: filler });
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(body),
+      });
+      res.end(body);
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * Binary EventStream upstream that emits `frameCount` COMPLETE, well-formed
+ * frames (4-byte big-endian totalLen prefix >= 12) packed into a SINGLE socket
+ * write of exactly `frameCount * frameLen` bytes. Delivering the whole body in
+ * one write means the recorder's `binaryFrameBuffer` concats it once and the
+ * splitter drains every complete frame, leaving binaryFrameBuffer back at 0 —
+ * isolating the byte-cap accounting (`bufferedBytes`) so the redundant
+ * `+ chunk.length` double-count is the ONLY thing that can trip the cap early.
+ */
+function createCompleteBinaryFrameUpstream(frameCount: number, frameLen: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "application/vnd.amazon.eventstream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      const frame = Buffer.alloc(frameLen, 0x41);
+      frame.writeUInt32BE(frameLen, 0); // totalLen prefix == whole frame length
+      // One write of the entire body so the recorder sees a single coalesced
+      // chunk whose binary frames all complete (binaryFrameBuffer drains to 0).
+      res.end(Buffer.concat(Array.from({ length: frameCount }, () => frame)));
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * Non-streamed (plain JSON) upstream returning a body of `totalBytes` with a
+ * caller-chosen status code. Used to prove the over-cap relay normalizes the
+ * upstream status (success→200 / error→502) like every other relay path.
+ */
+function createLargeJsonUpstreamWithStatus(totalBytes: number, status: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      const filler = "x".repeat(Math.max(0, totalBytes - 32));
+      const body = JSON.stringify({ id: "resp_1", big: filler });
+      res.writeHead(status, {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(body),
+      });
+      res.end(body);
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/** Stream a POST and accumulate the relayed body length. */
+function postStreaming(
+  url: string,
+  body: unknown,
+): Promise<{ status: number; bytesReceived: number }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        let bytesReceived = 0;
+        res.on("data", (c: Buffer) => {
+          bytesReceived += c.length;
+        });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, bytesReceived }));
+        // Without a res-side error handler a mid-stream relay error hangs to
+        // timeout — fail fast instead.
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+const CHAT_REQUEST = {
+  model: "gpt-4",
+  stream: true,
+  messages: [{ role: "user", content: "stream me a lot" }],
+};
+
+const NONSTREAM_REQUEST = {
+  model: "gpt-4",
+  messages: [{ role: "user", content: "give me a big json" }],
+};
+
+describe("proxy buffer cap enforcement", () => {
+  // A1 — per-frame cap. A single coalesced chunk carrying many complete frames
+  // must NOT overshoot the frame cap. The SSE/NDJSON splitter calls Date.now()
+  // exactly once per complete frame it timestamps, so counting Date.now()
+  // invocations during the request is a deterministic, GC-immune measure of how
+  // many frames were pushed before truncation stopped the loop.
+  it("A1: bounds per-frame timestamping on a single coalesced chunk of many frames", async () => {
+    const FRAMES = 600_000; // all delivered in ONE coalesced socket write
+    const BYTE_CAP = 256 * 1024 * 1024; // generous: only the frame cap can trip
+    // Tiny frame cap: a single ~64 KB TCP segment holds ~3800 tiny frames, so
+    // ONE coalesced data event already carries far more than the cap. Buggy
+    // (top-of-callback-only) code timestamps every frame in that segment before
+    // re-checking, massively overshooting; per-frame enforcement stops at ~cap.
+    const FRAME_CAP = 100;
+
+    const upstreamUrl = await createCoalescedFrameSseUpstream(FRAMES);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-a1-"));
+
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    // Count Date.now() calls — one per per-frame timestamp push.
+    const realNow = Date.now.bind(Date);
+    let nowCalls = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      nowCalls++;
+      return realNow();
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    // Client still gets every byte.
+    expect(resp.status).toBe(200);
+
+    // The frame cap tripped and recording was skipped.
+    const truncationWarn = warnings.find((w) => /frame cap/i.test(w));
+    expect(truncationWarn).toBeDefined();
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+
+    // RED on the buggy code: the cap is only checked at the TOP of the data
+    // callback, so the single coalesced chunk's splitter loop pushes a
+    // timestamp for ALL 600k frames before the next callback ever runs —
+    // Date.now() is called ~600k times. GREEN: per-frame enforcement stops the
+    // loop at the cap, so Date.now() is called only a few thousand times. Allow
+    // generous slack (startTime + flush + a chunk-boundary's worth).
+
+    console.log(`[A1] Date.now() calls (≈ frames timestamped): ${nowCalls}`);
+    // Bound: cap + one segment's leftover slack + startTime/flush. A single TCP
+    // segment is ~64 KB ≈ 3800 frames; per-frame enforcement caps the timestamp
+    // count near FRAME_CAP, so well under 1000 total.
+    expect(nowCalls).toBeLessThan(FRAME_CAP + 900);
+  });
+
+  // A2 — binary parse buffer must be counted toward the byte cap. On a
+  // never-completing binary frame, `binaryFrameBuffer` is a SECOND, parallel
+  // copy of every byte (Buffer.concat) that the buggy code does NOT count
+  // toward `bufferedBytes`. The raw `chunks` array trips the byte cap, but only
+  // AFTER `binaryFrameBuffer` has independently grown to ~the full cap's worth
+  // of bytes — so peak memory is ~2× the cap. We spy on Buffer.concat to
+  // capture the PEAK `binaryFrameBuffer` length: counting it toward the byte
+  // cap makes truncation trip far sooner, bounding the parallel copy well below
+  // the byte cap.
+  it("A2: counts binaryFrameBuffer toward the byte cap so it cannot grow a full second copy", async () => {
+    const TOTAL = 16 * 1024 * 1024; // 16 MB of bytes, never completing a frame
+    const CHUNK = 64 * 1024;
+    const BYTE_CAP = 512 * 1024; // low byte cap
+    const FRAME_CAP = 5_000_000; // generous: frame cap cannot trip (no frames complete)
+
+    const upstreamUrl = await createNeverCompletingBinaryUpstream(TOTAL, CHUNK);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-a2-"));
+
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    // Capture the peak size of any Buffer.concat result — the binary parse
+    // buffer is rebuilt via Buffer.concat([binaryFrameBuffer, chunk]) each tick.
+    const realConcat = Buffer.concat.bind(Buffer);
+    let peakConcat = 0;
+    vi.spyOn(Buffer, "concat").mockImplementation((list: readonly Uint8Array[], len?: number) => {
+      const out = len === undefined ? realConcat(list) : realConcat(list, len);
+      if (out.length > peakConcat) peakConcat = out.length;
+      return out;
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    expect(resp.status).toBe(200);
+
+    // RED: binaryFrameBuffer grows uncounted to ~BYTE_CAP (512 KB) before the
+    // chunks byte cap trips — a full parallel copy. GREEN: binaryFrameBuffer is
+    // counted toward the byte cap, so truncation trips before it can grow a
+    // full second copy; peak stays well under the byte cap.
+    // RED: binaryFrameBuffer grows uncounted to ~BYTE_CAP (≈488 KB observed)
+    // before the chunks byte cap trips — a near-full parallel copy, so total
+    // peak ≈ 2× cap. GREEN: counting binaryFrameBuffer toward the byte cap
+    // doubles the effective per-chunk accounting, tripping truncation at ~half
+    // the data, so the parallel copy peaks well under half the byte cap.
+
+    console.log(
+      `[A2] peak binaryFrameBuffer (Buffer.concat): ${peakConcat} bytes (cap=${BYTE_CAP})`,
+    );
+    expect(peakConcat).toBeLessThan(BYTE_CAP * 0.6);
+
+    const truncationWarn = warnings.find((w) => /byte cap/i.test(w));
+    expect(truncationWarn).toBeDefined();
+
+    // Recording skipped under truncation: no fixture written.
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+  });
+
+  // A3 — non-streamed over-cap must RELAY the received body, not 502.
+  it("A3: relays the real non-streamed body when it exceeds the cap (no synthetic 502)", async () => {
+    const TOTAL = 2 * 1024 * 1024; // 2 MB JSON
+    const BYTE_CAP = 256 * 1024; // below the body size
+
+    const upstreamUrl = await createLargeJsonUpstream(TOTAL);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-a3-"));
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, NONSTREAM_REQUEST);
+
+    // RED: buggy code returns 502 with a tiny synthetic error body. GREEN:
+    // client gets 200 + the full real body relayed.
+
+    console.log(`[A3] status=${resp.status} bytesReceived=${resp.bytesReceived}`);
+    expect(resp.status).toBe(200);
+    // The full real body is relayed (~TOTAL bytes), NOT a tiny ~129-byte
+    // synthetic 502 JSON. Allow small slack for the JSON envelope overhead.
+    expect(resp.bytesReceived).toBeGreaterThan(TOTAL - 1024);
+
+    // Recording skipped (truncated), so no fixture written.
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+  });
+
+  // R2-B — the binary byte-cap must NOT double-count the current chunk.
+  // `bufferedBytes` already includes `chunk.length` by the time the binary
+  // guard runs, so the original `bufferedBytes + binaryFrameBuffer.length +
+  // chunk.length > maxBufferBytes` trips ONE CHUNK EARLY. With complete frames
+  // (binaryFrameBuffer drains to ~0 each tick) and a total exactly equal to the
+  // cap, the corrected accounting must NOT trip, but the double-count does.
+  //   RED: byte cap trips though total bytes == cap (off by one chunk);
+  //        recording is skipped.
+  //   GREEN: does NOT trip; the stream records normally (no byte-cap warning).
+  it("R2-B: does not trip the binary byte cap one chunk early (no chunk double-count)", async () => {
+    const FRAME_LEN = 64 * 1024; // 64 KiB complete frames
+    const FRAMES = 7; // total == 448 KiB
+    const BYTE_CAP = 512 * 1024; // 512 KiB — total (448 KiB) sits one full frame under the cap
+    const FRAME_CAP = 5_000_000; // generous: frame cap cannot trip
+
+    const upstreamUrl = await createCompleteBinaryFrameUpstream(FRAMES, FRAME_LEN);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-r2b-"));
+
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    console.log(
+      `[R2-B] status=${resp.status} bytesReceived=${resp.bytesReceived} cap=${BYTE_CAP} byteCapTripped=${warnings.some((w) => /byte cap/i.test(w))}`,
+    );
+    expect(resp.status).toBe(200);
+    // RED: double-count trips the byte cap at the last chunk even though total
+    // == cap. GREEN: the configured cap is reached exactly, not exceeded, so no
+    // byte-cap truncation fires.
+    expect(warnings.some((w) => /byte cap/i.test(w))).toBe(false);
+
+    // Frame cap is generous and never trips either.
+    expect(warnings.some((w) => /frame cap/i.test(w))).toBe(false);
+  });
+
+  // R2-A — a non-progressive body LARGER than the hard ceiling must NOT be
+  // relayed as a truncated-but-2xx response. Lower the hard ceiling to a tiny
+  // value so a small JSON body exceeds it (keeping the test fast). The
+  // non-progressive buffer stops growing at the hard ceiling, so the buffered
+  // copy is PARTIAL.
+  //   RED: client receives a 2xx whose body is SHORTER than what upstream sent
+  //        (truncated, presented as success) — the silent-truncation bug.
+  //   GREEN: client receives a loud 502 ("exceeds proxy ceiling"), never a
+  //        truncated 2xx. (A full pass-through relay would be the other
+  //        acceptable outcome, but this fix chose fail-loud.)
+  it("R2-A: never relays a truncated body as 2xx when upstream exceeds the hard ceiling", async () => {
+    const HARD_CEILING = 64 * 1024; // tiny test-only ceiling
+    const TOTAL = 1 * 1024 * 1024; // 1 MB body — far over the ceiling
+    const BYTE_CAP = 16 * 1024; // soft cap below the ceiling too
+
+    setProxyBufferHardCeilingForTests(HARD_CEILING);
+    const upstreamUrl = await createLargeJsonUpstream(TOTAL);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-r2a-"));
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, NONSTREAM_REQUEST);
+
+    console.log(`[R2-A] status=${resp.status} bytesReceived=${resp.bytesReceived} (sent=${TOTAL})`);
+    // GREEN invariant: never a truncated body presented as success. Either the
+    // full body (>= TOTAL) or a loud error status. A 2xx with a body shorter
+    // than upstream sent is the forbidden state.
+    const truncatedAsSuccess =
+      resp.status >= 200 && resp.status < 300 && resp.bytesReceived < TOTAL - 1024;
+    expect(truncatedAsSuccess).toBe(false);
+    // This fix chose fail-loud: a body over the ceiling returns 502.
+    expect(resp.status).toBe(502);
+
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+  });
+
+  // R2-C — over-cap (under-ceiling) relay must NORMALIZE the upstream status
+  // (success→200 / error→502) like every other relay path, not leak the raw
+  // upstream code. Upstream returns a 503 body large enough to trip the soft
+  // cap but small enough to stay under the hard ceiling.
+  //   RED: client receives 503 verbatim.
+  //   GREEN: client receives a normalized 502.
+  it("R2-C: normalizes upstream status on the over-cap relay (503 -> 502)", async () => {
+    const TOTAL = 2 * 1024 * 1024; // 2 MB — over the soft cap, under the ceiling
+    const BYTE_CAP = 256 * 1024;
+
+    const upstreamUrl = await createLargeJsonUpstreamWithStatus(TOTAL, 503);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-r2c-"));
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, NONSTREAM_REQUEST);
+
+    console.log(
+      `[R2-C] upstream=503 relayedStatus=${resp.status} bytesReceived=${resp.bytesReceived}`,
+    );
+    // RED: 503 leaked verbatim. GREEN: normalized to 502.
+    expect(resp.status).toBe(502);
+    // Body is still relayed (full real upstream body, under the ceiling).
+    expect(resp.bytesReceived).toBeGreaterThan(TOTAL - 1024);
+
+    expect(noFixtureWritten(tmpDir)).toBe(true);
+  });
+});
+
+/**
+ * Walk `dir` recursively and return true when NO `.json` fixture exists
+ * anywhere beneath it. persistFixture can write into `slug/` or `context/`
+ * subdirectories, so a non-recursive readdir would go vacuously true even if a
+ * fixture WERE written into a subdir.
+ */
+function noFixtureWritten(dir: string): boolean {
+  if (!fs.existsSync(dir)) return true;
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+      const full = path.join(cur, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.name.endsWith(".json")) {
+        return false;
+      }
+    }
+  }
+  return true;
+}

--- a/src/__tests__/proxy-buffer-cap.test.ts
+++ b/src/__tests__/proxy-buffer-cap.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createServer, type ServerInstance } from "../server.js";
+import { Logger } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// Proxy-path upstream buffer cap.
+//
+// aimock proxies un-matched requests to a real upstream and (on that path)
+// accumulates the entire streaming response in memory to collapse/journal it.
+// With no size cap, a single very large proxied response builds a string that
+// can exceed V8's max string length (~512MB), throwing
+// `RangeError: Invalid string length`, and spikes the heap.
+//
+// These tests exercise the REAL proxyAndRecord/makeUpstreamRequest path via a
+// real local fake-upstream HTTP server streaming a large SSE body, with a
+// low test-only cap so the run stays fast.
+// ---------------------------------------------------------------------------
+
+let upstream: http.Server | undefined;
+let recorder: ServerInstance | undefined;
+let tmpDir: string | undefined;
+
+afterEach(async () => {
+  if (recorder) {
+    await new Promise<void>((resolve) => recorder!.server.close(() => resolve()));
+    recorder = undefined;
+  }
+  if (upstream) {
+    await new Promise<void>((resolve) => upstream!.close(() => resolve()));
+    upstream = undefined;
+  }
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+  vi.restoreAllMocks();
+});
+
+/**
+ * A raw upstream HTTP server that streams `frameCount` tiny complete SSE frames.
+ * Total bytes stay small (each frame is ~tens of bytes) so the BYTE cap is never
+ * the trigger — only the FRAME-COUNT cap can trip. This isolates the per-frame
+ * state leak (`frameTimestamps` grows once per frame regardless of byte size).
+ */
+function createManyFrameSseUpstream(frameCount: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      let sent = 0;
+      const writeNext = () => {
+        if (res.writableEnded || res.destroyed) return;
+        if (sent >= frameCount) {
+          res.write("data: [DONE]\n\n");
+          res.end();
+          return;
+        }
+        // A small batch per tick keeps the run fast while still flowing as
+        // distinct frames through the recorder's delimiter splitter.
+        let ok = true;
+        for (let k = 0; k < 500 && sent < frameCount && ok; k++) {
+          ok = res.write('data: {"delta":"a"}\n\n');
+          sent++;
+        }
+        if (ok) setImmediate(writeNext);
+        else res.once("drain", writeNext);
+      };
+      writeNext();
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/**
+ * A raw upstream HTTP server that streams an SSE body whose total size is
+ * `totalBytes`, in fixed-size chunks. Each chunk is a valid SSE data frame so
+ * the recorder's frame-splitting logic exercises normally.
+ */
+function createLargeSseUpstream(totalBytes: number, chunkBytes: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      let sent = 0;
+      // Each frame: `data: <payload>\n\n`. Payload is a run of 'x'.
+      const overhead = "data: \n\n".length;
+      const payloadLen = Math.max(1, chunkBytes - overhead);
+      const writeNext = () => {
+        if (sent >= totalBytes) {
+          res.write("data: [DONE]\n\n");
+          res.end();
+          return;
+        }
+        const frame = `data: ${"x".repeat(payloadLen)}\n\n`;
+        sent += Buffer.byteLength(frame);
+        // Use setImmediate to let the client drain — avoids a single huge sync
+        // write and mimics a real progressive stream.
+        if (res.write(frame)) {
+          setImmediate(writeNext);
+        } else {
+          res.once("drain", writeNext);
+        }
+      };
+      writeNext();
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/** Stream a POST and accumulate the relayed body length without buffering huge strings poorly. */
+function postStreaming(
+  url: string,
+  body: unknown,
+): Promise<{ status: number; bytesReceived: number }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        let bytesReceived = 0;
+        res.on("data", (c: Buffer) => {
+          bytesReceived += c.length;
+        });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, bytesReceived }));
+        // A mid-stream relay error must fail fast — without a res-side error
+        // handler the unhandled 'error' would hang the request to timeout.
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+const CHAT_REQUEST = {
+  model: "gpt-4",
+  stream: true,
+  messages: [{ role: "user", content: "stream me a lot" }],
+};
+
+describe("proxy-path upstream buffer cap", () => {
+  it("relays the full streamed body to the client, does not throw, and bounds the in-memory buffer when the response exceeds the cap", async () => {
+    // 4 MB total stream, 64 KB chunks, with a low 256 KB cap so the buffer is
+    // forced to truncate well before the full body is accumulated. The client
+    // must still receive every relayed byte.
+    const TOTAL = 4 * 1024 * 1024;
+    const CHUNK = 64 * 1024;
+    const CAP = 256 * 1024;
+
+    const upstreamUrl = await createLargeSseUpstream(TOTAL, CHUNK);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-bufcap-"));
+
+    // Capture warnings so we can assert the truncation was logged.
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    // Client correctness: full relay regardless of cap.
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThanOrEqual(TOTAL);
+
+    // The server must NOT have crashed with Invalid string length — if it had,
+    // the relay would have been interrupted (already asserted above) and the
+    // truncation warning would be absent. Assert the BYTE cap specifically:
+    // the warning must name the byte cap, not the frame cap (the two are no
+    // longer conflated).
+    const truncationWarn = warnings.find((w) => /byte cap/i.test(w));
+    expect(truncationWarn).toBeDefined();
+    // And the frame cap must NOT be the one reported here.
+    expect(warnings.some((w) => /frame cap/i.test(w))).toBe(false);
+
+    // Recording skipped under proxy-only + truncation: no fixture written.
+    if (fs.existsSync(tmpDir)) {
+      const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith(".json"));
+      expect(files).toHaveLength(0);
+    }
+  });
+
+  it("records normally when the response stays under the cap", async () => {
+    const TOTAL = 64 * 1024;
+    const CHUNK = 8 * 1024;
+    const CAP = 4 * 1024 * 1024;
+
+    const upstreamUrl = await createLargeSseUpstream(TOTAL, CHUNK);
+
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: upstreamUrl },
+        proxyOnly: true,
+        maxProxyBufferBytes: CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThanOrEqual(TOTAL);
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-frame state cap.
+  //
+  // `frameTimestamps` (and the SSE/EventStream parse buffers) accumulate once
+  // PER FRAME for the lifetime of a proxied stream. The byte cap is
+  // count-blind, so a long-lived / never-ending stream of small frames grows
+  // this state UNBOUNDED even when the byte cap is generous. The frame-count
+  // cap bounds it: truncation must trip on frame count even though total bytes
+  // stay far below the byte cap, freeing the accumulated frame state and
+  // skipping recording — while the client still receives every byte.
+  // -------------------------------------------------------------------------
+  it("trips truncation on frame COUNT (not bytes) for a many-frame stream, freeing per-frame state, while still relaying the full body", async () => {
+    // 200k tiny frames (~4 MB total) with a generous 64 MiB byte cap so ONLY
+    // the frame cap can trip, and a low 5k frame cap so it trips early.
+    const FRAMES = 200_000;
+    const BYTE_CAP = 64 * 1024 * 1024;
+    const FRAME_CAP = 5_000;
+
+    const upstreamUrl = await createManyFrameSseUpstream(FRAMES);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-framecap-"));
+
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    recorder = await createServer([], {
+      port: 0,
+      logLevel: "warn",
+      record: {
+        providers: { openai: upstreamUrl },
+        fixturePath: tmpDir,
+        proxyOnly: true,
+        maxProxyBufferBytes: BYTE_CAP,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+
+    // Client correctness: full relay regardless of the frame cap. The total
+    // body is well under the byte cap, so every byte must arrive.
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThan(FRAMES * 10); // ~20 bytes/frame
+
+    // The FRAME cap (not the byte cap) tripped. The previous assertion
+    // (/exceeded.*frames/i) was a tautology — the old conflated warning ALWAYS
+    // contained the word "frames" regardless of which cap fired, so it passed
+    // even if the frame-cap branch were deleted. Assert the specific
+    // cap-tripped indicator instead: the warning must name the FRAME cap, and
+    // the byte cap must NOT be the one reported (total bytes are far under it).
+    const truncationWarn = warnings.find((w) => /frame cap/i.test(w));
+    expect(truncationWarn).toBeDefined();
+    expect(warnings.some((w) => /byte cap/i.test(w))).toBe(false);
+
+    // Recording skipped under proxy-only + truncation: no fixture written
+    // (proves the accumulated frame state was dropped, not journaled).
+    if (fs.existsSync(tmpDir)) {
+      const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith(".json"));
+      expect(files).toHaveLength(0);
+    }
+  });
+
+  it("records normally when the frame count stays under the frame cap", async () => {
+    // A few hundred frames under a generous frame cap records as usual — the
+    // frame cap must NOT break the normal multi-frame streaming/recording path.
+    const FRAMES = 300;
+    const FRAME_CAP = 5_000_000;
+
+    const upstreamUrl = await createManyFrameSseUpstream(FRAMES);
+
+    recorder = await createServer([], {
+      port: 0,
+      record: {
+        providers: { openai: upstreamUrl },
+        proxyOnly: true,
+        maxProxyBufferFrames: FRAME_CAP,
+      },
+    });
+
+    const resp = await postStreaming(recorder.url, CHAT_REQUEST);
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThan(FRAMES * 10);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,8 @@ Options:
       --provider-openrouter <url> Upstream URL for OpenRouter (video record proxy)
       --upstream-timeout-ms <ms>  Idle timeout (ms) on upstream socket before response (default: 30000)
       --body-timeout-ms <ms>      Idle timeout (ms) on upstream response body between chunks (default: 30000)
+      --max-proxy-buffer-bytes <n> Cap (bytes) on in-memory proxy-path buffer; full body still relayed (default: 67108864)
+      --max-proxy-buffer-frames <n> Cap (frames) on in-memory proxy-path per-frame state; full body still relayed (default: 5000000)
       --agui-record              Enable AG-UI recording (proxy unmatched AG-UI requests)
       --agui-upstream <url>      Upstream AG-UI agent URL (used with --agui-record)
       --agui-proxy-only          AG-UI proxy mode: forward without saving
@@ -78,6 +80,8 @@ const { values } = parseArgs({
     "provider-openrouter": { type: "string" },
     "upstream-timeout-ms": { type: "string" },
     "body-timeout-ms": { type: "string" },
+    "max-proxy-buffer-bytes": { type: "string" },
+    "max-proxy-buffer-frames": { type: "string" },
     "agui-record": { type: "boolean", default: false },
     "agui-upstream": { type: "string" },
     "agui-proxy-only": { type: "boolean", default: false },
@@ -175,6 +179,30 @@ if (bodyTimeoutMsStr !== undefined) {
   }
 }
 
+const maxProxyBufferBytesStr = values["max-proxy-buffer-bytes"];
+let maxProxyBufferBytes: number | undefined;
+if (maxProxyBufferBytesStr !== undefined) {
+  maxProxyBufferBytes = Number(maxProxyBufferBytesStr);
+  if (!Number.isFinite(maxProxyBufferBytes) || maxProxyBufferBytes <= 0) {
+    console.error(
+      `Invalid max-proxy-buffer-bytes: ${maxProxyBufferBytesStr} (must be a positive finite number)`,
+    );
+    process.exit(1);
+  }
+}
+
+const maxProxyBufferFramesStr = values["max-proxy-buffer-frames"];
+let maxProxyBufferFrames: number | undefined;
+if (maxProxyBufferFramesStr !== undefined) {
+  maxProxyBufferFrames = Number(maxProxyBufferFramesStr);
+  if (!Number.isFinite(maxProxyBufferFrames) || maxProxyBufferFrames <= 0) {
+    console.error(
+      `Invalid max-proxy-buffer-frames: ${maxProxyBufferFramesStr} (must be a positive finite number)`,
+    );
+    process.exit(1);
+  }
+}
+
 const logger = new Logger(logLevel);
 
 // Parse chaos config from CLI flags
@@ -256,6 +284,8 @@ if (values.record || values["proxy-only"]) {
     recordFullModelVersion: values["record-full-model-version"],
     upstreamTimeoutMs,
     bodyTimeoutMs,
+    maxProxyBufferBytes,
+    maxProxyBufferFrames,
   };
 } else {
   // These flags configure upstream proxying — without --record or
@@ -279,9 +309,14 @@ if (values.record || values["proxy-only"]) {
       `--${droppedProviderFlags.join("/--")} only apply to --record/--proxy-only upstream proxying — ignored without one of those flags.`,
     );
   }
-  if (upstreamTimeoutMs !== undefined || bodyTimeoutMs !== undefined) {
+  if (
+    upstreamTimeoutMs !== undefined ||
+    bodyTimeoutMs !== undefined ||
+    maxProxyBufferBytes !== undefined ||
+    maxProxyBufferFrames !== undefined
+  ) {
     logger.warn(
-      "--upstream-timeout-ms/--body-timeout-ms only apply to --record/--proxy-only upstream proxying — ignored without one of those flags.",
+      "--upstream-timeout-ms/--body-timeout-ms/--max-proxy-buffer-bytes/--max-proxy-buffer-frames only apply to --record/--proxy-only upstream proxying — ignored without one of those flags.",
     );
   }
 }

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -24,6 +24,62 @@ import { getTestId, slugifyTestId } from "./helpers.js";
 import { DEFAULT_TEST_ID } from "./constants.js";
 
 /** Headers to strip when proxying — hop-by-hop (RFC 2616 §13.5.1) + client-set. */
+/**
+ * Default ceiling (bytes) for the in-memory proxy-path buffer. Chosen well
+ * under V8's ~512 MiB max string length so `rawBuffer.toString()` /
+ * stream-collapse never throws `RangeError: Invalid string length`, and so a
+ * single huge proxied response cannot spike the heap unbounded. Overridable
+ * via `RecordConfig.maxProxyBufferBytes` / `--max-proxy-buffer-bytes`.
+ */
+export const DEFAULT_MAX_PROXY_BUFFER_BYTES = 64 * 1024 * 1024; // 64 MiB
+
+/**
+ * Default ceiling for the number of SSE/NDJSON/EventStream frames whose
+ * per-frame state (`frameTimestamps`, parse buffers) aimock retains for a
+ * single proxied response. Frame state is count-indexed, not byte-sized, so a
+ * long-lived / never-ending stream accumulates `frameTimestamps` entries (and,
+ * if a frame never completes, parse-buffer bytes) UNBOUNDED even when the byte
+ * cap is generous — observed as multi-GB heap growth over many hours from a few
+ * long nested-sub-agent streams. Tripping truncation on EITHER bytes OR frame
+ * count bounds both. 5M frames is generous for any real response (a normal
+ * completion is hundreds-to-thousands of frames) while still bounding a runaway
+ * stream to ~tens of MB of frame state. Overridable via
+ * `RecordConfig.maxProxyBufferFrames` / `--max-proxy-buffer-frames`.
+ */
+export const DEFAULT_MAX_PROXY_BUFFER_FRAMES = 5_000_000;
+
+/**
+ * Absolute hard ceiling (bytes) for any in-memory proxy buffer, independent of
+ * the configurable `maxProxyBufferBytes`. V8's maximum STRING length on 64-bit
+ * is 2^29 - 1 (~512 MiB of UTF-16 code units), and the proxy buffer is
+ * eventually stringified via `rawBuffer.toString()` for collapse/relay — so the
+ * BYTE buffer must stay safely under that string limit or the toString throws
+ * `RangeError: Invalid string length`. 256 MiB of bytes is well under the
+ * ~512 MiB string-length boundary (these are different units — bytes vs UTF-16
+ * code units — but 256 MiB of bytes can never decode to more than 256 Mi code
+ * units, comfortably below 2^29 - 1). Used to clamp the configurable cap AND to
+ * bound the non-progressive relay buffer that must be retained past a cap trip.
+ */
+export const PROXY_BUFFER_HARD_CEILING = 256 * 1024 * 1024; // 256 MiB
+
+/**
+ * Test-only override of the effective hard ceiling. Lets the proxy-buffer
+ * enforcement suite exercise the >hard-ceiling fail-loud path with a small
+ * body instead of streaming 256 MiB. `undefined` (the default) uses the real
+ * `PROXY_BUFFER_HARD_CEILING`. NEVER set from production code.
+ */
+let proxyBufferHardCeilingOverride: number | undefined;
+
+/** @internal test-only — see `proxyBufferHardCeilingOverride`. */
+export function setProxyBufferHardCeilingForTests(value: number | undefined): void {
+  proxyBufferHardCeilingOverride = value;
+}
+
+/** Effective hard ceiling, honoring any active test-only override. */
+function effectiveHardCeiling(): number {
+  return proxyBufferHardCeilingOverride ?? PROXY_BUFFER_HARD_CEILING;
+}
+
 const STRIP_HEADERS = new Set([
   // Hop-by-hop (RFC 2616 §13.5.1)
   "connection",
@@ -343,6 +399,10 @@ export async function proxyAndRecord(
   let upstreamHeaders: http.IncomingHttpHeaders;
   let upstreamBody: string;
   let rawBuffer: Buffer;
+  let bufferTruncated = false;
+  let truncationCap: "byte" | "frame" | undefined;
+  let totalBytes = 0;
+  let hardCeilingExceeded = false;
 
   // Track whether we streamed SSE progressively to the client; if so,
   // skip the final res.writeHead/res.end relay at the bottom of this fn.
@@ -350,6 +410,8 @@ export async function proxyAndRecord(
   let clientDisconnected = false;
   let frameTimestamps: number[] = [];
   let streamStartTime = 0;
+  const maxProxyBufferBytes = clampMaxBufferBytes(record.maxProxyBufferBytes);
+  const maxProxyBufferFrames = clampMaxBufferFrames(record.maxProxyBufferFrames);
   try {
     const result = await makeUpstreamRequest(
       target,
@@ -359,6 +421,8 @@ export async function proxyAndRecord(
       req.method,
       defaults.logger,
       { upstreamTimeoutMs: record.upstreamTimeoutMs, bodyTimeoutMs: record.bodyTimeoutMs },
+      maxProxyBufferBytes,
+      maxProxyBufferFrames,
     );
     upstreamStatus = result.status;
     upstreamHeaders = result.headers;
@@ -368,6 +432,10 @@ export async function proxyAndRecord(
     clientDisconnected = result.clientDisconnected;
     frameTimestamps = result.frameTimestamps;
     streamStartTime = result.streamStartTime;
+    bufferTruncated = result.bufferTruncated;
+    truncationCap = result.truncationCap;
+    totalBytes = result.totalBytes;
+    hardCeilingExceeded = result.hardCeilingExceeded;
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Unknown proxy error";
     defaults.logger.error(`Proxy request failed: ${msg}`);
@@ -385,11 +453,66 @@ export async function proxyAndRecord(
     return "relayed";
   }
 
+  // Buffer cap tripped: skip collapse + recording (the in-memory buffer can't
+  // be safely/faithfully journaled), but ALWAYS deliver a faithful response to
+  // the client. The cap means "don't journal", not "don't answer".
+  //  - PROGRESSIVE stream: the bytes were already teed to the client live, so
+  //    nothing more to write — just end if still open.
+  //  - NON-progressive response, UNDER the hard ceiling: makeUpstreamRequest
+  //    kept the FULL body (bounded by PROXY_BUFFER_HARD_CEILING) precisely so we
+  //    can relay it here. Relay the real body so a large single-shot JSON
+  //    (embeddings / fal / image-b64) reaches the client intact — but NORMALIZE
+  //    the status (success→200 / error→502) exactly like every other relay path
+  //    so upstream provider details don't leak through this branch alone.
+  //  - NON-progressive response, OVER the hard ceiling: the retained buffer is
+  //    PARTIAL (we stopped buffering at the ceiling and there is no live tee),
+  //    so relaying it would present a truncated body as success. FAIL LOUD with
+  //    a 502 instead — never deliver a silently-truncated body as 2xx.
+  if (bufferTruncated) {
+    const capDetail =
+      truncationCap === "frame"
+        ? `the ${maxProxyBufferFrames}-frame cap`
+        : `the ${maxProxyBufferBytes}-byte cap`;
+    if (!streamedToClient && hardCeilingExceeded && !res.headersSent) {
+      const ceilingMiB = Math.round(PROXY_BUFFER_HARD_CEILING / (1024 * 1024));
+      defaults.logger.error(
+        `Upstream response exceeded the ${ceilingMiB} MiB proxy hard ceiling (saw ${totalBytes} bytes) on a non-progressive body — cannot relay the full body and refusing to relay a truncated one; returning 502`,
+      );
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: {
+            message: `Upstream response exceeds ${ceilingMiB}MiB proxy ceiling`,
+            type: "proxy_error",
+          },
+        }),
+      );
+      return "relayed";
+    }
+    defaults.logger.warn(
+      `Upstream response exceeded ${capDetail} (saw ${totalBytes} bytes) — relayed to client, recording skipped`,
+    );
+    if (!streamedToClient && !res.headersSent) {
+      // Normalize the relayed status like the under-cap relay paths
+      // (success→200, error→502) so this branch does not leak a raw upstream
+      // 429/503/etc. The full real body (under the hard ceiling) is relayed.
+      const clientStatus = upstreamStatus >= 200 && upstreamStatus < 300 ? 200 : 502;
+      const relayHeaders: Record<string, string> = {};
+      const ct = upstreamHeaders["content-type"];
+      const ctStr = Array.isArray(ct) ? ct.join(", ") : (ct ?? "");
+      relayHeaders["Content-Type"] = ctStr || "application/json";
+      res.writeHead(clientStatus, relayHeaders);
+      res.end(rawBuffer);
+    } else if (!res.writableEnded) {
+      res.end();
+    }
+    return "relayed";
+  }
+
   // Detect streaming response and collapse if necessary.
-  // NOTE: collapse buffers the entire upstream body in memory. Fine for
-  // current chat-completions traffic (responses are small), but revisit if
-  // this path ever proxies long-lived or large streams — both the buffer
-  // here and the hook below receive the full payload.
+  // NOTE: collapse buffers the upstream body in memory up to maxProxyBufferBytes
+  // (see makeUpstreamRequest). Over-cap responses short-circuit above, so the
+  // buffer reaching here is bounded and safe to stringify/collapse.
   const contentType = upstreamHeaders["content-type"];
   const ctString = Array.isArray(contentType) ? contentType.join(", ") : (contentType ?? "");
   const isBinaryStream = ctString.toLowerCase().includes("application/vnd.amazon.eventstream");
@@ -752,6 +875,37 @@ export function clampTimeout(value: number | undefined, fallback: number): numbe
   return value;
 }
 
+/**
+ * Sanitize the configured proxy-buffer cap: non-finite or non-positive values
+ * fall back to the default. Also hard-clamps to just under V8's max string
+ * length so a misconfigured large value can never permit an over-string-limit
+ * buffer to reach `.toString()`.
+ */
+export function clampMaxBufferBytes(value: number | undefined): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MAX_PROXY_BUFFER_BYTES;
+  }
+  return Math.min(value, PROXY_BUFFER_HARD_CEILING);
+}
+
+/**
+ * Sanitize the configured proxy-buffer frame cap: non-finite or non-positive
+ * values fall back to the default. Bounds the count-indexed per-frame state
+ * (`frameTimestamps` + parse buffers) that the byte cap cannot bound on its own.
+ */
+export function clampMaxBufferFrames(value: number | undefined): number {
+  // INTENTIONAL DIVERGENCE from journal-max's `0 = unbounded` convention: here
+  // 0 (and any non-positive / non-finite value) maps to the DEFAULT cap, never
+  // "unbounded". The frame cap exists as leak-safety for never-ending proxy
+  // streams; allowing 0 to disable it would reintroduce the exact unbounded
+  // per-frame-state growth this cap guards against. Do NOT make 0 mean
+  // unbounded.
+  if (value == null || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MAX_PROXY_BUFFER_FRAMES;
+  }
+  return Math.floor(value);
+}
+
 function makeUpstreamRequest(
   target: URL,
   headers: Record<string, string>,
@@ -760,6 +914,8 @@ function makeUpstreamRequest(
   method: string = "POST",
   logger?: Logger,
   timeouts?: Pick<RecordConfig, "upstreamTimeoutMs" | "bodyTimeoutMs">,
+  maxBufferBytes: number = DEFAULT_MAX_PROXY_BUFFER_BYTES,
+  maxBufferFrames: number = DEFAULT_MAX_PROXY_BUFFER_FRAMES,
 ): Promise<{
   status: number;
   headers: http.IncomingHttpHeaders;
@@ -769,6 +925,27 @@ function makeUpstreamRequest(
   clientDisconnected: boolean;
   frameTimestamps: number[];
   streamStartTime: number;
+  /**
+   * True when the upstream response exceeded `maxBufferBytes`. The client still
+   * received every byte (the relay is independent of this buffer), but the
+   * in-memory buffer was capped, so `body`/`rawBuffer` are partial and the
+   * caller MUST skip collapse/recording.
+   */
+  bufferTruncated: boolean;
+  /**
+   * Which cap tripped truncation (`"byte"` or `"frame"`), or `undefined` when
+   * not truncated. Lets the caller log accurately which budget was exceeded
+   * rather than conflating the two.
+   */
+  truncationCap?: "byte" | "frame";
+  /** Total bytes seen from upstream (may exceed the buffered amount when capped). */
+  totalBytes: number;
+  /**
+   * True when a NON-progressive (non-teed) upstream body exceeded the proxy
+   * hard ceiling, so the retained `rawBuffer` is PARTIAL. The caller MUST fail
+   * loud (502) rather than relay this truncated body as a success status.
+   */
+  hardCeilingExceeded: boolean;
 }> {
   return new Promise((resolve, reject) => {
     const transport = target.protocol === "https:" ? https : http;
@@ -838,17 +1015,130 @@ function makeUpstreamRequest(
             if (!clientRes.writableFinished) {
               clientDisconnected = true;
               req.destroy();
+              // Stop in-flight buffering immediately rather than draining the
+              // upstream socket under backpressure: detach the data listener so
+              // no further chunks accumulate, and free what's already buffered.
+              // The promise still settles via the 'end'/'error'/'close' the
+              // destroyed request emits; collapse/recording is skipped because
+              // the client disconnected.
+              res.removeListener("data", onUpstreamData);
+              chunks.length = 0;
+              bufferedBytes = 0;
+              frameTimestamps.length = 0;
+              frameBuffer = "";
+              binaryFrameBuffer = Buffer.alloc(0);
             }
           });
         }
         const chunks: Buffer[] = [];
-        res.on("data", (chunk: Buffer) => {
-          chunks.push(chunk);
+        // Bound the in-memory buffer used to collapse/journal the response so a
+        // single huge proxied stream can neither spike the heap nor build a
+        // string past V8's ~512 MiB limit (RangeError: Invalid string length).
+        // The client relay below is independent of this buffer, so capping it
+        // does NOT truncate what the client receives.
+        let bufferedBytes = 0;
+        let totalBytes = 0;
+        let bufferTruncated = false;
+        /** Which cap tripped truncation — surfaced to the caller for an accurate warning. */
+        let truncationCap: "byte" | "frame" | undefined;
+        // Snapshot the effective hard ceiling once for this request (honors the
+        // test-only override). Bounds the non-progressive relay buffer; when the
+        // body would exceed it we can neither buffer the full copy nor safely
+        // relay the partial one, so the caller fails loud instead of truncating.
+        const hardCeiling = effectiveHardCeiling();
+        /**
+         * True when a NON-progressive upstream body exceeded `hardCeiling`, so
+         * the buffered `rawBuffer` is a PARTIAL copy that must NOT be relayed as
+         * success. Distinct from `bufferTruncated` (which also covers the
+         * under-ceiling over-soft-cap case where the full body IS retained).
+         */
+        let hardCeilingExceeded = false;
+        // Trip truncation: mark the response over-cap so the caller skips
+        // collapse/recording, and eagerly drop the accumulated PARSE state
+        // (frameTimestamps + frame/binary parse buffers) which only ever feeds
+        // recording. Reused by the top-of-callback byte guard AND the per-frame
+        // guards inside the SSE/NDJSON and binary splitter loops, so a single
+        // coalesced chunk carrying many complete frames cannot overshoot the
+        // frame cap before the next data event re-checks.
+        //
+        // The raw `chunks` array is handled differently by stream shape:
+        //  - progressive streams (SSE/NDJSON/binary) are teed to the client
+        //    live, so the bytes are already on the wire — `chunks` is freed
+        //    immediately and the partial buffer is never relayed.
+        //  - non-progressive responses (a single non-stream body) are NOT teed;
+        //    the only copy the client can receive is `chunks`, so we KEEP
+        //    accumulating it (bounded by HARD_CEILING below) and relay it in
+        //    full. We still skip recording — the cap means "don't journal", not
+        //    "don't answer the client".
+        const tripTruncation = (cap: "byte" | "frame") => {
+          bufferTruncated = true;
+          truncationCap = cap;
+          frameTimestamps.length = 0;
+          frameBuffer = "";
+          // Intentional: the returned flush string is discarded (frameBuffer was
+          // just cleared and recording is skipped), but `.end()` releases any
+          // partial-multibyte bytes the StringDecoder is internally holding — so
+          // this frees decoder state rather than being dead cleanup.
+          frameDecoder.end();
+          binaryFrameBuffer = Buffer.alloc(0);
+          if (isProgressiveStream) {
+            chunks.length = 0;
+            bufferedBytes = 0;
+          }
+          // State which cap tripped accurately (do not conflate the two caps),
+          // and report the relay truthfully — the client received every byte on
+          // the streamed path and, post-fix, on the non-streamed path too.
+          const detail =
+            cap === "byte"
+              ? `byte cap (${maxBufferBytes} bytes)`
+              : `frame cap (${maxBufferFrames} frames)`;
+          logger?.warn(
+            `Upstream response exceeded the proxy buffer ${detail} — relaying full body to client, but skipping in-memory collapse/recording to bound memory`,
+          );
+        };
+        const onUpstreamData = (chunk: Buffer) => {
+          totalBytes += chunk.length;
+          // Trip truncation on EITHER bytes OR frame count. The byte cap alone
+          // never bounds `frameTimestamps` (count-indexed, not byte-sized) nor a
+          // never-completing parse buffer, so a long-lived / never-ending stream
+          // would otherwise grow per-frame state forever. `frameTimestamps.length`
+          // is the running complete-frame count. `>=` (not `>`) so we never
+          // retain MORE than `maxBufferFrames` frames — see the "maximum N
+          // frames retained" contract on DEFAULT_MAX_PROXY_BUFFER_FRAMES.
+          if (!bufferTruncated && bufferedBytes + chunk.length > maxBufferBytes) {
+            tripTruncation("byte");
+          } else if (!bufferTruncated && frameTimestamps.length >= maxBufferFrames) {
+            tripTruncation("frame");
+          }
+          // Buffer the raw bytes. Under cap: always. Over cap on a progressive
+          // stream: never (bytes are already teed live; chunks was freed). Over
+          // cap on a NON-progressive response: keep buffering for the relay —
+          // it has no live tee, so `chunks` is the only copy the client can get
+          // — but hard-cap it at HARD_CEILING (well under V8's max string
+          // length) so the eventual rawBuffer.toString() relay can never throw
+          // RangeError: Invalid string length.
+          if (!bufferTruncated) {
+            chunks.push(chunk);
+            bufferedBytes += chunk.length;
+          } else if (!isProgressiveStream) {
+            if (bufferedBytes + chunk.length <= hardCeiling) {
+              chunks.push(chunk);
+              bufferedBytes += chunk.length;
+            } else {
+              // The non-progressive relay copy would exceed the hard ceiling.
+              // We CANNOT relay the full body (it can't be buffered safely) and
+              // MUST NOT relay the partial buffer as a success — flag it so the
+              // caller fails loud (502) instead of presenting a truncated 2xx.
+              hardCeilingExceeded = true;
+            }
+          }
 
-          // Capture per-frame timestamps for SSE/NDJSON streams.
+          // Capture per-frame timestamps for SSE/NDJSON streams. Gated on
+          // !bufferTruncated so per-frame parse/timing state stops growing once
+          // the cap trips (the byte/frame guard above already freed it).
           // TCP data events don't align with SSE frames — buffer and
           // split on the protocol delimiter to timestamp each complete frame.
-          if (isSSE || isNDJSON) {
+          if (!bufferTruncated && (isSSE || isNDJSON)) {
             frameBuffer += frameDecoder.write(chunk);
             // Split on the protocol delimiter, tolerating CRLF line endings.
             // The SSE spec permits CRLF, and some upstreams/proxies emit
@@ -859,26 +1149,60 @@ function makeUpstreamRequest(
             const delimiter = isNDJSON ? /\r?\n/ : /\r?\n\r?\n/;
             const parts = frameBuffer.split(delimiter);
             // All complete frames (everything except the last part which
-            // may be incomplete).
+            // may be incomplete). Enforce the frame cap PER-FRAME: a single
+            // coalesced chunk can carry many complete frames, so checking only
+            // at the top of the callback would let one event push them all and
+            // overshoot the cap unbounded. Trip + bail mid-loop instead.
             for (let fi = 0; fi < parts.length - 1; fi++) {
+              if (frameTimestamps.length >= maxBufferFrames) {
+                tripTruncation("frame");
+                break;
+              }
               if (parts[fi].trim().length > 0) {
                 frameTimestamps.push(Date.now());
               }
             }
-            // Last part stays in buffer (may be incomplete)
-            frameBuffer = parts[parts.length - 1];
+            // Last part stays in buffer (may be incomplete). Skip when the
+            // per-frame guard just tripped — tripTruncation already cleared it.
+            if (!bufferTruncated) {
+              frameBuffer = parts[parts.length - 1];
+            }
           }
 
           // Binary EventStream frame boundary detection — parse the 4-byte
           // total-length prefix to detect complete frames without decoding
           // frame contents (CRC validation happens in stream-collapse).
-          if (isBinaryEventStream) {
-            binaryFrameBuffer = Buffer.concat([binaryFrameBuffer, chunk]);
-            while (binaryFrameBuffer.length >= 4) {
-              const totalLen = binaryFrameBuffer.readUInt32BE(0);
-              if (totalLen < 12 || binaryFrameBuffer.length < totalLen) break;
-              frameTimestamps.push(Date.now());
-              binaryFrameBuffer = binaryFrameBuffer.subarray(totalLen);
+          // Also gated on !bufferTruncated so binaryFrameBuffer stops growing
+          // once the cap trips.
+          if (!bufferTruncated && isBinaryEventStream) {
+            // Count the binary parse buffer's growth toward the byte cap.
+            // binaryFrameBuffer is a SECOND, parallel copy of the bytes (the
+            // raw `chunks` array also holds them), so without this a
+            // never-completing / malformed (`totalLen<12`) frame — which pushes
+            // no frameTimestamps — would let a full second copy accumulate up
+            // to the byte cap, peaking at ~2× the configured cap. Trip on the
+            // COMBINED footprint so the byte cap bounds both copies together.
+            // NOTE: `bufferedBytes` ALREADY includes the current `chunk.length`
+            // (added in the raw-buffer accumulation above), so the combined
+            // footprint is `bufferedBytes + binaryFrameBuffer.length`. Adding
+            // `chunk.length` again would double-count it and trip the cap one
+            // chunk early (matching the L<byte-guard> accounting at the top).
+            if (bufferedBytes + binaryFrameBuffer.length > maxBufferBytes) {
+              tripTruncation("byte");
+            } else {
+              binaryFrameBuffer = Buffer.concat([binaryFrameBuffer, chunk]);
+              while (binaryFrameBuffer.length >= 4) {
+                if (frameTimestamps.length >= maxBufferFrames) {
+                  // Per-frame cap: a single chunk can complete many binary
+                  // frames; trip mid-loop rather than overshoot.
+                  tripTruncation("frame");
+                  break;
+                }
+                const totalLen = binaryFrameBuffer.readUInt32BE(0);
+                if (totalLen < 12 || binaryFrameBuffer.length < totalLen) break;
+                frameTimestamps.push(Date.now());
+                binaryFrameBuffer = binaryFrameBuffer.subarray(totalLen);
+              }
             }
           }
 
@@ -898,15 +1222,18 @@ function makeUpstreamRequest(
               clientDisconnected = true;
             }
           }
-        });
+        };
+        res.on("data", onUpstreamData);
         res.on("error", reject);
         res.on("end", () => {
           if (res.socket) res.setTimeout(0);
           // Flush remaining text frame buffer — captures the last frame if
           // the stream ended without a trailing delimiter. Binary EventStream
           // frames are length-prefixed so partial frames at end-of-stream are
-          // genuinely incomplete and should not be timestamped.
-          if (isSSE || isNDJSON) {
+          // genuinely incomplete and should not be timestamped. Skipped when
+          // truncated: the decoder/parse buffer were already drained+cleared on
+          // the trip, and recording is skipped, so there is nothing to flush.
+          if (!bufferTruncated && (isSSE || isNDJSON)) {
             // Drain any bytes the decoder buffered for an incomplete multibyte
             // sequence so the final frame text is complete before we test it.
             frameBuffer += frameDecoder.end();
@@ -930,15 +1257,29 @@ function makeUpstreamRequest(
               );
             }
           }
+          // Decide the string `body`:
+          //  - not truncated: stringify the full buffer as usual.
+          //  - truncated PROGRESSIVE stream: `chunks` was freed on the trip, so
+          //    rawBuffer is empty; skip toString to keep the path allocation-free
+          //    (the client already got every byte via the live tee).
+          //  - truncated NON-progressive response: we deliberately kept the full
+          //    bytes (bounded by HARD_CEILING) so they can be relayed — stringify
+          //    them so proxyAndRecord can `res.end(body)` the real response.
+          const bodyString =
+            !bufferTruncated || (bufferTruncated && !streamedToClient) ? rawBuffer.toString() : "";
           resolve({
             status: res.statusCode ?? 500,
             headers: res.headers,
-            body: rawBuffer.toString(),
+            body: bodyString,
             rawBuffer,
             streamedToClient,
             clientDisconnected,
             frameTimestamps,
             streamStartTime,
+            bufferTruncated,
+            truncationCap,
+            totalBytes,
+            hardCeilingExceeded,
           });
         });
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -669,6 +669,28 @@ export interface RecordConfig {
    * downloading multi-minute video never times out — only a silent stall does.
    */
   bodyTimeoutMs?: number;
+  /**
+   * Maximum number of bytes aimock will accumulate in memory from a single
+   * proxied upstream response on the record/proxy path. The full response is
+   * still relayed to the client byte-for-byte; this cap only bounds the
+   * in-memory buffer used to collapse/journal the response. Once the cap is
+   * exceeded aimock stops appending to the buffer, marks the response as
+   * truncated, and skips collapse/recording — preventing both unbounded heap
+   * growth and the `RangeError: Invalid string length` that a >512MB string
+   * would otherwise throw. Default: 64 MiB.
+   */
+  maxProxyBufferBytes?: number;
+  /**
+   * Maximum number of SSE/NDJSON/EventStream frames whose per-frame state
+   * (`frameTimestamps`, parse buffers) aimock retains for a single proxied
+   * response. Frame state is count-indexed, not byte-sized, so a long-lived or
+   * never-ending stream accumulates it unbounded even when `maxProxyBufferBytes`
+   * is generous. Tripping truncation on EITHER bytes OR frame count bounds both;
+   * on the trip the accumulated frame state is freed and collapse/recording is
+   * skipped (the full response is still relayed to the client byte-for-byte).
+   * Default: 5,000,000 frames.
+   */
+  maxProxyBufferFrames?: number;
 }
 
 export interface OpenRouterVideoRecordConfig {


### PR DESCRIPTION
## Root cause

aimock's proxy/record path (`makeUpstreamRequest` → `proxyAndRecord` in `src/recorder.ts`) buffered an entire upstream streaming response in memory with **no size cap**, and accumulated per-frame state — `frameTimestamps[]` (one push per SSE/NDJSON frame), the frame parse buffers, and `chunks[]` — for a stream's **entire lifetime**. On a long-lived stream this is unbounded:

- **Heap leak → OOM.** Long-lived nested-sub-agent proxied SSE streams (the non-strict fall-through path to a real upstream) accumulated per-frame state indefinitely, driving a slow heap climb to ~8.4 GB over ~25 h and a fatal OOM + restart (a synchronized flap of every cell while ~7.7k fixtures reload).
- **`RangeError: Invalid string length`.** A single proxied response whose collapsed body exceeds V8's max string length (~512 MiB) threw on `.toString()`.

Both are on the proxy/fall-through path only; fixture-matched (strict harness) requests serve bounded pre-recorded responses and are unaffected.

## Fix

- Enforce **byte AND frame-count caps** on the proxy buffer, checked **per-frame inside** the SSE/NDJSON splitter and the binary EventStream loops (not just at chunk boundaries, so a single coalesced chunk can't overshoot), and on the binary parse buffer (counted toward the byte cap).
- **Clear** all accumulators (`chunks`, `frameTimestamps`, frame buffers) when a cap trips — free, don't freeze.
- **Client-disconnect cleanup**: remove the upstream data listener + clear accumulators on client `close`.
- **Relay is always preserved**: a non-streamed over-cap body is relayed in full with a **normalized status** (success→200, error→502) up to a 256 MiB hard ceiling; **above** the ceiling the proxy **fails loud with a 502** rather than relaying a silently-truncated body as success.
- New config/flags: `RecordConfig.maxProxyBufferBytes` / `maxProxyBufferFrames`, `--max-proxy-buffer-bytes` / `--max-proxy-buffer-frames`.

## Red–green

- Never-ending stream: heap **8.4→14.7 MB monotonic climb (RED) → flat 9.0→9.1 MB after the cap trips (GREEN)**, client still relayed in full.
- Coalesced single chunk with many frames: `frameTimestamps` **3846 → 102** (cap enforced per-frame).
- Binary EventStream: bounded by the byte cap; cap trips **at** the configured size, not a chunk early.
- Non-streamed over-256 MiB: **200/truncated (RED) → 502 fail-loud (GREEN)**; upstream 503 **→ normalized 502**, full under-ceiling body relayed.
- Full suite **3976 tests green**; typecheck/lint/build clean.

## Known minor follow-ups (non-blocking, observability-only)

- The over-ceiling 502 message uses the literal `PROXY_BUFFER_HARD_CEILING` instead of the effective ceiling — only mis-reports the number under a test-only override; production is always correct.
- Add an integer guard for a fractional `--max-proxy-buffer-frames` value; align the CLI's reject-0 with the clamp's 0=default convention.

## Release

Merging this PR publishes `@copilotkit/aimock` v1.33.0 via autopublish (`publish-release.yml` fires on push to `main` and publishes whenever `package.json`'s version is not yet on npm). The version bump + CHANGELOG entry are folded into this PR (commit `chore: release v1.33.0`), so the merge both lands the fix and cuts the release regardless of merge/squash strategy — no separate release PR or specific commit subject is required.
