### PR TITLE
chore: bump remaining version surfaces to 1.34.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "npm",
         "package": "@copilotkit/aimock",
-        "version": "^1.33.0"
+        "version": "^1.34.0"
       },
       "description": "Fixture authoring skill for @copilotkit/aimock — LLM, multimedia (image/TTS/transcription/video), MCP, A2A, AG-UI, vector, embeddings, structured output, sequential responses, streaming physics, record/replay, agent loop patterns, and debugging"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimock",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "Fixture authoring guidance for @copilotkit/aimock — LLM, multimedia, MCP, A2A, AG-UI, vector, and service mocking",
   "author": {
     "name": "CopilotKit"

--- a/charts/aimock/Chart.yaml
+++ b/charts/aimock/Chart.yaml
@@ -3,4 +3,4 @@ name: aimock
 description: Mock infrastructure for AI application testing (OpenAI, Anthropic, Gemini, MCP, A2A, vector)
 type: application
 version: 0.1.0
-appVersion: "1.33.0"
+appVersion: "1.34.0"

--- a/packages/aimock-pytest/src/aimock_pytest/_version.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_version.py
@@ -8,4 +8,4 @@ contains any new server routes/features the client calls (e.g. the reset-split
 control routes ship in the next release). Keep it tracking npm releases.
 """
 
-AIMOCK_VERSION = "1.33.0"
+AIMOCK_VERSION = "1.34.0"


### PR DESCRIPTION
Follow-up to the v1.34.0 release (#280): the release commit bumped `package.json` + `CHANGELOG.md` but missed the other 4 version surfaces, leaving them drifted at 1.33.0.

Bumps to 1.34.0:
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json` (`^1.34.0`)
- `charts/aimock/Chart.yaml` (`appVersion`)
- `packages/aimock-pytest/src/aimock_pytest/_version.py` (`AIMOCK_VERSION`) — functional: pytest default-download users would otherwise get 1.33.0 (old SDK 1.x Gemini Interactions shapes) and fail against the v2 migration in #279.

No republish — `package.json` is already 1.34.0 on npm; this only realigns downstream surfaces.