### PR TITLE
chore: release v1.35.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "npm",
         "package": "@copilotkit/aimock",
-        "version": "^1.34.0"
+        "version": "^1.35.0"
       },
       "description": "Fixture authoring skill for @copilotkit/aimock — LLM, multimedia (image/TTS/transcription/video), MCP, A2A, AG-UI, vector, embeddings, structured output, sequential responses, streaming physics, record/replay, agent loop patterns, and debugging"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimock",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "Fixture authoring guidance for @copilotkit/aimock — LLM, multimedia, MCP, A2A, AG-UI, vector, and service mocking",
   "author": {
     "name": "CopilotKit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.35.0] - 2026-06-27
+
 ### Added
 
 - Native Google Veo async video lifecycle mock — `POST /v1beta/models/{model}:predictLongRunning` submit, `GET /v1beta/operations/{name}` poll through `done:false → done:true`, poll-count progression via `veoVideo`; the Files-API `uri` is served as-is (aimock never proxies or downloads video bytes) (#278)

--- a/charts/aimock/Chart.yaml
+++ b/charts/aimock/Chart.yaml
@@ -3,4 +3,4 @@ name: aimock
 description: Mock infrastructure for AI application testing (OpenAI, Anthropic, Gemini, MCP, A2A, vector)
 type: application
 version: 0.1.0
-appVersion: "1.34.0"
+appVersion: "1.35.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/packages/aimock-pytest/src/aimock_pytest/_version.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_version.py
@@ -8,4 +8,4 @@ contains any new server routes/features the client calls (e.g. the reset-split
 control routes ship in the next release). Keep it tracking npm releases.
 """
 
-AIMOCK_VERSION = "1.34.0"
+AIMOCK_VERSION = "1.35.0"


### PR DESCRIPTION
Release v1.35.0 — bundles both feature PRs merged since 1.34.0:

- **#278 / #282** — native async video-gen mocks: Google Veo (`:predictLongRunning` + operations polling) and xAI Grok Imagine (`/v1/videos/generations`), each with replay + record-mode.
- **#274 / #283** — optional `blocks` array for tool-first / interleaved fixture ordering across all five providers (streaming + non-streaming).

Bumps all version surfaces 1.34.0 → 1.35.0 (package.json, Chart.yaml appVersion, plugin.json, marketplace.json, aimock-pytest _version.py) and cuts the `## [1.35.0]` CHANGELOG heading from `[Unreleased]`. Backward-compatible (minor); both feature sets are additive.

Publish via `npm run release` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)