### PR TITLE
recorder: don't drop fixtures when SDK closes socket after `data: [DONE]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Record mode no longer silently drops fixtures when an SDK closes its socket immediately after `data: [DONE]` (e.g. the OpenAI Python SDK); the completed upstream response is now persisted. Genuine mid-stream aborts (client disconnect before `[DONE]`) still abort upstream and write no fixture (#288)
+
 ## [1.35.0] - 2026-06-27
 
 ### Added

--- a/src/__tests__/recorder-early-client-close.test.ts
+++ b/src/__tests__/recorder-early-client-close.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { FixtureFile } from "../types.js";
+import { proxyAndRecord } from "../recorder.js";
+import { Logger } from "../logger.js";
+
+// ===========================================================================
+// Regression: record mode must persist the fixture when the client closes its
+// socket immediately after consuming `data: [DONE]`, before upstream has fired
+// `res.end`. Some SDKs (notably the OpenAI Python SDK) close the response the
+// instant they read `[DONE]`; if the recorder destroyed the upstream request
+// and discarded buffered chunks on that client-close signal, record mode would
+// silently produce NO fixture even though the full response body was received.
+//
+// This exercises the REAL recorder path (proxyAndRecord -> collapse ->
+// persistFixture) against a live upstream and a real client that disconnects
+// on `[DONE]` — not a stub of the recorder.
+// ===========================================================================
+describe("recorder — early client socket close after [DONE]", () => {
+  it("persists the full fixture when the client closes right after data: [DONE], before upstream end", async () => {
+    // Upstream streams a complete OpenAI chat-completions SSE turn ending with
+    // `data: [DONE]`, then holds the connection open briefly before calling
+    // `res.end()`. This reproduces the real race: the client sees `[DONE]` and
+    // closes its socket while upstream has NOT yet emitted `end`.
+    const UPSTREAM_END_DELAY_MS = 150;
+    const upstream = http.createServer((_upReq, upRes) => {
+      upRes.writeHead(200, { "Content-Type": "text/event-stream" });
+      upRes.write(
+        `data: ${JSON.stringify({ choices: [{ delta: { role: "assistant", content: "Hello" } }] })}\n\n`,
+      );
+      upRes.write(`data: ${JSON.stringify({ choices: [{ delta: { content: " world" } }] })}\n\n`);
+      upRes.write(
+        `data: ${JSON.stringify({ choices: [{ delta: {}, finish_reason: "stop" }] })}\n\n`,
+      );
+      upRes.write("data: [DONE]\n\n");
+      // Deliberately defer `end` so it fires AFTER the client has closed.
+      setTimeout(() => {
+        if (!upRes.writableEnded) upRes.end();
+      }, UPSTREAM_END_DELAY_MS);
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", () => resolve()));
+    const upstreamPort = (upstream.address() as { port: number }).port;
+
+    const fixturePath = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-early-close-"));
+    const logger = new Logger("silent");
+
+    const recorderServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", async () => {
+        const rawBody = Buffer.concat(chunks).toString();
+        await proxyAndRecord(
+          req,
+          res,
+          JSON.parse(rawBody),
+          "openai",
+          "/v1/chat/completions",
+          [],
+          {
+            record: { providers: { openai: `http://127.0.0.1:${upstreamPort}` }, fixturePath },
+            logger,
+          },
+          rawBody,
+        );
+      });
+    });
+    await new Promise<void>((resolve) => recorderServer.listen(0, "127.0.0.1", () => resolve()));
+    const recorderPort = (recorderServer.address() as { port: number }).port;
+
+    try {
+      // Client that closes its socket the instant it observes `data: [DONE]`,
+      // mimicking the OpenAI Python SDK's behavior.
+      await new Promise<void>((resolve) => {
+        const req = http.request(
+          {
+            hostname: "127.0.0.1",
+            port: recorderPort,
+            path: "/v1/chat/completions",
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          },
+          (res) => {
+            let seen = "";
+            res.on("data", (c: Buffer) => {
+              seen += c.toString();
+              if (seen.includes("data: [DONE]")) {
+                // Close immediately, before upstream has fired `end`.
+                req.destroy();
+                resolve();
+              }
+            });
+            res.on("error", () => resolve());
+            res.on("end", () => resolve());
+          },
+        );
+        req.on("error", () => resolve());
+        req.end(
+          JSON.stringify({
+            model: "gpt-4",
+            stream: true,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        );
+      });
+
+      // Allow upstream `end` to fire and the recorder to persist the fixture.
+      await new Promise<void>((resolve) => setTimeout(resolve, UPSTREAM_END_DELAY_MS + 150));
+
+      // The completed response must be recorded despite the early client close.
+      const all = fs.existsSync(fixturePath) ? fs.readdirSync(fixturePath) : [];
+      const jsons = all.filter((f) => f.endsWith(".json"));
+      const tmps = all.filter((f) => f.includes(".tmp."));
+      expect(jsons).toHaveLength(1);
+      expect(tmps).toHaveLength(0);
+
+      const fixture = JSON.parse(
+        fs.readFileSync(path.join(fixturePath, jsons[0]), "utf-8"),
+      ) as FixtureFile;
+      const saved = fixture.fixtures[0].response as { content?: string };
+      // The full streamed content must be captured, not a truncated fragment.
+      expect(saved.content).toBe("Hello world");
+    } finally {
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+      await new Promise<void>((resolve) => recorderServer.close(() => resolve()));
+      fs.rmSync(fixturePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -447,6 +447,7 @@ export async function proxyAndRecord(
   // skip the final res.writeHead/res.end relay at the bottom of this fn.
   let streamedToClient = false;
   let clientDisconnected = false;
+  let sawDone = false;
   let frameTimestamps: number[] = [];
   let streamStartTime = 0;
   const maxProxyBufferBytes = clampMaxBufferBytes(record.maxProxyBufferBytes);
@@ -469,6 +470,7 @@ export async function proxyAndRecord(
     rawBuffer = result.rawBuffer;
     streamedToClient = result.streamedToClient;
     clientDisconnected = result.clientDisconnected;
+    sawDone = result.sawDone;
     frameTimestamps = result.frameTimestamps;
     streamStartTime = result.streamStartTime;
     bufferTruncated = result.bufferTruncated;
@@ -779,13 +781,21 @@ export async function proxyAndRecord(
     }
   }
 
-  // Client may have closed its socket before upstream fired `end`
-  // (e.g. the OpenAI Python SDK closes the response immediately after
-  // consuming `data: [DONE]`). Because we no longer destroy the upstream
-  // request on client close (see the `clientRes.on("close")` handler
-  // below), reaching this point means upstream still ran to completion
-  // and the buffered body is intact — so recording the fixture is safe.
+  // Client may have closed its socket before upstream fired `end`.
+  // Distinguish two cases based on whether the SSE `[DONE]` marker was seen:
+  //   - sawDone=true: client closed after consuming `data: [DONE]` (e.g. the
+  //     OpenAI Python SDK closes the socket the moment it reads `[DONE]`).
+  //     Upstream ran to completion; the buffered body is intact. Log and
+  //     proceed to persist the full fixture.
+  //   - sawDone=false: genuine mid-stream abort. The buffered body is partial;
+  //     saving it would produce a corrupt fixture. Skip fixture persistence.
   if (clientDisconnected) {
+    if (!sawDone) {
+      defaults.logger.warn(
+        "Client disconnected mid-stream — skipping fixture save to avoid truncated data",
+      );
+      return "relayed";
+    }
     defaults.logger.warn(
       "Client closed connection before upstream end — upstream response completed, recording full fixture",
     );
@@ -1003,6 +1013,15 @@ function makeUpstreamRequest(
    * loud (502) rather than relay this truncated body as a success status.
    */
   hardCeilingExceeded: boolean;
+  /**
+   * True when the SSE terminal marker `data: [DONE]` was observed in the
+   * upstream stream before the client disconnected. When `clientDisconnected`
+   * is true AND `sawDone` is true, the client closed after consuming `[DONE]`
+   * (e.g. the OpenAI Python SDK) — the stream was logically complete, so the
+   * fixture SHOULD be persisted. When `sawDone` is false the disconnect was a
+   * genuine mid-stream abort and the fixture MUST NOT be persisted.
+   */
+  sawDone: boolean;
 }> {
   return new Promise((resolve, reject) => {
     const transport = target.protocol === "https:" ? https : http;
@@ -1056,6 +1075,16 @@ function makeUpstreamRequest(
 
         let streamedToClient = false;
         let clientDisconnected = false;
+        // True once the SSE terminal marker `data: [DONE]` has been seen in the
+        // upstream stream. Used to distinguish two client-close scenarios:
+        //   1. Close AT/AFTER `[DONE]`: the stream is logically complete (e.g.
+        //      the OpenAI Python SDK closes the socket the moment it reads
+        //      `[DONE]`, before upstream fires `res.end`). The upstream should
+        //      NOT be torn down — let it finish and persist the full fixture.
+        //   2. Close BEFORE `[DONE]`: genuine mid-stream abort. Restore the
+        //      original teardown so upstream is destroyed and no partial fixture
+        //      is persisted.
+        let sawDone = false;
         if (isProgressiveStream && clientRes && !clientRes.headersSent) {
           const relayHeaders: Record<string, string> = {
             "Cache-Control": "no-cache, no-transform",
@@ -1073,20 +1102,27 @@ function makeUpstreamRequest(
           // before the first data chunk arrives.
           if (typeof clientRes.flushHeaders === "function") clientRes.flushHeaders();
           streamedToClient = true;
-          // Track client disconnects but do NOT destroy the upstream
-          // request. Some SDKs (notably the OpenAI Python SDK) close
-          // their socket the instant they consume `data: [DONE]`, before
-          // upstream has fired `res.end`. If we destroyed upstream on
-          // that signal we would lose the tail of the response — or the
-          // whole response, when the SDK closes right after `[DONE]` —
-          // and record mode would silently produce no fixture. Letting
-          // upstream finish means we still capture a complete body; the
-          // `!clientDisconnected` guard inside `onUpstreamData` already
-          // prevents further writes to the now-closed client socket, so
-          // no data is written to a dead peer.
           clientRes.on("close", () => {
             if (!clientRes.writableFinished) {
               clientDisconnected = true;
+              if (!sawDone) {
+                // Genuine mid-stream abort — tear down upstream so it stops
+                // producing data, and clear all parse state so no partial
+                // fixture is persisted. Mirrors the pre-#288 behavior.
+                req.destroy();
+                res.removeListener("data", onUpstreamData);
+                chunks.length = 0;
+                bufferedBytes = 0;
+                frameTimestamps.length = 0;
+                frameBuffer = "";
+                binaryFrameBuffer = Buffer.alloc(0);
+              }
+              // If sawDone is true: client closed after consuming `[DONE]`
+              // (e.g. the OpenAI Python SDK). The upstream is logically
+              // complete; let it run to `res.end` so the full body is
+              // buffered and the fixture can be persisted. The
+              // `!clientDisconnected` guard inside `onUpstreamData` already
+              // prevents further writes to the now-closed client socket.
             }
           });
         }
@@ -1218,8 +1254,12 @@ function makeUpstreamRequest(
                 tripTruncation("frame");
                 break;
               }
-              if (parts[fi].trim().length > 0) {
+              const frame = parts[fi].trim();
+              if (frame.length > 0) {
                 frameTimestamps.push(Date.now());
+                // Track the SSE terminal marker so the client-close handler
+                // can distinguish a post-[DONE] close from a mid-stream abort.
+                if (frame === "data: [DONE]") sawDone = true;
               }
             }
             // Last part stays in buffer (may be incomplete). Skip when the
@@ -1340,6 +1380,7 @@ function makeUpstreamRequest(
             truncationCap,
             totalBytes,
             hardCeilingExceeded,
+            sawDone,
           });
         });
       },

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -779,14 +779,16 @@ export async function proxyAndRecord(
     }
   }
 
-  // If the client disconnected mid-stream, the collected data is likely
-  // truncated.  Saving a partial fixture is worse than saving none — skip
-  // fixture persistence entirely.
+  // Client may have closed its socket before upstream fired `end`
+  // (e.g. the OpenAI Python SDK closes the response immediately after
+  // consuming `data: [DONE]`). Because we no longer destroy the upstream
+  // request on client close (see the `clientRes.on("close")` handler
+  // below), reaching this point means upstream still ran to completion
+  // and the buffered body is intact — so recording the fixture is safe.
   if (clientDisconnected) {
     defaults.logger.warn(
-      "Client disconnected mid-stream — skipping fixture save to avoid truncated data",
+      "Client closed connection before upstream end — upstream response completed, recording full fixture",
     );
-    return "relayed";
   }
 
   // Build RecordedTimings from frame timestamps captured during streaming.
@@ -1071,25 +1073,20 @@ function makeUpstreamRequest(
           // before the first data chunk arrives.
           if (typeof clientRes.flushHeaders === "function") clientRes.flushHeaders();
           streamedToClient = true;
-          // Stop relaying if the client disconnects mid-stream.
-          // Check writableFinished to distinguish normal completion (where
-          // "close" also fires) from premature client disconnects.
+          // Track client disconnects but do NOT destroy the upstream
+          // request. Some SDKs (notably the OpenAI Python SDK) close
+          // their socket the instant they consume `data: [DONE]`, before
+          // upstream has fired `res.end`. If we destroyed upstream on
+          // that signal we would lose the tail of the response — or the
+          // whole response, when the SDK closes right after `[DONE]` —
+          // and record mode would silently produce no fixture. Letting
+          // upstream finish means we still capture a complete body; the
+          // `!clientDisconnected` guard inside `onUpstreamData` already
+          // prevents further writes to the now-closed client socket, so
+          // no data is written to a dead peer.
           clientRes.on("close", () => {
             if (!clientRes.writableFinished) {
               clientDisconnected = true;
-              req.destroy();
-              // Stop in-flight buffering immediately rather than draining the
-              // upstream socket under backpressure: detach the data listener so
-              // no further chunks accumulate, and free what's already buffered.
-              // The promise still settles via the 'end'/'error'/'close' the
-              // destroyed request emits; collapse/recording is skipped because
-              // the client disconnected.
-              res.removeListener("data", onUpstreamData);
-              chunks.length = 0;
-              bufferedBytes = 0;
-              frameTimestamps.length = 0;
-              frameBuffer = "";
-              binaryFrameBuffer = Buffer.alloc(0);
             }
           });
         }


### PR DESCRIPTION
## Summary

In record mode, `clientRes.on("close")` currently calls `req.destroy()` on the upstream request whenever the client closes its socket before `clientRes.writableFinished`, and downstream logic then skips saving the fixture entirely.

That's a reasonable guard against saving a truncated body when the client really did die mid-stream, but it also fires in a common benign case: SDKs that eagerly close their HTTP response the instant they consume the terminating SSE frame. The OpenAI Python SDK does exactly this — its `Stream.__stream__` breaks out of the iterator loop on `data: [DONE]` and its `finally: await response.aclose()` closes the socket immediately, often before upstream has fired its own `end` event.

Result: record mode silently produces **zero fixtures** for any OpenAI-SDK-driven traffic, even though the full response was received and rendered end-to-end by the caller. This is very easy to hit and hard to diagnose (the only signal in the logs is `Proxy request failed: aborted`, which looks like an upstream problem).

## Fix

Two small changes in `src/recorder.ts`:

1. In the `clientRes.on("close")` handler for progressive-stream responses: **stop destroying the upstream request** and stop discarding the already-buffered chunks. Just record that the client disconnected. Upstream is allowed to run to completion so the fixture body is complete. The existing `!clientDisconnected` guard in `onUpstreamData` already prevents any further writes to the closed client socket, so no data is written to a dead peer.

2. In the post-collapse `if (clientDisconnected)` branch: **remove the `return "relayed"`** — since we no longer destroy upstream on client close, reaching that point means upstream did complete cleanly and the buffered body is intact, so persisting the fixture is safe. The warn message is kept (retitled) so the disconnect is still observable.

## Repro (before fix)

Start aimock in record mode against any OpenAI-compatible upstream:

```
npx @copilotkit/aimock llmock \
  -p 4010 -f ./fixtures \
  --record --provider-openai https://your-openai-compatible-gw
```

Then drive it with the OpenAI Python SDK:

```python
from openai import AsyncOpenAI
import asyncio

async def main():
    client = AsyncOpenAI(
        base_url="http://127.0.0.1:4010/v1",
        api_key="sk-...",
        timeout=3600.0,
    )
    stream = await client.chat.completions.create(
        model="gpt-4o-mini",
        messages=[{"role": "user", "content": "hi"}],
        stream=True,
    )
    async for _ in stream:
        pass

asyncio.run(main())
```

Observed logs:

```
[aimock] NO FIXTURE MATCH — proxying to https://.../v1/chat/completions
[aimock] Proxy request failed: aborted
```

No fixture is written. The SDK, however, receives the full response — the abort is aimock destroying upstream in reaction to the SDK's normal post-`[DONE]` socket close.

## After fix

Same repro produces:

```
[aimock] NO FIXTURE MATCH — proxying to https://.../v1/chat/completions
[aimock] Streaming response detected (text/event-stream) — collapsing to fixture
[aimock] Client closed connection before upstream end — upstream response completed, recording full fixture
[aimock] Response recorded → ./fixtures/recorded/openai-YYYY-...-.json
```

Verified locally against a live OpenAI-compatible gateway with the OpenAI Python SDK 2.30.0 + httpx 0.28.1; 714 SSE chunks streamed to the SDK, fixture written to disk, replay works.

## Safety notes

- The "avoid saving truncated data" intent of the original guard is preserved for real mid-stream failures: those manifest as upstream errors (`res.on("error")`) or upstream timeouts (`req.on("timeout")` → `req.destroy(Error(...))`), and `makeUpstreamRequest` rejects with that error — control never reaches the `clientDisconnected` branch, and no fixture is written.
- The only behavior change for genuine client aborts is that upstream now runs to completion in the background. In practice this is a few KB of buffered SSE frames per request; unbounded growth is still bounded by the existing `maxProxyBufferBytes` / `maxProxyBufferFrames` caps.
