### PR TITLE
fix: migrate Gemini Interactions emitter to SDK 2.x event protocol (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Gemini Interactions mock now emits the SDK 2.x event protocol on both paths — streamed SSE (`step.*`, `interaction.created`/`completed`, tool args via `arguments_delta`) and non-streaming responses (`steps`/`output_text`); legacy 1.x recorded fixtures still parse (#279)
+
 ## [1.33.0] - 2026-06-23
 
 ### Added

--- a/src/__tests__/drift/sdk-shapes.ts
+++ b/src/__tests__/drift/sdk-shapes.ts
@@ -1613,43 +1613,43 @@ export function geminiInteractionsToolCallResponseShape(): ShapeNode {
 export function geminiInteractionsStreamEventShapes(): SSEEventShape[] {
   return [
     {
-      type: "interaction.start",
+      type: "interaction.created",
       dataShape: extractShape({
-        event_type: "interaction.start",
+        event_type: "interaction.created",
         interaction: { id: "int_abc123", status: "in_progress" },
         event_id: "evt_1",
       }),
     },
     {
-      type: "content.start",
+      type: "step.start",
       dataShape: extractShape({
-        event_type: "content.start",
+        event_type: "step.start",
         index: 0,
-        content: { type: "text" },
+        step: { type: "model_output" },
         event_id: "evt_2",
       }),
     },
     {
-      type: "content.delta",
+      type: "step.delta",
       dataShape: extractShape({
-        event_type: "content.delta",
+        event_type: "step.delta",
         index: 0,
         delta: { type: "text", text: "Hello" },
         event_id: "evt_3",
       }),
     },
     {
-      type: "content.stop",
+      type: "step.stop",
       dataShape: extractShape({
-        event_type: "content.stop",
+        event_type: "step.stop",
         index: 0,
         event_id: "evt_4",
       }),
     },
     {
-      type: "interaction.complete",
+      type: "interaction.completed",
       dataShape: extractShape({
-        event_type: "interaction.complete",
+        event_type: "interaction.completed",
         interaction: {
           id: "int_abc123",
           status: "completed",
@@ -1664,48 +1664,51 @@ export function geminiInteractionsStreamEventShapes(): SSEEventShape[] {
 export function geminiInteractionsToolCallStreamEventShapes(): SSEEventShape[] {
   return [
     {
-      type: "interaction.start",
+      type: "interaction.created",
       dataShape: extractShape({
-        event_type: "interaction.start",
+        event_type: "interaction.created",
         interaction: { id: "int_abc123", status: "in_progress" },
         event_id: "evt_1",
       }),
     },
     {
-      type: "content.start",
+      type: "step.start",
       dataShape: extractShape({
-        event_type: "content.start",
+        event_type: "step.start",
         index: 0,
-        content: { type: "function_call" },
+        step: {
+          type: "function_call",
+          id: "call_abc123",
+          name: "get_weather",
+          arguments: {},
+        },
         event_id: "evt_2",
       }),
     },
     {
-      type: "content.delta",
+      type: "step.delta",
       dataShape: extractShape({
-        event_type: "content.delta",
+        event_type: "step.delta",
         index: 0,
         delta: {
-          type: "function_call",
-          id: "call_abc123",
-          name: "get_weather",
-          arguments: { city: "Paris" },
+          type: "arguments_delta",
+          arguments: '{"city":"Paris"}',
         },
         event_id: "evt_3",
       }),
     },
     {
-      type: "content.stop",
+      type: "step.stop",
       dataShape: extractShape({
-        event_type: "content.stop",
+        event_type: "step.stop",
         index: 0,
         event_id: "evt_4",
       }),
     },
     {
-      type: "interaction.complete",
+      type: "interaction.completed",
       dataShape: extractShape({
-        event_type: "interaction.complete",
+        event_type: "interaction.completed",
         interaction: {
           id: "int_abc123",
           status: "requires_action",

--- a/src/__tests__/drift/sdk-shapes.ts
+++ b/src/__tests__/drift/sdk-shapes.ts
@@ -1587,7 +1587,8 @@ export function geminiInteractionsResponseShape(): ShapeNode {
     status: "completed",
     model: "gemini-2.5-flash",
     role: "model",
-    outputs: [{ type: "text", text: "Hello!" }],
+    output_text: "Hello!",
+    steps: [{ type: "model_output", content: [{ type: "text", text: "Hello!" }] }],
     usage: { total_input_tokens: 0, total_output_tokens: 0, total_tokens: 0 },
   });
 }
@@ -1598,7 +1599,7 @@ export function geminiInteractionsToolCallResponseShape(): ShapeNode {
     status: "requires_action",
     model: "gemini-2.5-flash",
     role: "model",
-    outputs: [
+    steps: [
       {
         type: "function_call",
         id: "call_abc123",

--- a/src/__tests__/gemini-interactions.test.ts
+++ b/src/__tests__/gemini-interactions.test.ts
@@ -870,6 +870,28 @@ describe("SSE event builders", () => {
     expect(JSON.parse(delta.arguments as string)).toEqual({ city: "NYC" });
   });
 
+  it("assigns sequential step indices for multiple tool calls (SDK 2.x)", () => {
+    const events = buildInteractionsToolCallSSEEvents(
+      [
+        { name: "get_weather", arguments: '{"city":"NYC"}', id: "call_1" },
+        { name: "get_time", arguments: '{"tz":"UTC"}', id: "call_2" },
+      ],
+      "aimock-int-0",
+      logger,
+    );
+    const stepStarts = events.filter((e) => e.event_type === "step.start");
+    expect(stepStarts.map((e) => e.index)).toEqual([0, 1]);
+    expect((stepStarts[0].step as Record<string, unknown>).name).toBe("get_weather");
+    expect((stepStarts[1].step as Record<string, unknown>).name).toBe("get_time");
+    // Each call's arguments_delta is keyed to its own index.
+    const argDeltas = events.filter(
+      (e) =>
+        e.event_type === "step.delta" &&
+        (e.delta as Record<string, unknown>).type === "arguments_delta",
+    );
+    expect(argDeltas.map((e) => e.index)).toEqual([0, 1]);
+  });
+
   it("builds content+tools SSE with correct indices (SDK 2.x)", () => {
     const events = buildInteractionsContentWithToolCallsSSEEvents(
       "Text",
@@ -1347,6 +1369,58 @@ describe("collapseGeminiInteractionsSSE", () => {
     // Fragments concatenate into valid JSON by step.stop.
     expect(result.toolCalls![0].arguments).toBe('{"city":"NYC"}');
     expect(result.toolCalls![0].id).toBe("call_1");
+  });
+
+  it("collapses multiple interleaved tool calls in step-index order (SDK 2.x)", () => {
+    const sse = [
+      'data: {"event_type":"step.start","index":1,"step":{"type":"function_call","id":"call_a","name":"get_weather","arguments":{}},"event_id":"evt_1"}',
+      'data: {"event_type":"step.start","index":2,"step":{"type":"function_call","id":"call_b","name":"get_time","arguments":{}},"event_id":"evt_2"}',
+      // Interleaved argument fragments for both calls.
+      'data: {"event_type":"step.delta","index":2,"delta":{"type":"arguments_delta","arguments":"{\\"tz\\":"},"event_id":"evt_3"}',
+      'data: {"event_type":"step.delta","index":1,"delta":{"type":"arguments_delta","arguments":"{\\"city\\":\\"NYC\\"}"},"event_id":"evt_4"}',
+      'data: {"event_type":"step.delta","index":2,"delta":{"type":"arguments_delta","arguments":"\\"UTC\\"}"},"event_id":"evt_5"}',
+      'data: {"event_type":"step.stop","index":1,"event_id":"evt_6"}',
+      'data: {"event_type":"step.stop","index":2,"event_id":"evt_7"}',
+    ].join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    expect(result.toolCalls).toHaveLength(2);
+    // Sorted by step index regardless of step.stop / delta arrival order.
+    expect(result.toolCalls![0]).toEqual({
+      name: "get_weather",
+      arguments: '{"city":"NYC"}',
+      id: "call_a",
+    });
+    expect(result.toolCalls![1]).toEqual({
+      name: "get_time",
+      arguments: '{"tz":"UTC"}',
+      id: "call_b",
+    });
+  });
+
+  it("flags assembled arguments_delta that is not valid JSON by step.stop", () => {
+    const sse = [
+      'data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_1","name":"fn","arguments":{}},"event_id":"evt_1"}',
+      // Truncated/interrupted stream — fragment never closes into valid JSON.
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"arguments_delta","arguments":"{\\"city\\":\\"NY"},"event_id":"evt_2"}',
+      'data: {"event_type":"step.stop","index":0,"event_id":"evt_3"}',
+    ].join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    // The (corrupt) call is still surfaced, but flagged so the recorder warns.
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].arguments).toBe('{"city":"NY');
+    expect(result.droppedChunks).toBe(1);
+    expect(result.firstDroppedSample).toMatch(/not valid JSON/);
+  });
+
+  it("preserves identity of a function_call step.start that arrives without an index", () => {
+    const sse = [
+      'data: {"event_type":"step.start","step":{"type":"function_call","id":"call_1","name":"fn","arguments":{"x":1}},"event_id":"evt_1"}',
+      'data: {"event_type":"step.stop","event_id":"evt_2"}',
+    ].join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].name).toBe("fn");
+    expect(result.toolCalls![0].arguments).toBe('{"x":1}');
   });
 
   it("uses step.start arguments object when no arguments_delta streams (SDK 2.x)", () => {

--- a/src/__tests__/gemini-interactions.test.ts
+++ b/src/__tests__/gemini-interactions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import * as http from "node:http";
 import type { Fixture } from "../types.js";
 import { createServer, type ServerInstance } from "../server.js";
@@ -937,6 +937,63 @@ describe("SSE event builders", () => {
     expect((deltas[1].delta as Record<string, unknown>).text).toBe("DEF");
     expect((deltas[2].delta as Record<string, unknown>).text).toBe("GH");
   });
+
+  it("falls back to empty args and warns on malformed tool-call arguments (streaming)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const events = buildInteractionsToolCallSSEEvents(
+        [{ name: "fn", arguments: "not-json", id: "call_1" }],
+        "aimock-int-0",
+        new Logger("warn"),
+      );
+      const argDelta = events.find(
+        (e) =>
+          e.event_type === "step.delta" &&
+          (e.delta as Record<string, unknown>).type === "arguments_delta",
+      )!;
+      // Malformed args degrade to a valid empty-object fragment, not garbage.
+      expect((argDelta.delta as Record<string, unknown>).arguments).toBe("{}");
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("emits usage and requires_action status on interaction.completed for tool calls", () => {
+    const events = buildInteractionsToolCallSSEEvents(
+      [{ name: "fn", arguments: '{"a":1}', id: "call_1" }],
+      "aimock-int-0",
+      logger,
+      { usage: { input_tokens: 3, output_tokens: 7 } },
+    );
+    const completed = events.find((e) => e.event_type === "interaction.completed")!;
+    const interaction = completed.interaction as Record<string, unknown>;
+    expect(interaction.status).toBe("requires_action");
+    expect(interaction.usage).toEqual({
+      total_input_tokens: 3,
+      total_output_tokens: 7,
+      total_tokens: 10,
+    });
+  });
+
+  it("emits usage and requires_action status on interaction.completed for content+tools", () => {
+    const events = buildInteractionsContentWithToolCallsSSEEvents(
+      "Text",
+      [{ name: "fn", arguments: "{}", id: "call_1" }],
+      "aimock-int-0",
+      100,
+      logger,
+      { usage: { input_tokens: 2, output_tokens: 4 } },
+    );
+    const completed = events.find((e) => e.event_type === "interaction.completed")!;
+    const interaction = completed.interaction as Record<string, unknown>;
+    expect(interaction.status).toBe("requires_action");
+    expect(interaction.usage).toEqual({
+      total_input_tokens: 2,
+      total_output_tokens: 4,
+      total_tokens: 6,
+    });
+  });
 });
 
 // ─── Integration tests: non-streaming ───────────────────────────────────
@@ -1155,6 +1212,10 @@ describe("Gemini Interactions — streaming", () => {
     expect(argDeltas).toHaveLength(1);
     const argsStr = (argDeltas[0].delta as Record<string, unknown>).arguments as string;
     expect(JSON.parse(argsStr)).toEqual({ city: "NYC" });
+
+    // The streamed interaction terminates in requires_action for a tool call.
+    const completed = events.find((e) => e.event_type === "interaction.completed")!;
+    expect((completed.interaction as Record<string, unknown>).status).toBe("requires_action");
   });
 
   it("assigns correct indices for content+tools stream", async () => {
@@ -1410,6 +1471,23 @@ describe("collapseGeminiInteractionsSSE", () => {
     expect(result.toolCalls![0].arguments).toBe('{"city":"NY');
     expect(result.droppedChunks).toBe(1);
     expect(result.firstDroppedSample).toMatch(/not valid JSON/);
+  });
+
+  it("drops an arguments_delta that arrives before its step.start (ordering)", () => {
+    // The SDK emits step.start before its arguments_delta fragments; a fragment
+    // arriving first can't correlate, so it is flagged rather than mis-attributed.
+    const sse = [
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"arguments_delta","arguments":"{\\"x\\":1}"},"event_id":"evt_1"}',
+      'data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_1","name":"fn","arguments":{}},"event_id":"evt_2"}',
+      'data: {"event_type":"step.stop","index":0,"event_id":"evt_3"}',
+    ].join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    expect(result.droppedChunks).toBe(1);
+    expect(result.firstDroppedSample).toMatch(/no correlating step\.start/);
+    // The call still surfaces (identity preserved), opening with empty args.
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].name).toBe("fn");
+    expect(result.toolCalls![0].arguments).toBe("{}");
   });
 
   it("preserves identity of a function_call step.start that arrives without an index", () => {

--- a/src/__tests__/gemini-interactions.test.ts
+++ b/src/__tests__/gemini-interactions.test.ts
@@ -830,19 +830,20 @@ describe("SSE event builders", () => {
     resetEventIdCounter();
   });
 
-  it("builds correct text SSE event sequence", () => {
+  it("builds correct text SSE event sequence (SDK 2.x)", () => {
     const events = buildInteractionsTextSSEEvents("Hello!", "aimock-int-0", 100);
-    expect(events[0].event_type).toBe("interaction.start");
-    expect(events[1].event_type).toBe("content.start");
+    expect(events[0].event_type).toBe("interaction.created");
+    expect(events[1].event_type).toBe("step.start");
     expect(events[1].index).toBe(0);
-    expect(events[2].event_type).toBe("content.delta");
+    expect((events[1].step as Record<string, unknown>).type).toBe("model_output");
+    expect(events[2].event_type).toBe("step.delta");
     expect((events[2].delta as Record<string, unknown>).type).toBe("text");
     expect((events[2].delta as Record<string, unknown>).text).toBe("Hello!");
-    expect(events[3].event_type).toBe("content.stop");
-    expect(events[4].event_type).toBe("interaction.complete");
+    expect(events[3].event_type).toBe("step.stop");
+    expect(events[4].event_type).toBe("interaction.completed");
   });
 
-  it("builds correct tool call SSE event sequence", () => {
+  it("builds correct tool call SSE event sequence (SDK 2.x)", () => {
     const events = buildInteractionsToolCallSSEEvents(
       [{ name: "get_weather", arguments: '{"city":"NYC"}', id: "call_1" }],
       "aimock-int-0",
@@ -850,19 +851,26 @@ describe("SSE event builders", () => {
     );
     const eventTypes = events.map((e) => e.event_type);
     expect(eventTypes).toEqual([
-      "interaction.start",
-      "content.start",
-      "content.delta",
-      "content.stop",
-      "interaction.complete",
+      "interaction.created",
+      "step.start",
+      "step.delta",
+      "step.stop",
+      "interaction.completed",
     ]);
+    // Identity (id/name) lives on step.start; arguments are an empty placeholder.
+    const step = events[1].step as Record<string, unknown>;
+    expect(step.type).toBe("function_call");
+    expect(step.id).toBe("call_1");
+    expect(step.name).toBe("get_weather");
+    expect(step.arguments).toEqual({});
+    // Arguments stream as a JSON-string fragment in an arguments_delta.
     const delta = events[2].delta as Record<string, unknown>;
-    expect(delta.type).toBe("function_call");
-    expect(delta.name).toBe("get_weather");
-    expect(delta.arguments).toEqual({ city: "NYC" });
+    expect(delta.type).toBe("arguments_delta");
+    expect(delta.arguments).toBe('{"city":"NYC"}');
+    expect(JSON.parse(delta.arguments as string)).toEqual({ city: "NYC" });
   });
 
-  it("builds content+tools SSE with correct indices", () => {
+  it("builds content+tools SSE with correct indices (SDK 2.x)", () => {
     const events = buildInteractionsContentWithToolCallsSSEEvents(
       "Text",
       [{ name: "fn", arguments: '{"a":1}', id: "call_1" }],
@@ -870,13 +878,14 @@ describe("SSE event builders", () => {
       100,
       logger,
     );
-    // Find content.start events — should have indices 0 and 1
-    const contentStarts = events.filter((e) => e.event_type === "content.start");
-    expect(contentStarts).toHaveLength(2);
-    expect(contentStarts[0].index).toBe(0); // text
-    expect((contentStarts[0].content as Record<string, unknown>).type).toBe("text");
-    expect(contentStarts[1].index).toBe(1); // function_call
-    expect((contentStarts[1].content as Record<string, unknown>).type).toBe("function_call");
+    // Find step.start events — should have indices 0 (text) and 1 (function_call)
+    const stepStarts = events.filter((e) => e.event_type === "step.start");
+    expect(stepStarts).toHaveLength(2);
+    expect(stepStarts[0].index).toBe(0); // text
+    expect((stepStarts[0].step as Record<string, unknown>).type).toBe("model_output");
+    expect(stepStarts[1].index).toBe(1); // function_call
+    expect((stepStarts[1].step as Record<string, unknown>).type).toBe("function_call");
+    expect((stepStarts[1].step as Record<string, unknown>).name).toBe("fn");
   });
 
   it("increments event_id correctly", () => {
@@ -885,11 +894,11 @@ describe("SSE event builders", () => {
     expect(ids).toEqual(["evt_1", "evt_2", "evt_3", "evt_4", "evt_5"]);
   });
 
-  it("includes usage in interaction.complete event", () => {
+  it("includes usage in interaction.completed event", () => {
     const events = buildInteractionsTextSSEEvents("Hi", "aimock-int-0", 100, {
       usage: { input_tokens: 10, output_tokens: 5 },
     });
-    const completeEvent = events.find((e) => e.event_type === "interaction.complete")!;
+    const completeEvent = events.find((e) => e.event_type === "interaction.completed")!;
     const interaction = completeEvent.interaction as Record<string, unknown>;
     expect(interaction.usage).toEqual({
       total_input_tokens: 10,
@@ -900,7 +909,7 @@ describe("SSE event builders", () => {
 
   it("chunks text by chunkSize", () => {
     const events = buildInteractionsTextSSEEvents("ABCDEFGH", "aimock-int-0", 3);
-    const deltas = events.filter((e) => e.event_type === "content.delta");
+    const deltas = events.filter((e) => e.event_type === "step.delta");
     expect(deltas).toHaveLength(3); // ABC, DEF, GH
     expect((deltas[0].delta as Record<string, unknown>).text).toBe("ABC");
     expect((deltas[1].delta as Record<string, unknown>).text).toBe("DEF");
@@ -1071,11 +1080,11 @@ describe("Gemini Interactions — streaming", () => {
     expect(events.length).toBeGreaterThanOrEqual(5);
 
     const eventTypes = (events as Array<Record<string, unknown>>).map((e) => e.event_type);
-    expect(eventTypes[0]).toBe("interaction.start");
-    expect(eventTypes[1]).toBe("content.start");
-    expect(eventTypes).toContain("content.delta");
-    expect(eventTypes).toContain("content.stop");
-    expect(eventTypes[eventTypes.length - 1]).toBe("interaction.complete");
+    expect(eventTypes[0]).toBe("interaction.created");
+    expect(eventTypes[1]).toBe("step.start");
+    expect(eventTypes).toContain("step.delta");
+    expect(eventTypes).toContain("step.stop");
+    expect(eventTypes[eventTypes.length - 1]).toBe("interaction.completed");
   });
 
   it("accumulates content from text deltas", async () => {
@@ -1093,14 +1102,13 @@ describe("Gemini Interactions — streaming", () => {
     });
     const events = parseInteractionsSSEEvents(res.body) as Array<Record<string, unknown>>;
     const textDeltas = events.filter(
-      (e) =>
-        e.event_type === "content.delta" && (e.delta as Record<string, unknown>).type === "text",
+      (e) => e.event_type === "step.delta" && (e.delta as Record<string, unknown>).type === "text",
     );
     const accumulated = textDeltas.map((e) => (e.delta as Record<string, unknown>).text).join("");
     expect(accumulated).toBe("ABCDEFGHIJ");
   });
 
-  it("streams tool call deltas", async () => {
+  it("streams tool call as step.start identity + arguments_delta", async () => {
     instance = await createServer([...allFixtures]);
     const res = await post(`${instance.url}/v1beta/interactions`, {
       model: "gemini-2.5-flash",
@@ -1108,15 +1116,23 @@ describe("Gemini Interactions — streaming", () => {
       stream: true,
     });
     const events = parseInteractionsSSEEvents(res.body) as Array<Record<string, unknown>>;
-    const funcDeltas = events.filter(
+    const stepStart = events.find(
       (e) =>
-        e.event_type === "content.delta" &&
-        (e.delta as Record<string, unknown>).type === "function_call",
+        e.event_type === "step.start" &&
+        (e.step as Record<string, unknown>).type === "function_call",
+    )!;
+    const step = stepStart.step as Record<string, unknown>;
+    expect(step.name).toBe("get_weather");
+    expect(step.id).toBe("call_1");
+
+    const argDeltas = events.filter(
+      (e) =>
+        e.event_type === "step.delta" &&
+        (e.delta as Record<string, unknown>).type === "arguments_delta",
     );
-    expect(funcDeltas).toHaveLength(1);
-    const delta = funcDeltas[0].delta as Record<string, unknown>;
-    expect(delta.name).toBe("get_weather");
-    expect(delta.arguments).toEqual({ city: "NYC" });
+    expect(argDeltas).toHaveLength(1);
+    const argsStr = (argDeltas[0].delta as Record<string, unknown>).arguments as string;
+    expect(JSON.parse(argsStr)).toEqual({ city: "NYC" });
   });
 
   it("assigns correct indices for content+tools stream", async () => {
@@ -1130,16 +1146,15 @@ describe("Gemini Interactions — streaming", () => {
 
     // Text at index 0, tool call at index 1
     const textDelta = events.find(
-      (e) =>
-        e.event_type === "content.delta" && (e.delta as Record<string, unknown>).type === "text",
+      (e) => e.event_type === "step.delta" && (e.delta as Record<string, unknown>).type === "text",
     );
-    const toolDelta = events.find(
+    const toolStart = events.find(
       (e) =>
-        e.event_type === "content.delta" &&
-        (e.delta as Record<string, unknown>).type === "function_call",
+        e.event_type === "step.start" &&
+        (e.step as Record<string, unknown>).type === "function_call",
     );
     expect(textDelta?.index).toBe(0);
-    expect(toolDelta?.index).toBe(1);
+    expect(toolStart?.index).toBe(1);
   });
 
   it("includes interactionId in lifecycle events", async () => {
@@ -1151,8 +1166,8 @@ describe("Gemini Interactions — streaming", () => {
     });
     const events = parseInteractionsSSEEvents(res.body) as Array<Record<string, unknown>>;
 
-    const startEvent = events.find((e) => e.event_type === "interaction.start")!;
-    const completeEvent = events.find((e) => e.event_type === "interaction.complete")!;
+    const startEvent = events.find((e) => e.event_type === "interaction.created")!;
+    const completeEvent = events.find((e) => e.event_type === "interaction.completed")!;
 
     const startInteraction = startEvent.interaction as Record<string, unknown>;
     const completeInteraction = completeEvent.interaction as Record<string, unknown>;
@@ -1303,69 +1318,97 @@ describe("Gemini Interactions — fixture matching", () => {
 // ─── Stream collapse ────────────────────────────────────────────────────
 
 describe("collapseGeminiInteractionsSSE", () => {
-  it("collapses text deltas", () => {
+  it("collapses text deltas (SDK 2.x)", () => {
     const sse = [
-      'data: {"event_type":"interaction.start","interaction":{"id":"int-0","status":"in_progress"},"event_id":"evt_1"}',
-      'data: {"event_type":"content.start","index":0,"content":{"type":"text"},"event_id":"evt_2"}',
-      'data: {"event_type":"content.delta","index":0,"delta":{"type":"text","text":"Hello "},"event_id":"evt_3"}',
-      'data: {"event_type":"content.delta","index":0,"delta":{"type":"text","text":"World"},"event_id":"evt_4"}',
-      'data: {"event_type":"content.stop","index":0,"event_id":"evt_5"}',
-      'data: {"event_type":"interaction.complete","interaction":{"id":"int-0","status":"completed","usage":{"total_input_tokens":10,"total_output_tokens":5,"total_tokens":15}},"event_id":"evt_6"}',
+      'data: {"event_type":"interaction.created","interaction":{"id":"int-0","status":"in_progress"},"event_id":"evt_1"}',
+      'data: {"event_type":"step.start","index":0,"step":{"type":"model_output"},"event_id":"evt_2"}',
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"text","text":"Hello "},"event_id":"evt_3"}',
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"text","text":"World"},"event_id":"evt_4"}',
+      'data: {"event_type":"step.stop","index":0,"event_id":"evt_5"}',
+      'data: {"event_type":"interaction.completed","interaction":{"id":"int-0","status":"completed","usage":{"total_input_tokens":10,"total_output_tokens":5,"total_tokens":15}},"event_id":"evt_6"}',
     ].join("\n\n");
     const result = collapseGeminiInteractionsSSE(sse);
     expect(result.content).toBe("Hello World");
     expect(result.toolCalls).toBeUndefined();
   });
 
-  it("collapses tool call deltas", () => {
+  it("collapses tool call via step.start identity + arguments_delta (SDK 2.x)", () => {
     const sse = [
-      'data: {"event_type":"interaction.start","interaction":{"id":"int-0"},"event_id":"evt_1"}',
-      'data: {"event_type":"content.start","index":0,"content":{"type":"function_call"},"event_id":"evt_2"}',
-      'data: {"event_type":"content.delta","index":0,"delta":{"type":"function_call","id":"call_1","name":"get_weather","arguments":{"city":"NYC"}},"event_id":"evt_3"}',
-      'data: {"event_type":"content.stop","index":0,"event_id":"evt_4"}',
-      'data: {"event_type":"interaction.complete","interaction":{"id":"int-0","status":"requires_action"},"event_id":"evt_5"}',
+      'data: {"event_type":"interaction.created","interaction":{"id":"int-0"},"event_id":"evt_1"}',
+      'data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_1","name":"get_weather","arguments":{}},"event_id":"evt_2"}',
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"arguments_delta","arguments":"{\\"city\\":"},"event_id":"evt_3"}',
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"arguments_delta","arguments":"\\"NYC\\"}"},"event_id":"evt_4"}',
+      'data: {"event_type":"step.stop","index":0,"event_id":"evt_5"}',
+      'data: {"event_type":"interaction.completed","interaction":{"id":"int-0","status":"requires_action"},"event_id":"evt_6"}',
     ].join("\n\n");
     const result = collapseGeminiInteractionsSSE(sse);
     expect(result.toolCalls).toHaveLength(1);
     expect(result.toolCalls![0].name).toBe("get_weather");
+    // Fragments concatenate into valid JSON by step.stop.
     expect(result.toolCalls![0].arguments).toBe('{"city":"NYC"}');
     expect(result.toolCalls![0].id).toBe("call_1");
   });
 
-  it("collapses content + tool calls", () => {
+  it("uses step.start arguments object when no arguments_delta streams (SDK 2.x)", () => {
     const sse = [
-      'data: {"event_type":"content.delta","index":0,"delta":{"type":"text","text":"Help"},"event_id":"evt_1"}',
-      'data: {"event_type":"content.delta","index":1,"delta":{"type":"function_call","id":"c1","name":"fn","arguments":{"x":1}},"event_id":"evt_2"}',
+      'data: {"event_type":"step.start","index":0,"step":{"type":"function_call","id":"call_1","name":"fn","arguments":{"x":1}},"event_id":"evt_1"}',
+      'data: {"event_type":"step.stop","index":0,"event_id":"evt_2"}',
+    ].join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].arguments).toBe('{"x":1}');
+  });
+
+  it("collapses content + tool calls (SDK 2.x)", () => {
+    const sse = [
+      'data: {"event_type":"step.start","index":0,"step":{"type":"model_output"},"event_id":"evt_1"}',
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"text","text":"Help"},"event_id":"evt_2"}',
+      'data: {"event_type":"step.stop","index":0,"event_id":"evt_3"}',
+      'data: {"event_type":"step.start","index":1,"step":{"type":"function_call","id":"c1","name":"fn","arguments":{}},"event_id":"evt_4"}',
+      'data: {"event_type":"step.delta","index":1,"delta":{"type":"arguments_delta","arguments":"{\\"x\\":1}"},"event_id":"evt_5"}',
+      'data: {"event_type":"step.stop","index":1,"event_id":"evt_6"}',
     ].join("\n\n");
     const result = collapseGeminiInteractionsSSE(sse);
     expect(result.content).toBe("Help");
     expect(result.toolCalls).toHaveLength(1);
     expect(result.toolCalls![0].name).toBe("fn");
+    expect(result.toolCalls![0].arguments).toBe('{"x":1}');
   });
 
-  it("collapses thought_summary deltas as reasoning", () => {
+  it("collapses thought_summary deltas as reasoning (SDK 2.x nested content)", () => {
     const sse = [
-      'data: {"event_type":"content.delta","index":0,"delta":{"type":"thought_summary","text":"Thinking..."},"event_id":"evt_1"}',
-      'data: {"event_type":"content.delta","index":1,"delta":{"type":"text","text":"Answer"},"event_id":"evt_2"}',
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"thought_summary","content":{"text":"Thinking..."}},"event_id":"evt_1"}',
+      'data: {"event_type":"step.delta","index":1,"delta":{"type":"text","text":"Answer"},"event_id":"evt_2"}',
     ].join("\n\n");
     const result = collapseGeminiInteractionsSSE(sse);
     expect(result.reasoning).toBe("Thinking...");
     expect(result.content).toBe("Answer");
   });
 
+  it("drops arguments_delta with no correlating step.start", () => {
+    const sse = [
+      'data: {"event_type":"step.delta","index":4,"delta":{"type":"arguments_delta","arguments":"{}"},"event_id":"evt_1"}',
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"text","text":"ok"},"event_id":"evt_2"}',
+    ].join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    expect(result.content).toBe("ok");
+    expect(result.toolCalls).toBeUndefined();
+    expect(result.droppedChunks).toBe(1);
+  });
+
   it("handles malformed chunks gracefully", () => {
     const sse = [
       "data: not-json",
-      'data: {"event_type":"content.delta","index":0,"delta":{"type":"text","text":"ok"},"event_id":"evt_1"}',
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"text","text":"ok"},"event_id":"evt_1"}',
     ].join("\n\n");
     const result = collapseGeminiInteractionsSSE(sse);
     expect(result.content).toBe("ok");
     expect(result.droppedChunks).toBe(1);
   });
 
-  it("handles incomplete stream (no interaction.complete)", () => {
+  it("handles incomplete stream (no interaction.completed)", () => {
     const sse = [
-      'data: {"event_type":"content.delta","index":0,"delta":{"type":"text","text":"partial"},"event_id":"evt_1"}',
+      'data: {"event_type":"step.delta","index":0,"delta":{"type":"text","text":"partial"},"event_id":"evt_1"}',
     ].join("\n\n");
     const result = collapseGeminiInteractionsSSE(sse);
     expect(result.content).toBe("partial");
@@ -1374,6 +1417,54 @@ describe("collapseGeminiInteractionsSSE", () => {
   it("returns empty content for stream with no data events", () => {
     const result = collapseGeminiInteractionsSSE("");
     expect(result.content).toBe("");
+  });
+
+  it("round-trips emitter output back through the collapser", () => {
+    resetEventIdCounter();
+    const events = buildInteractionsContentWithToolCallsSSEEvents(
+      "Let me check",
+      [{ name: "get_weather", arguments: '{"city":"NYC"}', id: "call_1" }],
+      "aimock-int-0",
+      100,
+      new Logger("silent"),
+    );
+    const sse = events.map((e) => `data: ${JSON.stringify(e)}`).join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    expect(result.content).toBe("Let me check");
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].name).toBe("get_weather");
+    expect(result.toolCalls![0].arguments).toBe('{"city":"NYC"}');
+    expect(result.toolCalls![0].id).toBe("call_1");
+  });
+
+  // ─── Backward compatibility: legacy SDK 1.x recorded fixtures ────────────
+
+  it("still collapses legacy 1.x content.delta text", () => {
+    const sse = [
+      'data: {"event_type":"content.delta","index":0,"delta":{"type":"text","text":"Hello "},"event_id":"evt_1"}',
+      'data: {"event_type":"content.delta","index":0,"delta":{"type":"text","text":"World"},"event_id":"evt_2"}',
+    ].join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    expect(result.content).toBe("Hello World");
+  });
+
+  it("still collapses legacy 1.x content.delta function_call", () => {
+    const sse = [
+      'data: {"event_type":"content.delta","index":0,"delta":{"type":"function_call","id":"call_1","name":"get_weather","arguments":{"city":"NYC"}},"event_id":"evt_1"}',
+    ].join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].name).toBe("get_weather");
+    expect(result.toolCalls![0].arguments).toBe('{"city":"NYC"}');
+    expect(result.toolCalls![0].id).toBe("call_1");
+  });
+
+  it("still collapses legacy 1.x flat thought_summary text", () => {
+    const sse = [
+      'data: {"event_type":"content.delta","index":0,"delta":{"type":"thought_summary","text":"Thinking..."},"event_id":"evt_1"}',
+    ].join("\n\n");
+    const result = collapseGeminiInteractionsSSE(sse);
+    expect(result.reasoning).toBe("Thinking...");
   });
 });
 
@@ -1450,7 +1541,7 @@ describe("Gemini Interactions — edge cases", () => {
       stream: true,
     });
     const events = parseInteractionsSSEEvents(res.body) as Array<Record<string, unknown>>;
-    const deltas = events.filter((e) => e.event_type === "content.delta");
+    const deltas = events.filter((e) => e.event_type === "step.delta");
     expect(deltas).toHaveLength(1);
     expect((deltas[0].delta as Record<string, unknown>).text).toBe("");
   });

--- a/src/__tests__/gemini-interactions.test.ts
+++ b/src/__tests__/gemini-interactions.test.ts
@@ -745,7 +745,10 @@ describe("response builders", () => {
     expect(resp.status).toBe("completed");
     expect(resp.model).toBe("gemini-2.5-flash");
     expect(resp.role).toBe("model");
-    expect(resp.outputs).toEqual([{ type: "text", text: "Hello!" }]);
+    expect(resp.output_text).toBe("Hello!");
+    expect(resp.steps).toEqual([
+      { type: "model_output", content: [{ type: "text", text: "Hello!" }] },
+    ]);
   });
 
   it("builds tool call response", () => {
@@ -756,11 +759,12 @@ describe("response builders", () => {
       logger,
     ) as Record<string, unknown>;
     expect(resp.status).toBe("requires_action");
-    const outputs = resp.outputs as Array<Record<string, unknown>>;
-    expect(outputs).toHaveLength(1);
-    expect(outputs[0].type).toBe("function_call");
-    expect(outputs[0].name).toBe("get_weather");
-    expect(outputs[0].arguments).toEqual({ city: "NYC" });
+    const steps = resp.steps as Array<Record<string, unknown>>;
+    expect(steps).toHaveLength(1);
+    expect(steps[0].type).toBe("function_call");
+    expect(steps[0].id).toBe("call_1");
+    expect(steps[0].name).toBe("get_weather");
+    expect(steps[0].arguments).toEqual({ city: "NYC" });
   });
 
   it("builds content+tools response", () => {
@@ -772,10 +776,13 @@ describe("response builders", () => {
       logger,
     ) as Record<string, unknown>;
     expect(resp.status).toBe("requires_action");
-    const outputs = resp.outputs as Array<Record<string, unknown>>;
-    expect(outputs).toHaveLength(2);
-    expect(outputs[0].type).toBe("text");
-    expect(outputs[1].type).toBe("function_call");
+    expect(resp.output_text).toBe("Here is the analysis");
+    const steps = resp.steps as Array<Record<string, unknown>>;
+    expect(steps).toHaveLength(2);
+    expect(steps[0].type).toBe("model_output");
+    expect(steps[0].content).toEqual([{ type: "text", text: "Here is the analysis" }]);
+    expect(steps[1].type).toBe("function_call");
+    expect(steps[1].name).toBe("analyze");
   });
 
   it("includes usage metadata", () => {
@@ -816,8 +823,8 @@ describe("response builders", () => {
       "id-0",
       logger,
     ) as Record<string, unknown>;
-    const outputs = resp.outputs as Array<Record<string, unknown>>;
-    expect(outputs[0].arguments).toEqual({});
+    const steps = resp.steps as Array<Record<string, unknown>>;
+    expect(steps[0].arguments).toEqual({});
   });
 });
 
@@ -1010,7 +1017,10 @@ describe("Gemini Interactions — non-streaming", () => {
     const body = JSON.parse(res.body);
     expect(body.status).toBe("completed");
     expect(body.role).toBe("model");
-    expect(body.outputs).toEqual([{ type: "text", text: "Hi there!" }]);
+    expect(body.output_text).toBe("Hi there!");
+    expect(body.steps).toEqual([
+      { type: "model_output", content: [{ type: "text", text: "Hi there!" }] },
+    ]);
     expect(body.id).toMatch(/^aimock-int-/);
   });
 
@@ -1024,11 +1034,11 @@ describe("Gemini Interactions — non-streaming", () => {
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.status).toBe("requires_action");
-    const outputs = body.outputs;
-    expect(outputs).toHaveLength(1);
-    expect(outputs[0].type).toBe("function_call");
-    expect(outputs[0].name).toBe("get_weather");
-    expect(outputs[0].arguments).toEqual({ city: "NYC" });
+    const steps = body.steps;
+    expect(steps).toHaveLength(1);
+    expect(steps[0].type).toBe("function_call");
+    expect(steps[0].name).toBe("get_weather");
+    expect(steps[0].arguments).toEqual({ city: "NYC" });
   });
 
   it("returns content + tool calls response", async () => {
@@ -1041,11 +1051,12 @@ describe("Gemini Interactions — non-streaming", () => {
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.status).toBe("requires_action");
-    expect(body.outputs).toHaveLength(2);
-    expect(body.outputs[0].type).toBe("text");
-    expect(body.outputs[0].text).toBe("Let me help you");
-    expect(body.outputs[1].type).toBe("function_call");
-    expect(body.outputs[1].name).toBe("analyze_data");
+    expect(body.output_text).toBe("Let me help you");
+    expect(body.steps).toHaveLength(2);
+    expect(body.steps[0].type).toBe("model_output");
+    expect(body.steps[0].content[0].text).toBe("Let me help you");
+    expect(body.steps[1].type).toBe("function_call");
+    expect(body.steps[1].name).toBe("analyze_data");
   });
 
   it("returns error response", async () => {
@@ -1122,7 +1133,10 @@ describe("Gemini Interactions — non-streaming", () => {
     });
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
-    expect(body.outputs).toEqual([{ type: "text", text: "Hi there!" }]);
+    expect(body.output_text).toBe("Hi there!");
+    expect(body.steps).toEqual([
+      { type: "model_output", content: [{ type: "text", text: "Hi there!" }] },
+    ]);
   });
 
   it("handles sequenceIndex for multi-turn", async () => {
@@ -1137,8 +1151,8 @@ describe("Gemini Interactions — non-streaming", () => {
       input: "step",
       stream: false,
     });
-    expect(JSON.parse(r1.body).outputs[0].text).toBe("First");
-    expect(JSON.parse(r2.body).outputs[0].text).toBe("Second");
+    expect(JSON.parse(r1.body).output_text).toBe("First");
+    expect(JSON.parse(r2.body).output_text).toBe("Second");
   });
 });
 
@@ -1334,7 +1348,7 @@ describe("Gemini Interactions — fixture matching", () => {
       input: "hello",
       stream: false,
     });
-    expect(JSON.parse(res.body).outputs[0].text).toBe("Hi there!");
+    expect(JSON.parse(res.body).output_text).toBe("Hi there!");
   });
 
   it("matches by sequenceIndex chaining", async () => {
@@ -1349,8 +1363,8 @@ describe("Gemini Interactions — fixture matching", () => {
       input: "step",
       stream: false,
     });
-    expect(JSON.parse(r1.body).outputs[0].text).toBe("First");
-    expect(JSON.parse(r2.body).outputs[0].text).toBe("Second");
+    expect(JSON.parse(r1.body).output_text).toBe("First");
+    expect(JSON.parse(r2.body).output_text).toBe("Second");
   });
 
   it("matches by model", async () => {
@@ -1360,7 +1374,7 @@ describe("Gemini Interactions — fixture matching", () => {
       input: "anything",
       stream: false,
     });
-    expect(JSON.parse(res.body).outputs[0].text).toBe("Pro response");
+    expect(JSON.parse(res.body).output_text).toBe("Pro response");
   });
 
   it("matches by predicate", async () => {
@@ -1370,7 +1384,7 @@ describe("Gemini Interactions — fixture matching", () => {
       input: "custom-check",
       stream: false,
     });
-    expect(JSON.parse(res.body).outputs[0].text).toBe("Predicate matched");
+    expect(JSON.parse(res.body).output_text).toBe("Predicate matched");
   });
 
   it("matches by toolName for tool-related fixtures", async () => {
@@ -1394,7 +1408,7 @@ describe("Gemini Interactions — fixture matching", () => {
     });
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
-    expect(body.outputs[0].name).toBe("search_tool");
+    expect(body.steps[0].name).toBe("search_tool");
   });
 });
 
@@ -1677,7 +1691,8 @@ describe("Gemini Interactions — edge cases", () => {
     });
     expect(res.status).toBe(200);
     const body = JSON.parse(res.body);
-    expect(body.outputs[0].text).toBe("");
+    expect(body.output_text).toBe("");
+    expect(body.steps[0].content[0].text).toBe("");
   });
 
   it("streams empty content correctly", async () => {

--- a/src/gemini-interactions.ts
+++ b/src/gemini-interactions.ts
@@ -545,8 +545,10 @@ export function buildInteractionsToolCallSSEEvents(
       event_id: nextEventId(),
     });
 
-    // arguments_delta.arguments is a string fragment; emitting the full
-    // serialized object as one fragment keeps the concatenation valid JSON.
+    // arguments_delta.arguments is a string fragment. The real SDK may split
+    // the args across several fragments that concatenate into valid JSON; the
+    // mock emits the whole serialized object as one fragment (a valid
+    // degenerate case the collapser handles identically).
     events.push({
       event_type: "step.delta",
       index: idx,

--- a/src/gemini-interactions.ts
+++ b/src/gemini-interactions.ts
@@ -446,25 +446,25 @@ export function buildInteractionsTextSSEEvents(
 ): InteractionsSSEEvent[] {
   const events: InteractionsSSEEvent[] = [];
 
-  // interaction.start
+  // interaction.created
   events.push({
-    event_type: "interaction.start",
+    event_type: "interaction.created",
     interaction: { id: interactionId, status: "in_progress" },
     event_id: nextEventId(),
   });
 
-  // content.start
+  // step.start — text step is the model_output
   events.push({
-    event_type: "content.start",
+    event_type: "step.start",
     index: 0,
-    content: { type: "text" },
+    step: { type: "model_output" },
     event_id: nextEventId(),
   });
 
-  // content.delta(s)
+  // step.delta(s) — inner delta shape is unchanged ({ type: "text", text })
   if (content.length === 0) {
     events.push({
-      event_type: "content.delta",
+      event_type: "step.delta",
       index: 0,
       delta: { type: "text", text: "" },
       event_id: nextEventId(),
@@ -473,7 +473,7 @@ export function buildInteractionsTextSSEEvents(
     for (let i = 0; i < content.length; i += chunkSize) {
       const slice = content.slice(i, i + chunkSize);
       events.push({
-        event_type: "content.delta",
+        event_type: "step.delta",
         index: 0,
         delta: { type: "text", text: slice },
         event_id: nextEventId(),
@@ -481,16 +481,16 @@ export function buildInteractionsTextSSEEvents(
     }
   }
 
-  // content.stop
+  // step.stop
   events.push({
-    event_type: "content.stop",
+    event_type: "step.stop",
     index: 0,
     event_id: nextEventId(),
   });
 
-  // interaction.complete
+  // interaction.completed
   events.push({
-    event_type: "interaction.complete",
+    event_type: "interaction.completed",
     interaction: {
       id: interactionId,
       status: "completed",
@@ -510,14 +510,17 @@ export function buildInteractionsToolCallSSEEvents(
 ): InteractionsSSEEvent[] {
   const events: InteractionsSSEEvent[] = [];
 
-  // interaction.start
+  // interaction.created
   events.push({
-    event_type: "interaction.start",
+    event_type: "interaction.created",
     interaction: { id: interactionId, status: "in_progress" },
     event_id: nextEventId(),
   });
 
-  // Each tool call gets its own content.start/delta/stop bracket
+  // Each tool call gets its own step.start/delta/stop bracket. In SDK 2.x the
+  // call identity (id, name) lives on step.start; the arguments stream as a
+  // dedicated `arguments_delta` carrying a JSON-string fragment, and step.start
+  // carries an empty `arguments: {}` placeholder.
   for (let idx = 0; idx < toolCalls.length; idx++) {
     const tc = toolCalls[idx];
     let argsObj: unknown;
@@ -531,34 +534,39 @@ export function buildInteractionsToolCallSSEEvents(
     }
 
     events.push({
-      event_type: "content.start",
+      event_type: "step.start",
       index: idx,
-      content: { type: "function_call" },
-      event_id: nextEventId(),
-    });
-
-    events.push({
-      event_type: "content.delta",
-      index: idx,
-      delta: {
+      step: {
         type: "function_call",
         id: tc.id || generateToolCallId(),
         name: tc.name,
-        arguments: argsObj,
+        arguments: {},
+      },
+      event_id: nextEventId(),
+    });
+
+    // arguments_delta.arguments is a string fragment; emitting the full
+    // serialized object as one fragment keeps the concatenation valid JSON.
+    events.push({
+      event_type: "step.delta",
+      index: idx,
+      delta: {
+        type: "arguments_delta",
+        arguments: JSON.stringify(argsObj),
       },
       event_id: nextEventId(),
     });
 
     events.push({
-      event_type: "content.stop",
+      event_type: "step.stop",
       index: idx,
       event_id: nextEventId(),
     });
   }
 
-  // interaction.complete
+  // interaction.completed
   events.push({
-    event_type: "interaction.complete",
+    event_type: "interaction.completed",
     interaction: {
       id: interactionId,
       status: "requires_action",
@@ -580,24 +588,24 @@ export function buildInteractionsContentWithToolCallsSSEEvents(
 ): InteractionsSSEEvent[] {
   const events: InteractionsSSEEvent[] = [];
 
-  // interaction.start
+  // interaction.created
   events.push({
-    event_type: "interaction.start",
+    event_type: "interaction.created",
     interaction: { id: interactionId, status: "in_progress" },
     event_id: nextEventId(),
   });
 
-  // Text content at index 0
+  // Text content at index 0 (model_output step)
   events.push({
-    event_type: "content.start",
+    event_type: "step.start",
     index: 0,
-    content: { type: "text" },
+    step: { type: "model_output" },
     event_id: nextEventId(),
   });
 
   if (content.length === 0) {
     events.push({
-      event_type: "content.delta",
+      event_type: "step.delta",
       index: 0,
       delta: { type: "text", text: "" },
       event_id: nextEventId(),
@@ -606,7 +614,7 @@ export function buildInteractionsContentWithToolCallsSSEEvents(
     for (let i = 0; i < content.length; i += chunkSize) {
       const slice = content.slice(i, i + chunkSize);
       events.push({
-        event_type: "content.delta",
+        event_type: "step.delta",
         index: 0,
         delta: { type: "text", text: slice },
         event_id: nextEventId(),
@@ -615,12 +623,12 @@ export function buildInteractionsContentWithToolCallsSSEEvents(
   }
 
   events.push({
-    event_type: "content.stop",
+    event_type: "step.stop",
     index: 0,
     event_id: nextEventId(),
   });
 
-  // Tool calls at index 1+
+  // Tool calls at index 1+ (identity on step.start, args as arguments_delta)
   for (let i = 0; i < toolCalls.length; i++) {
     const tc = toolCalls[i];
     const idx = i + 1; // offset by 1 because text is index 0
@@ -635,34 +643,37 @@ export function buildInteractionsContentWithToolCallsSSEEvents(
     }
 
     events.push({
-      event_type: "content.start",
+      event_type: "step.start",
       index: idx,
-      content: { type: "function_call" },
-      event_id: nextEventId(),
-    });
-
-    events.push({
-      event_type: "content.delta",
-      index: idx,
-      delta: {
+      step: {
         type: "function_call",
         id: tc.id || generateToolCallId(),
         name: tc.name,
-        arguments: argsObj,
+        arguments: {},
       },
       event_id: nextEventId(),
     });
 
     events.push({
-      event_type: "content.stop",
+      event_type: "step.delta",
+      index: idx,
+      delta: {
+        type: "arguments_delta",
+        arguments: JSON.stringify(argsObj),
+      },
+      event_id: nextEventId(),
+    });
+
+    events.push({
+      event_type: "step.stop",
       index: idx,
       event_id: nextEventId(),
     });
   }
 
-  // interaction.complete
+  // interaction.completed
   events.push({
-    event_type: "interaction.complete",
+    event_type: "interaction.completed",
     interaction: {
       id: interactionId,
       status: "requires_action",
@@ -711,10 +722,10 @@ export async function writeGeminiInteractionsSSEStream(
     if (res.writableEnded) return true;
     // Data-only SSE (no event: prefix, no [DONE])
     res.write(`data: ${JSON.stringify(event)}\n\n`);
-    // Only count content deltas for truncateAfterChunks — framing events
-    // (interaction.start, content.start, content.stop, interaction.complete)
+    // Only count step deltas for truncateAfterChunks — framing events
+    // (interaction.created, step.start, step.stop, interaction.completed)
     // should not consume chunk budget or trigger the chunk-sent callback.
-    if (event.event_type === "content.delta") {
+    if (event.event_type === "step.delta") {
       onChunkSent?.();
       chunkIndex++;
     }

--- a/src/gemini-interactions.ts
+++ b/src/gemini-interactions.ts
@@ -337,8 +337,27 @@ export function buildInteractionsTextResponse(
     status: "completed",
     model: overrides?.model ?? model,
     role: "model",
-    outputs: [{ type: "text", text: content }],
+    output_text: content,
+    steps: [{ type: "model_output", content: [{ type: "text", text: content }] }],
     usage: interactionsUsage(overrides),
+  };
+}
+
+// Build a single SDK 2.x function_call step from a fixture tool call,
+// reusing the existing malformed-arguments guard (logger.warn + {} fallback).
+function buildFunctionCallStep(tc: ToolCall, logger: Logger): object {
+  let argsObj: unknown;
+  try {
+    argsObj = JSON.parse(tc.arguments || "{}");
+  } catch {
+    logger.warn(`Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`);
+    argsObj = {};
+  }
+  return {
+    type: "function_call",
+    id: tc.id || generateToolCallId(),
+    name: tc.name,
+    arguments: argsObj,
   };
 }
 
@@ -354,23 +373,7 @@ export function buildInteractionsToolCallResponse(
     status: "requires_action",
     model: overrides?.model ?? model,
     role: "model",
-    outputs: toolCalls.map((tc) => {
-      let argsObj: unknown;
-      try {
-        argsObj = JSON.parse(tc.arguments || "{}");
-      } catch {
-        logger.warn(
-          `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
-        );
-        argsObj = {};
-      }
-      return {
-        type: "function_call",
-        id: tc.id || generateToolCallId(),
-        name: tc.name,
-        arguments: argsObj,
-      };
-    }),
+    steps: toolCalls.map((tc) => buildFunctionCallStep(tc, logger)),
     usage: interactionsUsage(overrides),
   };
 }
@@ -383,23 +386,9 @@ export function buildInteractionsContentWithToolCallsResponse(
   logger: Logger,
   overrides?: ResponseOverrides,
 ): object {
-  const outputs: object[] = [{ type: "text", text: content }];
+  const steps: object[] = [{ type: "model_output", content: [{ type: "text", text: content }] }];
   for (const tc of toolCalls) {
-    let argsObj: unknown;
-    try {
-      argsObj = JSON.parse(tc.arguments || "{}");
-    } catch {
-      logger.warn(
-        `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
-      );
-      argsObj = {};
-    }
-    outputs.push({
-      type: "function_call",
-      id: tc.id || generateToolCallId(),
-      name: tc.name,
-      arguments: argsObj,
-    });
+    steps.push(buildFunctionCallStep(tc, logger));
   }
 
   return {
@@ -407,7 +396,8 @@ export function buildInteractionsContentWithToolCallsResponse(
     status: "requires_action",
     model: overrides?.model ?? model,
     role: "model",
-    outputs,
+    output_text: content,
+    steps,
     usage: interactionsUsage(overrides),
   };
 }

--- a/src/stream-collapse.ts
+++ b/src/stream-collapse.ts
@@ -1215,6 +1215,10 @@ export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
     number,
     { id?: string; name: string; argsObj?: unknown; argsStr: string }
   >();
+  // Synthetic keys for function_call step.start events that arrive without an
+  // index (matches the sibling collapsers); seeded high to avoid colliding with
+  // real step indices.
+  let nextSyntheticStepIndex = 1_000_000;
 
   for (const line of lines) {
     const data = extractSSEData(splitSSELines(line));
@@ -1242,8 +1246,12 @@ export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
     if (eventType === "step.start") {
       // 2.x — tool-call identity lives on step.start, not in a delta.
       const step = parsed.step as Record<string, unknown> | undefined;
-      if (step && step.type === "function_call" && index !== undefined) {
-        stepToolCalls.set(index, {
+      if (step && step.type === "function_call") {
+        // An index-less start can't correlate later arguments_delta fragments,
+        // but minting a synthetic key preserves the call's identity instead of
+        // dropping it silently.
+        const key = index ?? nextSyntheticStepIndex++;
+        stepToolCalls.set(key, {
           id: step.id ? String(step.id) : undefined,
           name: String(step.name ?? ""),
           // step.start may carry a fully-populated `arguments` object (non-
@@ -1298,12 +1306,27 @@ export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
 
   // Finalize 2.x tool calls in step-index order.
   for (const [, tc] of Array.from(stepToolCalls.entries()).sort(([a], [b]) => a - b)) {
-    const args =
-      tc.argsStr !== ""
-        ? tc.argsStr
-        : typeof tc.argsObj === "string"
-          ? tc.argsObj
-          : JSON.stringify(tc.argsObj ?? {});
+    let args: string;
+    if (tc.argsStr !== "") {
+      args = tc.argsStr;
+      // The arguments_delta fragments must concatenate into valid JSON by
+      // step.stop. A truncated/interrupted stream can leave them malformed;
+      // surface that via droppedChunks rather than writing a corrupt fixture
+      // silently (mirrors the per-chunk parse guard above).
+      try {
+        JSON.parse(args);
+      } catch {
+        droppedChunks++;
+        if (droppedChunks === 1) {
+          firstDroppedSample = `assembled arguments_delta not valid JSON for "${tc.name}": ${surrogateSafeSlice(
+            args,
+            200,
+          )}`;
+        }
+      }
+    } else {
+      args = typeof tc.argsObj === "string" ? tc.argsObj : JSON.stringify(tc.argsObj ?? {});
+    }
     toolCalls.push({ name: tc.name, arguments: args, ...(tc.id ? { id: tc.id } : {}) });
   }
 

--- a/src/stream-collapse.ts
+++ b/src/stream-collapse.ts
@@ -1190,9 +1190,16 @@ export function collapseBedrockEventStream(body: Buffer): CollapseResult {
 /**
  * Collapse Gemini Interactions SSE stream into a single response.
  *
- * Format (data-only, event_type inside JSON):
- *   data: {"event_type":"content.delta","index":0,"delta":{"type":"text","text":"Hello"}}\n\n
- *   data: {"event_type":"interaction.complete","interaction":{"id":"...","usage":{...}}}\n\n
+ * Handles the SDK 2.x event protocol (the "Interactions breaking changes,
+ * May 2026" shapes):
+ *   data: {"event_type":"step.start","index":1,"step":{"type":"function_call","id":"call_1","name":"fn","arguments":{}}}
+ *   data: {"event_type":"step.delta","index":0,"delta":{"type":"text","text":"Hello"}}
+ *   data: {"event_type":"step.delta","index":1,"delta":{"type":"arguments_delta","arguments":"{\"x\":1}"}}
+ *   data: {"event_type":"interaction.completed","interaction":{"id":"...","usage":{...}}}
+ *
+ * The legacy SDK 1.x shapes (`content.delta` with an inline `function_call`
+ * delta) are still accepted for backward compatibility with previously
+ * recorded fixtures.
  */
 export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
   const lines = splitSSEEvents(body);
@@ -1200,7 +1207,14 @@ export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
   let reasoning = "";
   let droppedChunks = 0;
   let firstDroppedSample: string | undefined;
+  // Legacy 1.x tool calls arrive fully formed in a single content.delta.
   const toolCalls: ToolCall[] = [];
+  // 2.x tool calls are assembled across step.start (identity) + arguments_delta
+  // (string fragments), keyed by step index.
+  const stepToolCalls = new Map<
+    number,
+    { id?: string; name: string; argsObj?: unknown; argsStr: string }
+  >();
 
   for (const line of lines) {
     const data = extractSSEData(splitSSELines(line));
@@ -1223,13 +1237,45 @@ export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
     const eventType = parsed.event_type as string | undefined;
     if (!eventType) continue;
 
-    if (eventType === "content.delta") {
+    const index = typeof parsed.index === "number" ? parsed.index : undefined;
+
+    if (eventType === "step.start") {
+      // 2.x — tool-call identity lives on step.start, not in a delta.
+      const step = parsed.step as Record<string, unknown> | undefined;
+      if (step && step.type === "function_call" && index !== undefined) {
+        stepToolCalls.set(index, {
+          id: step.id ? String(step.id) : undefined,
+          name: String(step.name ?? ""),
+          // step.start may carry a fully-populated `arguments` object (non-
+          // streamed calls) or an empty `{}` placeholder (streamed calls).
+          argsObj: step.arguments,
+          argsStr: "",
+        });
+      }
+    } else if (eventType === "step.delta" || eventType === "content.delta") {
       const delta = parsed.delta as Record<string, unknown> | undefined;
       if (!delta) continue;
 
       if (delta.type === "text" && typeof delta.text === "string") {
         content += delta.text;
+      } else if (delta.type === "arguments_delta") {
+        // 2.x — argument fragment (a JSON string) keyed by step index.
+        const entry = index !== undefined ? stepToolCalls.get(index) : undefined;
+        if (entry) {
+          if (typeof delta.arguments === "string") {
+            entry.argsStr += delta.arguments;
+          }
+        } else {
+          droppedChunks++;
+          if (droppedChunks === 1) {
+            firstDroppedSample = `arguments_delta with no correlating step.start: ${surrogateSafeSlice(
+              payload,
+              200,
+            )}`;
+          }
+        }
       } else if (delta.type === "function_call") {
+        // Legacy 1.x — full tool call inline in a content.delta.
         toolCalls.push({
           name: String(delta.name ?? ""),
           arguments:
@@ -1238,10 +1284,27 @@ export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
               : JSON.stringify(delta.arguments ?? {}),
           ...(delta.id ? { id: String(delta.id) } : {}),
         });
-      } else if (delta.type === "thought_summary" && typeof delta.text === "string") {
-        reasoning += delta.text;
+      } else if (delta.type === "thought_summary") {
+        // 2.x nests the text under `content.text`; 1.x used a flat `text`.
+        const summaryContent = delta.content as Record<string, unknown> | undefined;
+        if (summaryContent && typeof summaryContent.text === "string") {
+          reasoning += summaryContent.text;
+        } else if (typeof delta.text === "string") {
+          reasoning += delta.text;
+        }
       }
     }
+  }
+
+  // Finalize 2.x tool calls in step-index order.
+  for (const [, tc] of Array.from(stepToolCalls.entries()).sort(([a], [b]) => a - b)) {
+    const args =
+      tc.argsStr !== ""
+        ? tc.argsStr
+        : typeof tc.argsObj === "string"
+          ? tc.argsObj
+          : JSON.stringify(tc.argsObj ?? {});
+    toolCalls.push({ name: tc.name, arguments: args, ...(tc.id ? { id: tc.id } : {}) });
   }
 
   if (toolCalls.length > 0) {


### PR DESCRIPTION
## Summary

Migrates the Gemini **Interactions** mock from the SDK 1.x event/response format to SDK 2.x (the "Interactions breaking changes, May 2026" shapes in `@google/genai` v2) — covering **both** the streamed SSE emitter **and** the non-streaming (unary) JSON response builders. Previously the streamed path produced `interaction.start`/`interaction.complete` + `content.start`/`content.delta`/`content.stop` (**zero `event_type` overlap** with the v2 adapter — a migrated consumer hit its `switch` default for every event and rendered an empty assistant message), and the non-streaming path emitted a 1.x `outputs` envelope the v2 consumer never reads. Both paths now speak v2.

Closes #277.

## What changed — streamed SSE

**`src/gemini-interactions.ts`** — rewrote the three SSE builders:
- Lifecycle: `interaction.start`/`complete` → `interaction.created`/`completed` (id stays populated on both; status text→`completed`, tool calls→`requires_action`).
- Text: `content.start/delta/stop` → `step.start { step: { type: "model_output" } }` / `step.delta { delta: { type: "text", text } }` / `step.stop`.
- Tool calls: call identity (`id`, `name`) now lives on `step.start` with an `arguments: {}` placeholder; arguments stream as `step.delta { delta: { type: "arguments_delta", arguments: "<json-string fragment>" } }`, valid JSON by `step.stop`.
- `writeGeminiInteractionsSSEStream` now counts `step.delta` (not `content.delta`) for the `truncateAfterChunks` budget.

**`src/stream-collapse.ts`** — `collapseGeminiInteractionsSSE` now parses 2.x events (assemble tool calls from `step.start` identity + `arguments_delta` string fragments keyed by index; nested `thought_summary.content.text`), while keeping 1.x parsing for previously recorded fixtures. Hardened against silent data loss: malformed assembled args and index-less / uncorrelated `step.start`/`arguments_delta` are flagged via `droppedChunks`/`firstDroppedSample` rather than written silently.

## What changed — non-streaming (unary) responses

The `@google/genai` v2 Interactions consumer (`extractTextFromInteraction` in `packages/ai-gemini/src/experimental/text-interactions/adapter.ts`, TanStack/ai#781) reads a non-streaming interaction from `interaction.output_text` (string fast-path) then walks `interaction.steps` — `model_output` steps' `content[]` text parts and `function_call` steps — and **never** reads `outputs`. So a v2 consumer doing a non-streaming completion got a silently empty result: the same failure class the streamed path fixed. These builders are reachable (`if (!streaming)` routing in `src/gemini-interactions.ts`).

Migrated `outputs → steps`:
- `buildInteractionsTextResponse` → `{ id, status: "completed", model, role: "model", output_text: content, steps: [{ type: "model_output", content: [{ type: "text", text: content }] }], usage }`.
- `buildInteractionsToolCallResponse` → `steps: toolCalls.map(... { type: "function_call", id, name, arguments: <parsed> })`, status `requires_action`; preserves the malformed-args `try/catch` + `logger.warn` guard (extracted into a shared `buildFunctionCallStep` helper).
- `buildInteractionsContentWithToolCallsResponse` → `output_text` + a `model_output` text step followed by `function_call` steps.

## Tests + drift baseline

Updated unit/integration/collapse tests and `src/__tests__/drift/sdk-shapes.ts` (`geminiInteractionsStreamEventShapes`, `geminiInteractionsResponseShape`, `geminiInteractionsToolCallResponseShape`) to 2.x; added round-trip, multiple/interleaved tool calls, ordering, malformed-args, usage/status, and 1.x backward-compat coverage; flipped the non-streaming unit/integration assertions to the v2 `steps`/`output_text` shape.

## Verification

```bash
grep -E 'event_type: "(step|interaction\.created|interaction\.completed)' dist/gemini-interactions.js
```
matches after build (0 legacy shapes remain). Full suite: **3982 passing / 44 skipped**, prettier + eslint clean, build OK.

Red → green proof for the non-streaming migration (assertions run against the real builder output / real server JSON, not a re-implementation):

```text
# RED (against the old `outputs` source, before the builder change)
 × response builders > builds text response
   → expected undefined to be 'Hello!' // Object.is equality
 × Gemini Interactions — non-streaming > returns tool call response
   → Target cannot be null or undefined.
       Tests  2 failed | 97 skipped (99)
 # (full file pre-fix: 15 failed | 84 passed (99))

# GREEN (after migrating the builders to `steps`)
 ✓ src/__tests__/gemini-interactions.test.ts (99 tests | 97 skipped)
       Tests  2 passed | 97 skipped (99)
 # (full file: 99 passed (99); full suite: 3982 passed | 44 skipped; eslint + prettier clean; build OK)
```

This unblocks re-enabling the `stateful-interactions` e2e test in TanStack/ai#781 once aimock is bumped/released.

## Notes / scope
- One ambiguous case is deliberately not signalled: a streamed `function_call` whose `step.start` carries an empty `{}` placeholder but never receives an `arguments_delta` finalizes to `"{}"`. On the wire that is byte-identical to a legitimately empty-args call, so flagging it would false-positive on every legitimate empty-args call.
- Empty-text non-streaming responses emit `output_text: ""` and a single `model_output` step whose text part is `""` (mirrors the streamed empty-content behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
