### PR TITLE
chore: release v1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.34.0] - 2026-06-24
+
 ### Changed
 
 - Replay matching is content-anchored: `turnIndex` disambiguates, no longer a hard reject gate (#276)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Release **v1.34.0** — bundles the two grouped PRs now on `main`.

## Included
- **#276** (`Changed`) — content-anchored fixture matching; `turnIndex` is a non-fatal disambiguator, not a hard reject gate. New `turnIndexRelaxed` diagnostic + one-shot warn; `AIMOCK_STRICT_TURN_INDEX=1` restores strict replay. Record path stays strict.
- **#279** (`Fixed`) — Gemini Interactions mock now emits the SDK 2.x event protocol on both streamed SSE and non-streaming paths; legacy 1.x recorded fixtures still parse.

## Mechanics
- `package.json` → `1.34.0`; CHANGELOG `[Unreleased]` finalized under `## [1.34.0] - 2026-06-24`.
- Merging to `main` triggers `publish-release.yml` → `npm publish` + tag `v1.34.0`.
- Local gate green: prettier/eslint/build clean, 4055 tests pass.

Minor bump (not v2): both changes ship with back-compat/opt-out.