### PR TITLE
fix(drift): surface known-models canary drift as critical instead of crashing

### DIFF
--- a/scripts/drift-report-collector.ts
+++ b/scripts/drift-report-collector.ts
@@ -19,6 +19,7 @@
 import { execSync } from "node:child_process";
 import { existsSync, statSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { DriftEntry, DriftReport, DriftSeverity, ParsedDiff } from "./drift-types.js";
 
@@ -178,7 +179,7 @@ const AGUI_DRIFT_TEST = "src/__tests__/drift/agui-schema.drift.ts";
  */
 const VALID_SEVERITIES = new Set<DriftSeverity>(["critical", "warning", "info"]);
 
-function parseDriftBlock(text: string): { context: string; diffs: ParsedDiff[] } | null {
+export function parseDriftBlock(text: string): { context: string; diffs: ParsedDiff[] } | null {
   const headerMatch = text.match(/API DRIFT DETECTED:\s*(.+)/);
   if (!headerMatch) return null;
 
@@ -225,7 +226,7 @@ function parseDriftBlock(text: string): { context: string; diffs: ParsedDiff[] }
  *   "OpenAI Chat (non-streaming text)" → "OpenAI Chat"
  *   "Anthropic Claude drift" → "Anthropic Claude"
  */
-function extractProviderName(text: string): string | null {
+export function extractProviderName(text: string): string | null {
   // Try matching against known provider keys (longest first to avoid partial matches)
   const sorted = Object.keys(PROVIDER_MAP).sort((a, b) => b.length - a.length);
   for (const key of sorted) {
@@ -240,9 +241,146 @@ function extractProviderName(text: string): string | null {
  * "OpenAI Chat (non-streaming text)" → "non-streaming text"
  * "Anthropic Claude (streaming tool call)" → "streaming tool call"
  */
-function extractScenario(context: string): string {
+export function extractScenario(context: string): string {
   const parenMatch = context.match(/\(([^)]+)\)/);
   return parenMatch ? parenMatch[1] : context;
+}
+
+// ---------------------------------------------------------------------------
+// Known-models canary recognizer
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated result of parsing the ws-realtime canary failure.
+ *
+ * CLASS 3: `ids` holds ONLY genuine model ids (never a prose sentinel). The
+ * "some ids were truncated in CI output" fact is a boolean flag, not a fake id,
+ * so a non-model annotation can never flow into `DriftEntry.real` downstream.
+ *
+ * CLASS 2: `noGA` marks the hasGA-false mode — the GA realtime family was
+ * renamed/removed or the credential could not see any realtime models. `ids`
+ * then carries the OBSERVED realtime models (possibly empty), not "unknown"
+ * ones. Either mode is a critical, exit-2 drift signal.
+ */
+export interface CanaryParseResult {
+  ids: string[];
+  truncated?: boolean;
+  noGA?: boolean;
+  /**
+   * NO_GA mode only: the unknown-model list observed in the SAME run. Because
+   * the hasGA assertion short-circuits the later unknown-models assertion, the
+   * NO_GA marker carries both lists (`… | UNKNOWN_REALTIME_MODELS=…`); this
+   * field holds the unknown segment so the combined case loses no information.
+   */
+  unknownIds?: string[];
+}
+
+/**
+ * Parse the ws-realtime canary assertion failure. Two canary modes exist:
+ *
+ * 1. UNKNOWN models — `expect(unknown, \`UNKNOWN_REALTIME_MODELS=…\`).toEqual([])`
+ *    shape: `AssertionError: UNKNOWN_REALTIME_MODELS=a,b: expected [ 'a', …(1) ]
+ *    to deeply equal []`.
+ * 2. NO GA models (CLASS 2) — `expect(hasGA, \`NO_GA_REALTIME_MODELS=…\`).toBe(true)`
+ *    shape: `AssertionError: NO_GA_REALTIME_MODELS=x,y: expected false to be true`.
+ *
+ * PRIMARY SOURCE: the `*_REALTIME_MODELS=` marker carries the FULL, non-truncated
+ * comma-joined list verbatim (vitest truncates the printed array with `…(N)` /
+ * `... (N)`, so ids beyond the first are unrecoverable from the array alone).
+ *
+ * FALLBACK (unknown-mode only, marker missing/mangled): parse the printed array
+ * and set `truncated` when a CI ellipsis is present.
+ *
+ * Returns a CanaryParseResult, or null if the message is not a canary shape.
+ */
+export function parseKnownModelsCanary(text: string): CanaryParseResult | null {
+  // CLASS 2 PRIMARY: hasGA-false marker. The GA family is gone/unreachable — a
+  // critical signal even when the observed list is empty. Recognize it FIRST so
+  // the "expected false to be true" shape is a structured entry, not a crash.
+  const noGaMatch = text.match(/NO_GA_REALTIME_MODELS=(.*?)(?::\s*expected\b|\n|$)/);
+  if (noGaMatch) {
+    // The NO_GA marker carries BOTH the observed realtime models AND the
+    // unknown-model list observed in the same run, joined as
+    // `<observed> | UNKNOWN_REALTIME_MODELS=<unknown>`. Split the two apart so
+    // neither list pollutes the other (the combined no-GA + unknown case must
+    // not lose the unknown list, since the hasGA assertion short-circuits the
+    // later unknown-models assertion). A legacy message without the unknown
+    // segment still parses — `split` yields a single element.
+    const [observedRaw, unknownRaw] = noGaMatch[1].split(/\s*\|\s*UNKNOWN_REALTIME_MODELS=/);
+    const toList = (s: string | undefined): string[] =>
+      (s ?? "")
+        .split(",")
+        .map((v) => v.trim())
+        .filter((v) => v.length > 0);
+    const ids = toList(observedRaw);
+    const unknownIds = toList(unknownRaw);
+    return unknownIds.length > 0 ? { ids, noGA: true, unknownIds } : { ids, noGA: true };
+  }
+
+  // UNKNOWN-mode PRIMARY: stable marker carrying the full, non-truncated list.
+  // Scan the whole message (not just line 0) so a leading blank line cannot hide
+  // it. Capture the ENTIRE value up to the vitest boilerplate (`: expected …`)
+  // or end-of-line. On a malformed/empty marker we fall THROUGH to the
+  // printed-array fallback so a recoverable id in the array is still surfaced.
+  const markerMatch = text.match(/UNKNOWN_REALTIME_MODELS=(.*?)(?::\s*expected\b|\n|$)/);
+  if (markerMatch) {
+    const ids = markerMatch[1]
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (ids.length > 0) return { ids };
+  }
+
+  // FALLBACK GATE: the printed-array fallback matches the GENERIC vitest shape
+  // `expected [ ... ] to deeply equal []`, which ANY `toEqual([])` assertion in
+  // ANY provider's test emits. On its own that shape is NOT a canary signal — a
+  // non-canary failure (e.g. a different provider asserting an empty array whose
+  // observed value happens to be a secret or an object shape) would otherwise be
+  // misclassified as OpenAI-Realtime known-models drift and have its arbitrary
+  // array contents relabeled as "unknown model ids". So the fallback fires ONLY
+  // when the message is clearly the ws-realtime known-models canary. Two
+  // recognizers (either suffices):
+  //   1. the realtime-canary marker family (`UNKNOWN_REALTIME_MODELS=` /
+  //      `NO_GA_REALTIME_MODELS=`), even mangled/partial — the marker paths
+  //      above only fall through here when the marker VALUE was empty/unusable,
+  //      but the TOKEN itself still identifies the canary; and
+  //   2. the canary's origin file in the stack trace — a real canary failure
+  //      ALWAYS carries an `at …/ws-realtime.drift.ts` frame.
+  // A generic non-canary `toEqual([])` failure has neither, so it returns null
+  // and falls through to the collector's normal unparseable/fail-loud handling.
+  const isRealtimeCanaryContext =
+    /_REALTIME_MODELS=/.test(text) || /ws-realtime\.drift\.ts/.test(text);
+  if (!isRealtimeCanaryContext) return null;
+
+  // FALLBACK: no (usable) marker but a confirmed canary context. Best-effort
+  // parse of the printed array on the first line. The canary assertion is always
+  // on line 1.
+  const firstLine = text.split("\n")[0];
+
+  // Shape: ...: expected [ ... ] to deeply equal []
+  const canaryMatch = firstLine.match(/expected\s*\[([^\]]*)\]\s*to deeply equal \[\]/);
+  if (!canaryMatch) return null;
+
+  const inner = canaryMatch[1].trim();
+
+  // Extract quoted model ids from the bracket list
+  const ids: string[] = [];
+  const idPattern = /'([^']+)'/g;
+  let m: RegExpExecArray | null;
+  while ((m = idPattern.exec(inner)) !== null) {
+    ids.push(m[1]);
+  }
+
+  // CI truncation marker in BOTH forms: single-glyph `…(N)` and three-dot ASCII
+  // `... (N)`. CLASS 3: this is a BOOLEAN flag — never a synthetic id.
+  const truncated = /(?:…|\.{3})\s*\(\d+\)/.test(inner);
+
+  // A genuinely-empty inner list with no truncation (`expected [] to deeply
+  // equal []`) means the canary's `unknown` array was empty — no drift to
+  // surface. Return null so it is not a spurious entry.
+  if (ids.length === 0 && !truncated) return null;
+
+  return truncated ? { ids, truncated: true } : { ids };
 }
 
 // ---------------------------------------------------------------------------
@@ -324,7 +462,162 @@ function runDriftTests(): VitestJsonResult {
   }
 }
 
-function collectDriftEntries(results: VitestJsonResult): DriftEntry[] {
+/**
+ * Distinguish genuine infrastructure errors from genuine-but-unparseable drift
+ * reports. Returns true when the whole batch of unparseable messages should be
+ * SWALLOWED as benign infra (collector exits 0); false means genuine drift is
+ * present and the collector must throw.
+ *
+ * A false "infra" classification here is dangerous: it makes the collector exit
+ * 0 and silently drop real drift.
+ *
+ * F2: `/AssertionError/i` is DELIBERATELY NOT an infra indicator. Every vitest
+ * drift failure is an AssertionError, so treating it as benign infra masks real
+ * drift. Infra failures announce themselves with network/HTTP/parse markers
+ * below; a bare AssertionError is drift until proven infra.
+ *
+ * A3: BOTH the infra-indicator scan and the drift-like scan run against the
+ * SAME normalized text (stack-trace `  at …` frames stripped). An earlier
+ * version scanned the RAW message for infra indicators but the stack-stripped
+ * message for drift indicators; that asymmetry could tip the benign-infra gate
+ * true and silently drop genuine drift. Normalizing both identically keeps the
+ * two scans from ever disagreeing on the same input.
+ */
+// Infra indicators. IMPORTANT (CLASS 1 / uniform anchoring): every infra
+// indicator is defined here as a BARE phrase (the source string only, no `^`,
+// no flags, no anchoring-defeating `(?:.*:\s*)?` prefix). The line-anchor is
+// applied UNIFORMLY by `anchorInfraIndicator` below, so no single indicator can
+// be individually mis-anchored and a phrase added to this list later is
+// automatically anchored the same way as its siblings.
+//
+// The anchor requires the phrase to BE the failure reason at the START of a
+// line (optional leading whitespace, an optional `HTTP ` prefix for the numeric
+// ones), followed by a word boundary. This means a genuine infra REASON like
+// `empty response`, `fetch failed`, or `API returned 503` at line start still
+// classifies as infra, while a labelled drift-body VALUE like
+// `     Real: API returned 503` / `     Real:    empty response` can NEVER trip
+// the gate (the phrase is not at the line start, it follows a `Field:` label).
+//
+// Each entry is a bare `source` phrase plus a `boundary` flag: `true` appends a
+// trailing `\b` (word-like phrases such as `empty response` / `ECONNREFUSED`),
+// `false` omits it for phrases whose next char is punctuation (`INFRA_ERROR:`)
+// or a tag (`<!DOCTYPE`, `<html`) where `\b` would misfire.
+interface InfraIndicatorSpec {
+  /** Bare regex source for the phrase — no anchor, no flags. */
+  source: string;
+  /** Append a trailing `\b` word boundary (default true). */
+  boundary?: boolean;
+}
+
+const INFRA_INDICATOR_SPECS: InfraIndicatorSpec[] = [
+  { source: "INFRA_ERROR:", boundary: false },
+  { source: "API returned \\d{3}" },
+  { source: "status\\s*:?\\s*\\d{3}" },
+  { source: "<!DOCTYPE", boundary: false },
+  { source: "<html", boundary: false },
+  { source: "failed to parse JSON" },
+  { source: "empty response" },
+  { source: "fetch failed" },
+  { source: "ECONNREFUSED" },
+  { source: "ETIMEDOUT" },
+  { source: "ENOTFOUND" },
+  { source: "network error" },
+  { source: "API unavailable" },
+  { source: "returned no SSE events" },
+  { source: "returned empty body" },
+  { source: "waitUntil timeout" },
+  { source: "STACK_TRACE_ERROR" },
+];
+
+/**
+ * Wrap a bare infra phrase into a uniformly line-anchored, case-insensitive,
+ * multiline regex. The anchor is IDENTICAL for every indicator:
+ *
+ *   ^\s*(?:HTTP\s+)?<phrase>[\b]
+ *
+ * so the phrase must be the failure reason at the start of a line. A labelled
+ * drift-body value (`Real: <phrase>`) is preceded by a `Field:` label and thus
+ * never matches. This is the single choke point that makes anchoring uniform —
+ * there is no per-indicator anchoring to get wrong.
+ */
+function anchorInfraIndicator(spec: InfraIndicatorSpec): RegExp {
+  const boundary = spec.boundary === false ? "" : "\\b";
+  return new RegExp(`^\\s*(?:HTTP\\s+)?${spec.source}${boundary}`, "im");
+}
+
+/**
+ * The bare infra phrase sources, exported so tests can iterate the REAL list
+ * (property-based test in drift-collector.test.ts) rather than a hand-copied
+ * subset. A future indicator added to INFRA_INDICATOR_SPECS is automatically
+ * covered — if it were somehow mis-anchored the property test would fail.
+ */
+export const INFRA_INDICATOR_SOURCES: readonly string[] = INFRA_INDICATOR_SPECS.map(
+  (s) => s.source,
+);
+
+/**
+ * A concrete failure-reason sample for a given bare infra phrase source, used
+ * by the property-based test to synthesize both a bare (line-start, infra) and
+ * a labelled (`Real: …`, drift) line. Regex metacharacters in the source
+ * (`\d{3}`, `\s*:?`, tag `<`) are replaced with literal, matching sample text.
+ */
+export function infraIndicatorSample(source: string): string {
+  return source
+    .replace(/\\s\*:\?\\s\*/g, ": ") // status\s*:?\s* → "status: "
+    .replace(/\\s\*/g, " ")
+    .replace(/\\d\{3\}/g, "503")
+    .replace(/\\d\+/g, "503")
+    .replace(/\\b/g, "");
+}
+
+const INFRA_INDICATORS: RegExp[] = INFRA_INDICATOR_SPECS.map(anchorInfraIndicator);
+
+// Drift-like indicators. A genuine drift failure is drift until proven infra.
+// The `expected … to be/equal/deeply equal …` shape is the canonical vitest
+// assertion body for our drift/canary assertions — the OLD `/expected.*but/i`
+// guard was DEAD (vitest never emits "expected … but …"), so it never fired and
+// left bare assertion failures indistinguishable from infra. This repaired
+// guard fires on the shapes vitest actually emits, so an unrecognized assertion
+// failure counts as drift-like and forces a fail-loud (throw → exit 1).
+const DRIFT_LIKE_INDICATORS = [
+  /drift/i,
+  /mismatch/i,
+  /\bexpected\b.*\bto\s+(?:be|equal|deeply equal|contain|match|have)\b/i,
+  /LLMOCK DRIFT/i,
+  /API DRIFT/i,
+];
+
+/** Strip vitest stack-trace frames (`  at …`) so filenames like
+ * "ws-realtime.drift.ts" cannot influence content-based classification. */
+function stripStackFrames(msg: string): string {
+  return msg
+    .split("\n")
+    .filter((line) => !/^\s*at\s/.test(line))
+    .join("\n");
+}
+
+export function classifyUnparseableAsInfra(unparseableMessages: string[]): boolean {
+  // CLASS 1 — fail-loud on absent evidence. No messages means NO positive infra
+  // evidence, so this is NOT a benign "all clear". `[].every(...)` is vacuously
+  // true, which would have wrongly classified an empty batch as infra and made
+  // the collector exit 0. Root invariant: unrecognized ⇒ fail loud, never a
+  // false all-clear.
+  if (unparseableMessages.length === 0) return false;
+
+  // Normalize ONCE per message; both scans consume the identical normalized
+  // text (A3 — the two scans must never disagree due to differing inputs).
+  const normalized = unparseableMessages.map(stripStackFrames);
+
+  // Infra requires POSITIVE evidence on EVERY message AND zero drift signal on
+  // ALL of them. If any message lacks an infra indicator, or any message looks
+  // drift-like, we do NOT swallow — the caller throws (exit 1, investigate).
+  const allInfraErrors = normalized.every((msg) => INFRA_INDICATORS.some((re) => re.test(msg)));
+  const anyDriftLike = normalized.some((msg) => DRIFT_LIKE_INDICATORS.some((re) => re.test(msg)));
+
+  return allInfraErrors && !anyDriftLike;
+}
+
+export function collectDriftEntries(results: VitestJsonResult): DriftEntry[] {
   const entries: DriftEntry[] = [];
   const unmapped: string[] = [];
   let unparseable = 0;
@@ -337,6 +630,100 @@ function collectDriftEntries(results: VitestJsonResult): DriftEntry[] {
       const fullMessage = assertion.failureMessages.join("\n");
       const parsed = parseDriftBlock(fullMessage);
       if (!parsed || parsed.diffs.length === 0) {
+        // Check for the ws-realtime canary assertion shapes BEFORE classifying
+        // as unparseable — both the unknown-models mode and the hasGA-false mode
+        // (CLASS 2) are genuine, critical drift and must be surfaced (exit 2),
+        // never crashed as unparseable (exit 1).
+        const canary = parseKnownModelsCanary(fullMessage);
+        if (canary !== null) {
+          const mapping = PROVIDER_MAP["OpenAI Realtime"];
+
+          // Build the critical diffs. F4: severity MUST be "critical" — the Fix
+          // Drift workflow (.github/workflows/fix-drift.yml) gates remediation
+          // entirely on exit code 2, which main() emits only when
+          // criticalCount > 0. F5: this canary is real-API-only — there is no
+          // mock leg, so we never mislabel a model id as a mock value.
+          const NO_MOCK_LEG = "<no mock leg — real-API-only canary>";
+          const diffs: ParsedDiff[] = canary.noGA
+            ? [
+                // CLASS 2: the GA realtime family is renamed/removed or the
+                // credential cannot see it. Surface the observed models (may be
+                // empty) so the auto-fix prompt knows what IS present.
+                {
+                  severity: "critical" as const,
+                  issue:
+                    "GA realtime family unavailable — no known GA model in the OpenAI realtime list. " +
+                    "OpenAI may have renamed/removed the GA family, or the realtime credential cannot see it. " +
+                    "Update the gaModels list in ws-realtime.drift.ts.",
+                  path: "gaModels",
+                  expected: "(at least one GA realtime model present)",
+                  real:
+                    canary.ids.length > 0
+                      ? `observed realtime models: ${canary.ids.join(", ")}`
+                      : "no realtime models observed",
+                  mock: NO_MOCK_LEG,
+                },
+                // The hasGA assertion short-circuits the later unknown-models
+                // assertion, so surface any unknown models observed in the SAME
+                // run here (carried by the NO_GA marker). Without this, a run
+                // that is BOTH no-GA AND has new unknown models would lose the
+                // unknown list from the auto-fix prompt. One diff per id — each
+                // is a genuine model id (never a prose sentinel).
+                ...(canary.unknownIds ?? []).map((id) => ({
+                  severity: "critical" as const,
+                  issue:
+                    "Unknown realtime model detected (observed in the same run as the missing GA " +
+                    "family) — add to knownModels in ws-realtime.drift.ts",
+                  path: "knownModels",
+                  expected: "(not in knownModels set)",
+                  real: id,
+                  mock: NO_MOCK_LEG,
+                })),
+              ]
+            : // CLASS 3: only genuine model ids become `real` diffs. The
+              // truncation fact is carried as a SEPARATE diff whose `real` is a
+              // count note, never a fake model id in a per-model slot.
+              [
+                ...canary.ids.map((id) => ({
+                  severity: "critical" as const,
+                  issue:
+                    "Unknown realtime model detected — add to knownModels in ws-realtime.drift.ts",
+                  path: "knownModels",
+                  expected: "(not in knownModels set)",
+                  real: id,
+                  mock: NO_MOCK_LEG,
+                })),
+                ...(canary.truncated
+                  ? [
+                      {
+                        severity: "critical" as const,
+                        issue:
+                          "Additional unknown realtime models were truncated in CI output — " +
+                          "the full list is unrecoverable without the UNKNOWN_REALTIME_MODELS= marker. " +
+                          "Re-run with the marker to enumerate them.",
+                        path: "knownModels[truncated]",
+                        // CLASS 3: `real`/`expected` NEVER carry a prose sentinel.
+                        // The truncation fact lives entirely in `issue`/`path`;
+                        // there is no observed model value to report here.
+                        expected: "<unavailable>",
+                        real: "<unavailable>",
+                        mock: NO_MOCK_LEG,
+                      },
+                    ]
+                  : []),
+              ];
+
+          entries.push({
+            provider: "OpenAI Realtime",
+            scenario: "known-models canary",
+            builderFile: mapping.builderFile,
+            builderFunctions: mapping.builderFunctions,
+            typesFile: mapping.typesFile ?? null,
+            sdkShapesFile: SDK_SHAPES_FILE,
+            diffs,
+          });
+          continue;
+        }
         unparseable++;
         continue;
       }
@@ -391,39 +778,7 @@ function collectDriftEntries(results: VitestJsonResult): DriftEntry[] {
       console.warn(`  Unparseable failure message (first 300 chars): ${msg.slice(0, 300)}`);
     }
 
-    // Distinguish infrastructure errors from broken drift report formats
-    const infraIndicators = [
-      /^INFRA_ERROR:/m,
-      /API returned \d{3}/i,
-      /status \d{3}/i,
-      /<!DOCTYPE/i,
-      /<html/i,
-      /failed to parse JSON/i,
-      /empty response/i,
-      /fetch failed/i,
-      /ECONNREFUSED/i,
-      /ETIMEDOUT/i,
-      /ENOTFOUND/i,
-      /network error/i,
-      /API unavailable/i,
-      /returned no SSE events/i,
-      /returned empty body/i,
-      /waitUntil timeout/i,
-      /AssertionError/i,
-      /^Error:/m,
-      /at\s+\S+\s+\(file:/,
-      /STACK_TRACE_ERROR/,
-    ];
-    const driftLikeIndicators = [/drift/i, /mismatch/i, /expected.*but/i, /LLMOCK DRIFT/i];
-
-    const allInfraErrors = unparseableMessages.every((msg) =>
-      infraIndicators.some((re) => re.test(msg)),
-    );
-    const anyDriftLike = unparseableMessages.some((msg) =>
-      driftLikeIndicators.some((re) => re.test(msg)),
-    );
-
-    if (allInfraErrors && !anyDriftLike) {
+    if (classifyUnparseableAsInfra(unparseableMessages)) {
       console.warn(
         `WARNING: ${unparseable} test failure(s) appear to be API/infrastructure errors ` +
           `(not drift reports). Continuing with 0 drift entries.`,
@@ -700,9 +1055,28 @@ function main(): void {
   console.log("No critical diffs found.");
 }
 
-try {
-  main();
-} catch (err: unknown) {
-  console.error("Fatal error:", err);
-  process.exit(1);
+/**
+ * Entry-point guard: only run main() when this module is executed directly
+ * (e.g. `npx tsx scripts/drift-report-collector.ts` from the Fix Drift
+ * workflow), NOT when it is imported (e.g. by the vitest suite that exercises
+ * the exported pure functions). Without this guard, importing the module for
+ * tests would spawn the whole drift suite via execSync and call process.exit.
+ */
+function isDirectRun(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return fileURLToPath(import.meta.url) === resolve(entry);
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
+  try {
+    main();
+  } catch (err: unknown) {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  }
 }

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -1,39 +1,37 @@
 /**
- * Tests for key functions in scripts/drift-report-collector.ts
+ * Tests for the drift-report collector's pure functions.
  *
- * Since scripts/ is outside the rootDir for the main tsconfig (and vitest
- * only covers src/__tests__), these functions are duplicated here as local
- * test helpers to keep the test runner config intact. Any changes to the
- * originals must be reflected here.
+ * These tests import and exercise the REAL exported functions from
+ * scripts/drift-report-collector.ts — NOT local reimplementations. Importing
+ * the module does NOT run main(): the collector guards its entry point with an
+ * `isDirectRun()` check (main() only fires under `tsx scripts/…` invocation),
+ * so importing here is side-effect-free.
+ *
+ * The canary fixtures below are REAL vitest failure-message shapes captured by
+ * running the canary / drift / infra assertions under
+ * `vitest run … --reporter=json` (see PR #291 RED/GREEN logs under tmp/). They
+ * are NOT hand-authored: the single-glyph Unicode ellipsis `…(N)`, the
+ * `AssertionError:` prefix, the leading blank line before a formatted drift
+ * report, and the stack-frame layout are exactly what vitest emits.
  */
 
 import { describe, it, expect } from "vitest";
 import { formatDriftReport } from "./drift/schema.js";
 import type { ShapeDiff } from "./drift/schema.js";
+import {
+  parseDriftBlock,
+  extractProviderName,
+  extractScenario,
+  parseKnownModelsCanary,
+  collectDriftEntries,
+  classifyUnparseableAsInfra,
+  INFRA_INDICATOR_SOURCES,
+  infraIndicatorSample,
+} from "../../scripts/drift-report-collector.js";
 
 // ---------------------------------------------------------------------------
-// Local copies of the types and functions under test
-// (mirrors scripts/drift-report-collector.ts — keep in sync)
+// Vitest JSON reporter fixture builders
 // ---------------------------------------------------------------------------
-
-type DriftSeverity = "critical" | "warning" | "info";
-
-interface ParsedDiff {
-  path: string;
-  severity: DriftSeverity;
-  issue: string;
-  expected: string;
-  real: string;
-  mock: string;
-}
-
-interface VitestJsonResult {
-  testResults: VitestTestFile[];
-}
-
-interface VitestTestFile {
-  assertionResults: VitestAssertion[];
-}
 
 interface VitestAssertion {
   status: string;
@@ -42,225 +40,9 @@ interface VitestAssertion {
   failureMessages: string[];
 }
 
-interface ProviderMapping {
-  builderFile: string;
-  builderFunctions: string[];
-  typesFile: string | null;
-  sdkShapesFile?: string;
+interface VitestJsonResult {
+  testResults: { assertionResults: VitestAssertion[] }[];
 }
-
-const PROVIDER_MAP: Record<string, ProviderMapping> = {
-  "OpenAI Chat": {
-    builderFile: "src/helpers.ts",
-    builderFunctions: [
-      "buildTextCompletion",
-      "buildToolCallCompletion",
-      "buildTextChunks",
-      "buildToolCallChunks",
-    ],
-    typesFile: "src/types.ts",
-  },
-  "OpenAI Responses": {
-    builderFile: "src/responses.ts",
-    builderFunctions: [
-      "buildTextResponse",
-      "buildToolCallResponse",
-      "buildTextStreamEvents",
-      "buildToolCallStreamEvents",
-    ],
-    typesFile: null,
-  },
-  Anthropic: {
-    builderFile: "src/messages.ts",
-    builderFunctions: [
-      "buildClaudeTextResponse",
-      "buildClaudeToolCallResponse",
-      "buildClaudeTextStreamEvents",
-      "buildClaudeToolCallStreamEvents",
-    ],
-    typesFile: null,
-  },
-  "Anthropic Claude": {
-    builderFile: "src/messages.ts",
-    builderFunctions: [
-      "buildClaudeTextResponse",
-      "buildClaudeToolCallResponse",
-      "buildClaudeTextStreamEvents",
-      "buildClaudeToolCallStreamEvents",
-    ],
-    typesFile: null,
-  },
-  "Google Gemini": {
-    builderFile: "src/gemini.ts",
-    builderFunctions: [
-      "buildGeminiTextResponse",
-      "buildGeminiToolCallResponse",
-      "buildGeminiTextStreamChunks",
-      "buildGeminiToolCallStreamChunks",
-    ],
-    typesFile: null,
-  },
-  Gemini: {
-    builderFile: "src/gemini.ts",
-    builderFunctions: [
-      "buildGeminiTextResponse",
-      "buildGeminiToolCallResponse",
-      "buildGeminiTextStreamChunks",
-      "buildGeminiToolCallStreamChunks",
-    ],
-    typesFile: null,
-  },
-  "OpenAI Realtime": {
-    builderFile: "src/ws-realtime.ts",
-    builderFunctions: ["handleWebSocketRealtime", "realtimeItemsToMessages"],
-    typesFile: null,
-  },
-  "OpenAI Responses WS": {
-    builderFile: "src/ws-responses.ts",
-    builderFunctions: ["handleWebSocketResponses"],
-    typesFile: null,
-  },
-  "Gemini Live": {
-    builderFile: "src/ws-gemini-live.ts",
-    builderFunctions: ["handleWebSocketGeminiLive"],
-    typesFile: null,
-  },
-  "OpenAI Embeddings": {
-    builderFile: "src/helpers.ts",
-    builderFunctions: ["buildEmbeddingResponse", "generateDeterministicEmbedding"],
-    typesFile: null,
-    sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
-  },
-  "Gemini Interactions": {
-    builderFile: "src/gemini-interactions.ts",
-    builderFunctions: [
-      "buildInteractionsTextResponse",
-      "buildInteractionsToolCallResponse",
-      "buildInteractionsContentWithToolCallsResponse",
-      "buildInteractionsTextSSEEvents",
-      "buildInteractionsToolCallSSEEvents",
-      "buildInteractionsContentWithToolCallsSSEEvents",
-    ],
-    typesFile: null,
-  },
-};
-
-const SDK_SHAPES_FILE = "src/__tests__/drift/sdk-shapes.ts";
-
-const VALID_SEVERITIES = new Set<DriftSeverity>(["critical", "warning", "info"]);
-
-function parseDriftBlock(text: string): { context: string; diffs: ParsedDiff[] } | null {
-  const headerMatch = text.match(/API DRIFT DETECTED:\s*(.+)/);
-  if (!headerMatch) return null;
-
-  const context = headerMatch[1].trim();
-  const diffs: ParsedDiff[] = [];
-
-  const entryPattern =
-    /\d+\.\s*\[(\w+)\]\s*(.+)\n\s*Path:\s*(.+)\n\s*SDK:\s*(.+)\n\s*Real:\s*(.+)\n\s*Mock:\s*(.+)/g;
-
-  let match: RegExpExecArray | null;
-  while ((match = entryPattern.exec(text)) !== null) {
-    const severity = match[1].trim();
-    if (!VALID_SEVERITIES.has(severity as DriftSeverity)) continue;
-    diffs.push({
-      severity: severity as DriftSeverity,
-      issue: match[2].trim(),
-      path: match[3].trim(),
-      expected: match[4].trim(),
-      real: match[5].trim(),
-      mock: match[6].trim(),
-    });
-  }
-
-  return { context, diffs };
-}
-
-function extractProviderName(text: string): string | null {
-  const sorted = Object.keys(PROVIDER_MAP).sort((a, b) => b.length - a.length);
-  for (const key of sorted) {
-    if (text.includes(key)) return key;
-  }
-  return null;
-}
-
-function extractScenario(context: string): string {
-  const parenMatch = context.match(/\(([^)]+)\)/);
-  return parenMatch ? parenMatch[1] : context;
-}
-
-function collectDriftEntries(results: VitestJsonResult): Array<{
-  provider: string;
-  scenario: string;
-  builderFile: string;
-  builderFunctions: string[];
-  typesFile: string | null;
-  sdkShapesFile: string;
-  diffs: ParsedDiff[];
-}> {
-  const entries: Array<{
-    provider: string;
-    scenario: string;
-    builderFile: string;
-    builderFunctions: string[];
-    typesFile: string | null;
-    sdkShapesFile: string;
-    diffs: ParsedDiff[];
-  }> = [];
-  const unmapped: string[] = [];
-  let unparseable = 0;
-
-  for (const file of results.testResults) {
-    for (const assertion of file.assertionResults) {
-      if (assertion.status !== "failed") continue;
-      if (assertion.failureMessages.length === 0) continue;
-
-      const fullMessage = assertion.failureMessages.join("\n");
-      const parsed = parseDriftBlock(fullMessage);
-      if (!parsed || parsed.diffs.length === 0) {
-        unparseable++;
-        continue;
-      }
-
-      const ancestorText = assertion.ancestorTitles.join(" ");
-      const provider = extractProviderName(ancestorText) ?? extractProviderName(parsed.context);
-      if (!provider) {
-        unmapped.push(`${ancestorText} > ${assertion.title}`);
-        continue;
-      }
-
-      const mapping = PROVIDER_MAP[provider];
-      if (!mapping) {
-        unmapped.push(`${ancestorText} > ${assertion.title} (provider: ${provider})`);
-        continue;
-      }
-
-      entries.push({
-        provider,
-        scenario: extractScenario(parsed.context),
-        builderFile: mapping.builderFile,
-        builderFunctions: mapping.builderFunctions,
-        typesFile: mapping.typesFile,
-        sdkShapesFile: SDK_SHAPES_FILE,
-        diffs: parsed.diffs,
-      });
-    }
-  }
-
-  if (unmapped.length > 0) {
-    throw new Error(`${unmapped.length} unmapped drift entries — update PROVIDER_MAP`);
-  }
-
-  if (unparseable > 0 && entries.length === 0) {
-    throw new Error(`${unparseable} unparseable test failures with 0 drift entries — investigate`);
-  }
-
-  return entries;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers for building test fixtures
-// ---------------------------------------------------------------------------
 
 function makeResult(assertions: VitestAssertion[]): VitestJsonResult {
   return { testResults: [{ assertionResults: assertions }] };
@@ -295,7 +77,87 @@ const SAMPLE_DIFF_WARNING: ShapeDiff = {
 };
 
 // ---------------------------------------------------------------------------
-// parseDriftBlock tests
+// REAL captured vitest --reporter=json failure-message fixtures.
+// Captured via throwaway `*.drift.ts` capture tests run under the drift config;
+// see tmp/canary-fixtures.json + the PR #291 RED/GREEN logs.
+// ---------------------------------------------------------------------------
+
+// Canary tripped with FOUR unknown models. The printed array is truncated by
+// vitest to `…(3)` (single-glyph Unicode ellipsis), but the custom assertion
+// message `UNKNOWN_REALTIME_MODELS=…` carries the full list verbatim.
+// NOTE (A4): the ids below are HYPOTHETICAL future models that are NOT in the
+// knownModels set in ws-realtime.drift.ts — so the real canary really could
+// emit them as unknown. (gpt-realtime-2.1 / -2.1-mini ARE in knownModels and
+// therefore can never appear here — the earlier fixture that used them was
+// impossible.)
+const CANARY_MARKER_MULTI =
+  "AssertionError: UNKNOWN_REALTIME_MODELS=gpt-realtime-3,gpt-realtime-3-mini,gpt-realtime-3-preview,gpt-realtime-ultra: expected [ 'gpt-realtime-3', …(3) ] to deeply equal []\n" +
+  "    at /repo/src/__tests__/drift/ws-realtime.drift.ts:108:69\n" +
+  "    at file:///repo/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11\n" +
+  "    at processTicksAndRejections (node:internal/process/task_queues:104:5)";
+
+// A GENUINE drift report carried inside an AssertionError. formatDriftReport
+// prepends "\n", so line 0 is just "AssertionError: " and the "API DRIFT
+// DETECTED" / "mismatch" markers live on LATER lines. This is a fully-formatted
+// report body (parseDriftBlock parses it into one critical diff).
+const GENUINE_DRIFT_WITH_STACK =
+  "AssertionError: \nAPI DRIFT DETECTED: OpenAI Chat (non-streaming text)\n\n" +
+  "  1. [critical] LLMOCK DRIFT — mismatch detected\n" +
+  "     Path:    choices[0].message.refusal\n" +
+  "     SDK:     null\n" +
+  "     Real:    null\n" +
+  "     Mock:    <absent>\n" +
+  ": expected [ Array(1) ] to deeply equal []\n" +
+  "    at /repo/src/__tests__/drift/openai-chat.drift.ts:42:30\n" +
+  "    at file:///repo/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11";
+
+// A genuinely-unparseable failure whose ONLY infra token (ECONNREFUSED) sits in
+// a STACK FRAME; the assertion body is neutral (no infra token, no drift
+// marker). This is the A3 asymmetry surface — a raw scan would see the frame
+// token and wrongly swallow the failure; a stack-stripped scan does not.
+const INFRA_TOKEN_IN_STACKFRAME_ONLY =
+  "AssertionError: expected 1 to be 2 // Object.is equality\n" +
+  "    at ECONNREFUSED (/repo/src/__tests__/drift/some.drift.ts:8:13)\n" +
+  "    at file:///repo/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11";
+
+// A genuine infra failure whose token is in the BODY (the well-behaved case).
+const REAL_INFRA_BODY = "fetch failed\n    at handler (file:///repo/src/x.drift.ts:5:1)";
+
+// CLASS 2 — the canary `hasGA`-false mode. Captured REAL from a throwaway
+// `*.drift.ts` capture run under the drift config (see tmp/captured-vitest-shapes.json).
+// When OpenAI renames/removes the GA realtime family, the canary emits the
+// NO_GA_REALTIME_MODELS= marker (symmetric to UNKNOWN_REALTIME_MODELS=) and the
+// assertion fails with "expected false to be true". The collector must map this
+// to a CRITICAL OpenAI-Realtime DriftEntry (exit-2), NOT crash to exit-1.
+const CANARY_NO_GA_MARKER =
+  "AssertionError: NO_GA_REALTIME_MODELS=gpt-foo,gpt-bar | UNKNOWN_REALTIME_MODELS=: expected false to be true // Object.is equality\n" +
+  "    at /repo/src/__tests__/drift/ws-realtime.drift.ts:96:44\n" +
+  "    at file:///repo/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11\n" +
+  "    at processTicksAndRejections (node:internal/process/task_queues:104:5)";
+
+// CLASS 2 combined case — the run is BOTH no-GA AND carries new unknown models.
+// The hasGA assertion throws first (short-circuiting the unknown-models
+// assertion), so the NO_GA marker carries BOTH lists. The collector must
+// preserve the unknown list (no information loss into the auto-fix prompt).
+const CANARY_NO_GA_WITH_UNKNOWN =
+  "AssertionError: NO_GA_REALTIME_MODELS=gpt-foo,gpt-bar | UNKNOWN_REALTIME_MODELS=gpt-realtime-99,gpt-realtime-99-mini: expected false to be true // Object.is equality\n" +
+  "    at /repo/src/__tests__/drift/ws-realtime.drift.ts:96:44\n" +
+  "    at file:///repo/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11";
+
+// A NO_GA marker with an empty observed list (key could not see ANY realtime
+// models — still a critical signal that the GA family is unreachable/gone).
+const CANARY_NO_GA_EMPTY =
+  "AssertionError: NO_GA_REALTIME_MODELS= | UNKNOWN_REALTIME_MODELS=: expected false to be true // Object.is equality\n" +
+  "    at /repo/src/__tests__/drift/ws-realtime.drift.ts:96:44";
+
+// CLASS 3 — a marker-less truncated canary array. The truncation fact must
+// become a boolean flag, never a prose sentinel occupying a model-id slot.
+const CANARY_FALLBACK_TRUNCATED =
+  "AssertionError: expected [ 'gpt-realtime-9', …(2) ] to deeply equal []\n" +
+  "    at /repo/src/__tests__/drift/ws-realtime.drift.ts:108:69";
+
+// ---------------------------------------------------------------------------
+// parseDriftBlock
 // ---------------------------------------------------------------------------
 
 describe("parseDriftBlock", () => {
@@ -337,7 +199,6 @@ describe("parseDriftBlock", () => {
   });
 
   it("skips entries with unknown severity", () => {
-    // Manually construct a report with a bad severity
     const text = `
 API DRIFT DETECTED: OpenAI Chat (test)
 
@@ -355,7 +216,6 @@ API DRIFT DETECTED: OpenAI Chat (test)
 `;
     const result = parseDriftBlock(text);
     expect(result).not.toBeNull();
-    // Only the critical entry should be in diffs
     expect(result!.diffs).toHaveLength(1);
     expect(result!.diffs[0].severity).toBe("critical");
     expect(result!.diffs[0].path).toBe("baz.qux");
@@ -401,7 +261,7 @@ API DRIFT DETECTED: OpenAI Chat (test)
 });
 
 // ---------------------------------------------------------------------------
-// extractProviderName tests
+// extractProviderName
 // ---------------------------------------------------------------------------
 
 describe("extractProviderName", () => {
@@ -412,7 +272,6 @@ describe("extractProviderName", () => {
   });
 
   it("uses longest match — Anthropic Claude over Anthropic", () => {
-    // "Anthropic Claude" is longer and should win over "Anthropic"
     expect(extractProviderName("Anthropic Claude drift")).toBe("Anthropic Claude");
     expect(extractProviderName("Anthropic Claude (streaming tool call)")).toBe("Anthropic Claude");
   });
@@ -441,7 +300,22 @@ describe("extractProviderName", () => {
 });
 
 // ---------------------------------------------------------------------------
-// collectDriftEntries tests
+// extractScenario
+// ---------------------------------------------------------------------------
+
+describe("extractScenario", () => {
+  it("extracts the parenthetical scenario", () => {
+    expect(extractScenario("OpenAI Chat (non-streaming text)")).toBe("non-streaming text");
+    expect(extractScenario("Anthropic Claude (streaming tool call)")).toBe("streaming tool call");
+  });
+
+  it("returns the whole context when there is no parenthetical", () => {
+    expect(extractScenario("OpenAI Chat")).toBe("OpenAI Chat");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectDriftEntries (HTTP drift path)
 // ---------------------------------------------------------------------------
 
 describe("collectDriftEntries", () => {
@@ -559,5 +433,593 @@ describe("collectDriftEntries", () => {
     expect(entries).toHaveLength(2);
     expect(entries[0].provider).toBe("OpenAI Chat");
     expect(entries[1].provider).toBe("Google Gemini");
+  });
+
+  // -------------------------------------------------------------------------
+  // INTEGRATION: the canary → critical → exit-2 contract, end to end through
+  // the REAL collectDriftEntries. This is the whole reason PR #291 exists.
+  // -------------------------------------------------------------------------
+
+  it("emits ONE critical DriftEntry carrying the FULL unknown-model list from a real canary failure (RED without the marker fix)", () => {
+    const result = makeResult([
+      makeAssertion({
+        status: "failed",
+        ancestorTitles: ["OpenAI Realtime API drift"],
+        title: "canary: GA realtime models available",
+        failureMessages: [CANARY_MARKER_MULTI],
+      }),
+    ]);
+
+    const entries = collectDriftEntries(result);
+    expect(entries).toHaveLength(1);
+
+    const entry = entries[0];
+    expect(entry.provider).toBe("OpenAI Realtime");
+    expect(entry.scenario).toBe("known-models canary");
+    expect(entry.builderFile).toBe("src/ws-realtime.ts");
+
+    // FULL list recovered from the marker (NOT truncated to just the first id).
+    const reals = entry.diffs.map((d) => d.real);
+    expect(reals).toEqual([
+      "gpt-realtime-3",
+      "gpt-realtime-3-mini",
+      "gpt-realtime-3-preview",
+      "gpt-realtime-ultra",
+    ]);
+
+    // Every diff is critical so the collector exits 2 and the Fix Drift
+    // workflow reaches the auto-fix step.
+    expect(entry.diffs.every((d) => d.severity === "critical")).toBe(true);
+    // Real-API-only canary: the model id must NOT be mislabeled as a mock value.
+    for (const d of entry.diffs) {
+      expect(d.mock).not.toBe(d.real);
+      expect(d.mock).toContain("no mock leg");
+    }
+
+    // The exit-2 gate condition (criticalCount > 0) that main() checks.
+    const criticalCount = entries.reduce(
+      (sum, e) => sum + e.diffs.filter((d) => d.severity === "critical").length,
+      0,
+    );
+    expect(criticalCount).toBe(4);
+  });
+
+  it("does NOT misattribute a non-canary toEqual([]) failure from another provider as OpenAI-Realtime drift (RED without the gate)", () => {
+    // A different provider's test failed with the generic vitest shape
+    // `expected [ 'sk-leaked' ] to deeply equal []`. Pre-fix, the unguarded
+    // canary fallback matched this and emitted a CRITICAL "OpenAI Realtime
+    // known-models canary" entry with `real: 'sk-leaked'`, pointing the auto-fix
+    // at src/ws-realtime.ts and relabeling arbitrary array contents as a model
+    // id. It must NOT be claimed as a canary; with no other parseable/infra
+    // signal the collector must fail loud (throw) rather than fabricate an entry.
+    const NON_CANARY_TOEQUAL_EMPTY =
+      "AssertionError: expected [ 'sk-leaked' ] to deeply equal []\n" +
+      "    at /repo/src/__tests__/drift/openai-chat.drift.ts:42:30\n" +
+      "    at file:///repo/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11";
+    const result = makeResult([
+      makeAssertion({
+        status: "failed",
+        ancestorTitles: ["OpenAI Chat Completions drift"],
+        title: "non-streaming text matches real API",
+        failureMessages: [NON_CANARY_TOEQUAL_EMPTY],
+      }),
+    ]);
+
+    // No OpenAI-Realtime entry may be produced. Because the message is neither a
+    // parseable drift block, a canary, nor infra, the collector fails loud.
+    expect(() => collectDriftEntries(result)).toThrow(/unparseable test failures/);
+  });
+
+  it("surfaces a genuine drift report carried in an AssertionError with a leading blank line (does not swallow)", () => {
+    const result = makeResult([
+      makeAssertion({
+        status: "failed",
+        ancestorTitles: ["OpenAI Chat Completions drift"],
+        title: "non-streaming text matches real API",
+        failureMessages: [GENUINE_DRIFT_WITH_STACK],
+      }),
+    ]);
+
+    const entries = collectDriftEntries(result);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].provider).toBe("OpenAI Chat");
+    expect(entries[0].diffs).toHaveLength(1);
+    expect(entries[0].diffs[0].severity).toBe("critical");
+  });
+
+  it("throws (does NOT exit 0) when the only failure is unparseable with an infra token confined to a stack frame (A3)", () => {
+    // RED on the pre-fix collector: the raw-vs-stripped asymmetry classified
+    // this as benign infra and swallowed it (returned []). The fix normalizes
+    // both scans, so an infra token that survives ONLY in a stripped-away stack
+    // frame no longer flips the gate — the failure is surfaced via throw.
+    const result = makeResult([
+      makeAssertion({
+        status: "failed",
+        ancestorTitles: ["OpenAI Realtime API drift"],
+        title: "canary: GA realtime models available",
+        failureMessages: [INFRA_TOKEN_IN_STACKFRAME_ONLY],
+      }),
+    ]);
+    expect(() => collectDriftEntries(result)).toThrow(/unparseable test failures/);
+  });
+
+  // -------------------------------------------------------------------------
+  // CLASS 2 — hasGA-false canary maps to a CRITICAL OpenAI-Realtime entry
+  // (exit-2 path) instead of crashing to exit-1.
+  // -------------------------------------------------------------------------
+  it("maps a NO_GA_REALTIME_MODELS canary failure to a CRITICAL OpenAI-Realtime entry (exit-2, not a throw)", () => {
+    const result = makeResult([
+      makeAssertion({
+        status: "failed",
+        ancestorTitles: ["OpenAI Realtime API drift"],
+        title: "canary: GA realtime models available",
+        failureMessages: [CANARY_NO_GA_MARKER],
+      }),
+    ]);
+
+    const entries = collectDriftEntries(result);
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry.provider).toBe("OpenAI Realtime");
+    expect(entry.builderFile).toBe("src/ws-realtime.ts");
+    expect(entry.diffs.length).toBeGreaterThan(0);
+    expect(entry.diffs.every((d) => d.severity === "critical")).toBe(true);
+
+    const criticalCount = entries.reduce(
+      (sum, e) => sum + e.diffs.filter((d) => d.severity === "critical").length,
+      0,
+    );
+    expect(criticalCount).toBeGreaterThan(0);
+  });
+
+  it("preserves the unknown-model list in the NO_GA entry (no info loss when both fire)", () => {
+    // A run that is BOTH no-GA AND has new unknown models must surface the
+    // unknown ids as critical diffs, not lose them to the short-circuited
+    // unknown-models assertion.
+    const result = makeResult([
+      makeAssertion({
+        status: "failed",
+        ancestorTitles: ["OpenAI Realtime API drift"],
+        title: "canary: GA realtime models available",
+        failureMessages: [CANARY_NO_GA_WITH_UNKNOWN],
+      }),
+    ]);
+    const entries = collectDriftEntries(result);
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry.provider).toBe("OpenAI Realtime");
+    expect(entry.diffs.every((d) => d.severity === "critical")).toBe(true);
+    // The unknown model ids survive as `real` values on knownModels diffs.
+    const knownModelReals = entry.diffs.filter((d) => d.path === "knownModels").map((d) => d.real);
+    expect(knownModelReals).toEqual(["gpt-realtime-99", "gpt-realtime-99-mini"]);
+    // The GA-family diff is still present.
+    expect(entry.diffs.some((d) => d.path === "gaModels")).toBe(true);
+  });
+
+  it("maps an EMPTY NO_GA marker (no realtime models observed) to a CRITICAL entry too", () => {
+    const result = makeResult([
+      makeAssertion({
+        status: "failed",
+        ancestorTitles: ["OpenAI Realtime API drift"],
+        title: "canary: GA realtime models available",
+        failureMessages: [CANARY_NO_GA_EMPTY],
+      }),
+    ]);
+    const entries = collectDriftEntries(result);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].provider).toBe("OpenAI Realtime");
+    expect(entries[0].diffs.every((d) => d.severity === "critical")).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // CLASS 3 — no DriftEntry.real is a non-model prose sentinel, even when the
+  // canary array was truncated in CI output.
+  // -------------------------------------------------------------------------
+  it("never lands a prose sentinel in DriftEntry.real when the canary array is truncated (CLASS 3)", () => {
+    const result = makeResult([
+      makeAssertion({
+        status: "failed",
+        ancestorTitles: ["OpenAI Realtime API drift"],
+        title: "canary: GA realtime models available",
+        failureMessages: [CANARY_FALLBACK_TRUNCATED],
+      }),
+    ]);
+    const entries = collectDriftEntries(result);
+    expect(entries).toHaveLength(1);
+    for (const d of entries[0].diffs) {
+      // No `real` value may be a prose annotation (e.g. "(additional models…)").
+      expect(d.real.startsWith("(")).toBe(false);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // CLASS 1 — corpus/table test asserting the SAFE outcome for the recurring
+  // classifier failure shapes. `throws: true` = fail-loud (exit-1 investigate);
+  // `throws: false` = surfaced as a structured entry (never a silent exit-0).
+  // -------------------------------------------------------------------------
+  describe("CLASS 1 fail-loud corpus", () => {
+    const DRIFT_VALUE_WITH_STATUS_200 = formatDriftReport("OpenAI Chat (non-streaming text)", [
+      {
+        path: "choices[0].message.content",
+        severity: "critical",
+        issue: "LLMOCK DRIFT — value mismatch",
+        expected: "status 200",
+        real: "status 200",
+        mock: "<absent>",
+      },
+    ]);
+
+    const rows: {
+      name: string;
+      messages: string[];
+      throws: boolean;
+    }[] = [
+      {
+        name: "a drift body containing the substring 'status 200' is surfaced, NOT swallowed as infra",
+        messages: [DRIFT_VALUE_WITH_STATUS_200],
+        throws: false, // parsed into a structured entry
+      },
+      {
+        name: "a genuine drift report with a leading blank line is surfaced",
+        messages: [GENUINE_DRIFT_WITH_STACK],
+        throws: false,
+      },
+      {
+        name: "an 'expected false to be true' hasGA shape is surfaced (canary), not swallowed",
+        messages: [CANARY_NO_GA_MARKER],
+        throws: false,
+      },
+      {
+        name: "an 'expected […] to deeply equal []' canary shape is surfaced, not swallowed",
+        messages: [CANARY_MARKER_MULTI],
+        throws: false,
+      },
+      {
+        name: "a bare AssertionError with no infra token and no drift marker fails loud",
+        messages: ["AssertionError: expected 1 to be 2 // Object.is equality\n    at foo (x:1:1)"],
+        throws: true,
+      },
+      {
+        name: "an infra token confined to a stack frame fails loud (A3)",
+        messages: [INFRA_TOKEN_IN_STACKFRAME_ONLY],
+        throws: true,
+      },
+    ];
+
+    for (const row of rows) {
+      it(row.name, () => {
+        const result = makeResult(
+          row.messages.map((m) =>
+            makeAssertion({
+              status: "failed",
+              ancestorTitles: ["OpenAI Realtime API drift"],
+              title: "canary: GA realtime models available",
+              failureMessages: [m],
+            }),
+          ),
+        );
+        if (row.throws) {
+          expect(() => collectDriftEntries(result)).toThrow();
+        } else {
+          expect(() => collectDriftEntries(result)).not.toThrow();
+          expect(collectDriftEntries(result).length).toBeGreaterThan(0);
+        }
+      });
+    }
+
+    it("still classifies genuine infra (body token) as benign — collector returns [] without throwing", () => {
+      const result = makeResult([
+        makeAssertion({
+          status: "failed",
+          ancestorTitles: ["OpenAI Chat Completions drift"],
+          title: "non-streaming text matches real API",
+          failureMessages: [REAL_INFRA_BODY],
+        }),
+      ]);
+      expect(collectDriftEntries(result)).toEqual([]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseKnownModelsCanary
+// ---------------------------------------------------------------------------
+
+describe("parseKnownModelsCanary", () => {
+  it("recovers the FULL unknown-model list from the UNKNOWN_REALTIME_MODELS marker (not truncated)", () => {
+    // The printed array is truncated to `…(3)` but the marker carries all four.
+    const result = parseKnownModelsCanary(CANARY_MARKER_MULTI);
+    expect(result).not.toBeNull();
+    expect(result!.ids).toEqual([
+      "gpt-realtime-3",
+      "gpt-realtime-3-mini",
+      "gpt-realtime-3-preview",
+      "gpt-realtime-ultra",
+    ]);
+    // CLASS 3: the marker carries the full list, so nothing is truncated and no
+    // prose sentinel may ever occupy an id slot.
+    expect(result!.truncated).toBeFalsy();
+    expect(result!.ids.every((id) => !id.startsWith("("))).toBe(true);
+  });
+
+  it("returns null when the marker is present but the unknown list was empty", () => {
+    // Empty unknown list = no drift to surface.
+    const msg = "AssertionError: UNKNOWN_REALTIME_MODELS=: expected [] to deeply equal []";
+    expect(parseKnownModelsCanary(msg)).toBeNull();
+  });
+
+  it("falls through to the printed-array fallback when the marker value is mangled/empty (A2)", () => {
+    // A2: an empty/mangled marker must NOT short-circuit to null; it must fall
+    // through so a recoverable id in the printed array is still surfaced.
+    const msg =
+      "AssertionError: UNKNOWN_REALTIME_MODELS=: expected [ 'gpt-realtime-3', …(1) ] to deeply equal []";
+    const result = parseKnownModelsCanary(msg);
+    expect(result).not.toBeNull();
+    expect(result!.ids[0]).toBe("gpt-realtime-3");
+    // CLASS 3: truncation is a boolean flag, NOT a prose id in the list.
+    expect(result!.truncated).toBe(true);
+    expect(result!.ids.every((id) => !id.startsWith("("))).toBe(true);
+  });
+
+  it("returns null for a non-canary message", () => {
+    expect(parseKnownModelsCanary("TypeError: something unrelated")).toBeNull();
+    expect(parseKnownModelsCanary("")).toBeNull();
+  });
+
+  describe("fallback (no marker — legacy message shape)", () => {
+    // NOTE: the fallback fires ONLY in a confirmed ws-realtime canary context.
+    // A REAL marker-less canary failure ALWAYS carries the canary's origin frame
+    // (`at …/ws-realtime.drift.ts`), which these fixtures include — that frame
+    // is the recognizer that distinguishes a genuine canary from a generic
+    // non-canary `toEqual([])` failure in some other provider's test.
+    const CANARY_ORIGIN = "\n    at /repo/src/__tests__/drift/ws-realtime.drift.ts:108:69";
+
+    it("detects the single-glyph Unicode ellipsis `…(1)` truncation (as a flag, not a sentinel id)", () => {
+      const msg =
+        "AssertionError: expected [ 'gpt-realtime-3', …(1) ] to deeply equal []" + CANARY_ORIGIN;
+      const result = parseKnownModelsCanary(msg);
+      expect(result).not.toBeNull();
+      expect(result!.ids[0]).toBe("gpt-realtime-3");
+      // CLASS 3: no prose sentinel in the id list; truncation is a boolean.
+      expect(result!.truncated).toBe(true);
+      expect(result!.ids.every((id) => !id.startsWith("("))).toBe(true);
+    });
+
+    it("also detects the three-dot ASCII ellipsis `... (1)` truncation", () => {
+      const msg =
+        "AssertionError: expected [ 'gpt-realtime-3', ... (1) ] to deeply equal []" + CANARY_ORIGIN;
+      const result = parseKnownModelsCanary(msg);
+      expect(result!.truncated).toBe(true);
+      expect(result!.ids.every((id) => !id.startsWith("("))).toBe(true);
+    });
+
+    it("parses a small untruncated printed array", () => {
+      const msg =
+        "AssertionError: expected [ 'gpt-realtime-3', 'gpt-realtime-3-mini' ] to deeply equal []" +
+        CANARY_ORIGIN;
+      const result = parseKnownModelsCanary(msg);
+      expect(result!.ids).toEqual(["gpt-realtime-3", "gpt-realtime-3-mini"]);
+      expect(result!.truncated).toBeFalsy();
+    });
+
+    it("returns null for an empty printed array (genuinely no unknown models)", () => {
+      const msg = "AssertionError: expected [] to deeply equal []";
+      expect(parseKnownModelsCanary(msg)).toBeNull();
+    });
+
+    it("flags truncation-only content (glyph present, no extractable id) without inventing a prose id", () => {
+      // Inner had a truncation glyph but no quoted ids we could extract. Carries
+      // the ws-realtime canary origin path so the fallback gate recognizes it as
+      // a genuine canary failure (a real canary failure ALWAYS carries this
+      // frame). Without a canary-origin token the fallback must NOT fire.
+      const msg =
+        "AssertionError: expected [ …(4) ] to deeply equal []\n" +
+        "    at /repo/src/__tests__/drift/ws-realtime.drift.ts:108:69";
+      const result = parseKnownModelsCanary(msg);
+      expect(result).not.toBeNull();
+      // CLASS 3: no non-model prose id — the fact lives entirely in `truncated`.
+      expect(result!.ids.every((id) => !id.startsWith("("))).toBe(true);
+      expect(result!.truncated).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // MISATTRIBUTION GUARD (bucket (a) finding): the printed-array fallback must
+  // fire ONLY for a genuine ws-realtime known-models canary failure. A generic
+  // `expected [...] to deeply equal []` from ANY OTHER provider/test (no
+  // realtime-canary marker AND not originating from ws-realtime.drift.ts) must
+  // NOT be claimed as OpenAI-Realtime known-models drift — its arbitrary array
+  // contents (which could be a leaked secret, an object shape, anything) must
+  // never be relabeled as "unknown model ids".
+  // -------------------------------------------------------------------------
+  describe("fallback gating — non-canary toEqual([]) is NOT misattributed", () => {
+    it("returns null for a non-canary toEqual([]) failure carrying arbitrary array contents (RED before gate)", () => {
+      // A DIFFERENT provider's test asserted `toEqual([])` and the array held an
+      // arbitrary value — here a leaked-looking secret. NO realtime-canary marker
+      // and NO ws-realtime.drift.ts origin: this is not the canary and must not
+      // be parsed as one.
+      const msg =
+        "AssertionError: expected [ 'sk-leaked' ] to deeply equal []\n" +
+        "    at /repo/src/__tests__/drift/openai-chat.drift.ts:42:30";
+      expect(parseKnownModelsCanary(msg)).toBeNull();
+    });
+
+    it("returns null for a bare non-canary toEqual([]) failure with no origin frame at all", () => {
+      const msg = "AssertionError: expected [ 'sk-leaked' ] to deeply equal []";
+      expect(parseKnownModelsCanary(msg)).toBeNull();
+    });
+
+    it("still parses a genuine marker-less canary failure that carries the ws-realtime.drift.ts origin", () => {
+      // No structured marker (mangled/stripped), but the stack frame identifies
+      // the canary — the fallback SHOULD still recover the id.
+      const result = parseKnownModelsCanary(CANARY_FALLBACK_TRUNCATED);
+      expect(result).not.toBeNull();
+      expect(result!.ids[0]).toBe("gpt-realtime-9");
+      expect(result!.truncated).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // CLASS 2 — the NO_GA_REALTIME_MODELS marker (hasGA-false mode)
+  // -------------------------------------------------------------------------
+  describe("NO_GA_REALTIME_MODELS marker (hasGA-false)", () => {
+    it("recognizes the marker and returns the observed model ids with noGA=true", () => {
+      const result = parseKnownModelsCanary(CANARY_NO_GA_MARKER);
+      expect(result).not.toBeNull();
+      expect(result!.noGA).toBe(true);
+      expect(result!.ids).toEqual(["gpt-foo", "gpt-bar"]);
+    });
+
+    it("recognizes an EMPTY NO_GA marker (no realtime models observed at all) as noGA=true", () => {
+      const result = parseKnownModelsCanary(CANARY_NO_GA_EMPTY);
+      expect(result).not.toBeNull();
+      expect(result!.noGA).toBe(true);
+      expect(result!.ids).toEqual([]);
+      expect(result!.unknownIds ?? []).toEqual([]);
+    });
+
+    it("preserves the unknown-model list carried alongside the NO_GA marker (info-loss fix)", () => {
+      // Combined case: no-GA AND new unknown models. The hasGA assertion
+      // short-circuits the unknown-models assertion, so the NO_GA marker carries
+      // BOTH lists. The observed and unknown lists must be split cleanly.
+      const result = parseKnownModelsCanary(CANARY_NO_GA_WITH_UNKNOWN);
+      expect(result).not.toBeNull();
+      expect(result!.noGA).toBe(true);
+      expect(result!.ids).toEqual(["gpt-foo", "gpt-bar"]);
+      expect(result!.unknownIds).toEqual(["gpt-realtime-99", "gpt-realtime-99-mini"]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyUnparseableAsInfra (A3 — symmetric normalization safety net)
+// ---------------------------------------------------------------------------
+
+describe("classifyUnparseableAsInfra", () => {
+  it("returns false for an EMPTY evidence array — no evidence is NOT proof of infra (CLASS 1)", () => {
+    // Vacuous `.every` on [] returns true; the fix must NOT treat "no evidence"
+    // as "all clear". Unrecognized ⇒ fail loud, never a false all-clear.
+    expect(classifyUnparseableAsInfra([])).toBe(false);
+  });
+
+  it("does NOT swallow a failure whose only infra token is confined to a stack frame (A3)", () => {
+    // Pre-fix: the raw scan saw ECONNREFUSED in the frame → allInfraErrors true
+    // → swallowed. The fix strips frames for BOTH scans, so the token is gone
+    // and the failure is not classified as infra.
+    expect(classifyUnparseableAsInfra([INFRA_TOKEN_IN_STACKFRAME_ONLY])).toBe(false);
+  });
+
+  it("does NOT swallow genuine drift carried in an AssertionError with a leading blank line", () => {
+    expect(classifyUnparseableAsInfra([GENUINE_DRIFT_WITH_STACK])).toBe(false);
+  });
+
+  it("does NOT treat a bare AssertionError as benign infra", () => {
+    const msg = "AssertionError: expected [ 'x' ] to deeply equal []\n    at foo (file:///x)";
+    expect(classifyUnparseableAsInfra([msg])).toBe(false);
+  });
+
+  it("still classifies genuine infra errors (token in the body) as infra", () => {
+    expect(classifyUnparseableAsInfra([REAL_INFRA_BODY])).toBe(true);
+    expect(classifyUnparseableAsInfra(["INFRA_ERROR: upstream down\n    at foo (file:///x)"])).toBe(
+      true,
+    );
+    expect(classifyUnparseableAsInfra(["API returned 503 Service Unavailable"])).toBe(true);
+  });
+
+  it("does NOT classify a drift body whose VALUE contains 'status 200' as infra (CLASS 1 anchoring)", () => {
+    // A real drift value like "status 200" appearing anywhere in the body must
+    // not trip the infra gate. The infra 'status \\d{3}' indicator must anchor
+    // to the failure reason/line, not a bare substring inside a drift value.
+    const msg =
+      "AssertionError: \nAPI DRIFT DETECTED: OpenAI Chat (non-streaming text)\n\n" +
+      "  1. [critical] LLMOCK DRIFT — mismatch detected\n" +
+      "     Path:    choices[0].message.content\n" +
+      "     SDK:     status 200\n" +
+      "     Real:    status 200\n" +
+      "     Mock:    <absent>\n";
+    expect(classifyUnparseableAsInfra([msg])).toBe(false);
+  });
+
+  it("does NOT classify a labelled 'Real: API returned 503' drift VALUE as infra (CLASS 1 anchoring)", () => {
+    // Symmetric to the 'status 200' anchoring case above, and to the already-
+    // anchored 'status \\d{3}' sibling. A drift *value* like "API returned 503"
+    // appearing AFTER a `Field:` label must NOT trip the infra gate. The
+    // 'API returned \\d{3}' indicator must anchor to the failure reason/line
+    // (line start, optional `HTTP ` prefix) exactly like 'status \\d{3}' does —
+    // an anchoring-defeating `(?:.*:\\s*)?` prefix lets a labelled value match
+    // and silently swallow genuine drift. This message is deliberately NOT
+    // drift-like (no "drift"/"mismatch"/"expected…to" markers) so the
+    // anchoring of the infra indicator is the SOLE determinant of the outcome.
+    const msg =
+      "     Path:    choices[0].message.content\n" +
+      "     SDK:     n/a\n" +
+      "     Real: API returned 503\n" +
+      "     Mock:    <absent>\n";
+    expect(classifyUnparseableAsInfra([msg])).toBe(false);
+  });
+
+  it("still classifies a bare line-start 'API returned 503' reason as infra (anchoring preserved)", () => {
+    // The anchoring fix must NOT break the genuine infra case: a line whose
+    // reason IS "API returned <status>" (optionally `HTTP `-prefixed, at line
+    // start) is still infra. Guards against over-tightening the anchor.
+    expect(classifyUnparseableAsInfra(["API returned 503 Service Unavailable"])).toBe(true);
+    expect(classifyUnparseableAsInfra(["  HTTP API returned 500"])).toBe(true);
+  });
+
+  it("does not false-positive drift from a stack-trace filename like ws-realtime.drift.ts", () => {
+    // A recognized infra error (token in BODY) whose stack frame mentions
+    // "ws-realtime.drift.ts" stays infra — the frame filename is stripped.
+    const msg = "fetch failed\n    at handler (file:///repo/src/ws-realtime.drift.ts:5:1)";
+    expect(classifyUnparseableAsInfra([msg])).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // PROPERTY-BASED uniform-anchoring test — the NON-RECURRING deliverable.
+  //
+  // Iterates the REAL exported infra-indicator list (INFRA_INDICATOR_SOURCES),
+  // NOT a hand-copied subset. For EVERY indicator it asserts through the REAL
+  // exported classifyUnparseableAsInfra that:
+  //   (a) a labelled drift-body line `Real:    <sample>` (no drift marker) is
+  //       NOT classified as infra — genuine drift is surfaced/fail-loud; and
+  //   (b) a bare line-start `<sample>` failure reason IS classified as infra.
+  //
+  // This is what makes the class non-recurring: if a future indicator is added
+  // to INFRA_INDICATOR_SPECS but individually mis-anchored (e.g. with the
+  // old `(?:.*:\s*)?` prefix or an unanchored `/i`), row (a) fails automatically
+  // for that indicator — no one has to remember to add a bespoke test.
+  //
+  // RED before the uniform-anchoring fix: at minimum the `empty response`,
+  // `returned no SSE events`, and `returned empty body` rows fail case (a)
+  // (they were `(?:.*:\s*)?`-prefixed or unanchored, so a labelled value matched
+  // and swallowed genuine drift). GREEN after: all rows pass both cases.
+  // -------------------------------------------------------------------------
+  describe("uniform anchoring across the REAL infra-indicator list (property)", () => {
+    it("exports a non-empty indicator list to iterate", () => {
+      expect(INFRA_INDICATOR_SOURCES.length).toBeGreaterThan(0);
+    });
+
+    for (const source of INFRA_INDICATOR_SOURCES) {
+      const sample = infraIndicatorSample(source);
+
+      it(`[${source}] a labelled drift-body value "Real: ${sample}" is NOT swallowed as infra (a)`, () => {
+        // A labelled body line carrying the phrase as a drift VALUE. No drift
+        // marker present, so the infra-indicator anchoring is the SOLE
+        // determinant: if the indicator is properly line-anchored it does NOT
+        // match here (the phrase follows a `Real:` label), so the batch is not
+        // all-infra and the failure is surfaced (classify → false).
+        const msg =
+          "     Path:    choices[0].message.content\n" +
+          "     SDK:     n/a\n" +
+          `     Real:    ${sample}\n` +
+          "     Mock:    <absent>\n";
+        expect(classifyUnparseableAsInfra([msg])).toBe(false);
+      });
+
+      it(`[${source}] a bare line-start "${sample}" failure reason IS classified as infra (b)`, () => {
+        // The phrase AS the failure reason at line start must still be infra —
+        // the anchoring fix must not over-tighten and break genuine infra.
+        expect(classifyUnparseableAsInfra([sample])).toBe(true);
+      });
+    }
   });
 });

--- a/src/__tests__/drift/ws-realtime.drift.ts
+++ b/src/__tests__/drift/ws-realtime.drift.ts
@@ -35,7 +35,18 @@ const BETA_SUPPRESSED_EVENTS = new Set(["conversation.item.done"]);
 // ---------------------------------------------------------------------------
 
 let instance: ServerInstance;
+// The known-models canary — the entire reason this suite exists — fetches the
+// model list via GET /v1/models, which returns ALL models for ANY valid OpenAI
+// key regardless of realtime access. So it uses OPENAI_API_KEY (the credential
+// CI actually provides to the drift job) and is gated ONLY on OPENAI_API_KEY,
+// guaranteeing it runs in CI and cannot silently skip.
+//
+// The real realtime WS *session* tests connect a live socket that legitimately
+// requires realtime access, so they gate on OPENAI_REALTIME_KEY and pass that
+// same credential in their session config — using the chat-only OPENAI_API_KEY
+// there could produce a spurious auth-failure "drift" if the two keys differ.
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_REALTIME_KEY = process.env.OPENAI_REALTIME_KEY;
 
 beforeAll(async () => {
   instance = await startDriftServer();
@@ -50,14 +61,24 @@ afterAll(async () => {
 // ---------------------------------------------------------------------------
 
 describe.skipIf(!OPENAI_API_KEY)("OpenAI Realtime API drift", () => {
-  const config = { apiKey: OPENAI_API_KEY! };
+  // Session config for the real WS realtime tests uses the realtime credential,
+  // NOT the chat-only OPENAI_API_KEY, so that a differing realtime key can't
+  // cause a spurious auth-failure "drift". The canary below does NOT use this.
+  const config = { apiKey: OPENAI_REALTIME_KEY! };
 
   it("canary: GA realtime models available", async () => {
-    const models = await listOpenAIModels(config.apiKey);
+    // Fetch via GET /v1/models, which lists ALL models for ANY valid key. Use
+    // OPENAI_API_KEY (guaranteed present by the describe.skipIf above and the
+    // credential CI provides) so the canary ALWAYS runs in CI and never skips —
+    // gating this on OPENAI_REALTIME_KEY (which CI does NOT provide) would have
+    // silently skipped the one check this whole suite exists to run.
+    const models = await listOpenAIModels(OPENAI_API_KEY!);
 
     const gaModels = [
       "gpt-realtime",
       "gpt-realtime-2",
+      "gpt-realtime-2.1",
+      "gpt-realtime-2.1-mini",
       "gpt-realtime-2025-08-28",
       "gpt-realtime-1.5",
       "gpt-realtime-mini",
@@ -89,16 +110,42 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Realtime API drift", () => {
 
     const realtimeModels = models.filter((m) => m.includes("realtime"));
 
-    // At least one GA model should exist
-    const hasGA = realtimeModels.some((m) => gaModels.includes(m));
-    expect(hasGA).toBe(true);
-
-    // Flag unknown realtime models
+    // Compute the unknown-model list BEFORE the hasGA assertion. A run can be
+    // BOTH GA-family-gone AND carry new unknown models; because the hasGA
+    // assertion below throws first, the later unknown-models assertion would
+    // never run and its list would be lost from the NO_GA failure message (and
+    // therefore from the auto-fix prompt). So we carry the unknown list into the
+    // NO_GA marker too — no information is lost in the combined case.
     const unknown = realtimeModels.filter((m) => !knownModels.has(m));
     if (unknown.length > 0) {
       console.warn(`[DRIFT] Unknown realtime models detected: ${unknown.join(", ")}`);
     }
-    expect(unknown).toEqual([]);
+
+    // At least one GA model should exist. Carry the OBSERVED realtime models in
+    // a stable custom assertion message (symmetric to UNKNOWN_REALTIME_MODELS=
+    // below) so that when the GA family is renamed/removed — or the credential
+    // cannot see any realtime models — the drift collector recognizes the
+    // NO_GA_REALTIME_MODELS= marker and emits a CRITICAL OpenAI-Realtime entry
+    // (exit 2, auto-remediated) instead of crashing to exit 1. Without the
+    // marker, "expected false to be true" is an unrecognized shape that the
+    // collector would treat as unparseable and throw on.
+    //
+    // The message ALSO carries the unknown list after a ` | UNKNOWN_REALTIME_MODELS=`
+    // segment so the combined (no-GA AND unknown-models-present) case does not
+    // lose the unknown list when this assertion short-circuits the one below.
+    // The collector splits the two markers apart; each list stays clean.
+    const hasGA = realtimeModels.some((m) => gaModels.includes(m));
+    expect(
+      hasGA,
+      `NO_GA_REALTIME_MODELS=${realtimeModels.join(",")} | UNKNOWN_REALTIME_MODELS=${unknown.join(",")}`,
+    ).toBe(true);
+
+    // Carry the FULL unknown-model list in a stable custom assertion message.
+    // vitest truncates the printed array in failureMessages (`…(N)`), so the
+    // drift collector cannot recover ids beyond the first from the array. The
+    // custom message is emitted verbatim and is NOT truncated, so the collector
+    // parses the UNKNOWN_REALTIME_MODELS= marker as its source of truth.
+    expect(unknown, `UNKNOWN_REALTIME_MODELS=${unknown.join(",")}`).toEqual([]);
   });
 
   it.skipIf(!process.env.OPENAI_REALTIME_KEY)(


### PR DESCRIPTION
## What this fixes

The scheduled **Fix Drift** workflow crashed ([run 28848422043](https://github.com/CopilotKit/aimock/actions/runs/28848422043)) the moment OpenAI shipped new realtime models. The known-models canary failed as intended, but the collector couldn't turn the vitest `AssertionError` into a structured drift report — so it hard-exited instead of opening an auto-fix PR.

Two root problems, both fixed:

1. **New models weren't recognized.** Added `gpt-realtime-2.1` / `gpt-realtime-2.1-mini`, and — more importantly — the canary now emits a stable custom-message marker (`UNKNOWN_REALTIME_MODELS=` / `NO_GA_REALTIME_MODELS=`) carrying the full model list, so the collector parses it deterministically instead of scraping vitest's truncated array output. Both failure modes (a new unknown model, or the GA family being renamed/removed) now produce a **critical** entry and exit 2 → auto-remediation.

2. **The collector mis-handled unparseable failures.** It now **fails loud** on anything it can't positively classify (a false "no drift, exit 0" was the original incident class); every infra indicator is uniformly line-anchored through one wrapper so a drift value like `Real: API returned 503` can't masquerade as an infra error; and the canary's printed-array fallback is scoped to the realtime context so a non-canary `toEqual([])` failure from another provider can't be misattributed as realtime model drift.

## Testing

Every fix was proven red→green through the **real exported collector functions** against **real** vitest `--reporter=json` output (not hand-authored strings). Full suite: **4327 passing**. The tests now import the real functions rather than reimplementing them, and a property-based test iterates the real infra-indicator list so no indicator can be individually mis-anchored again.

## Review

Ran a full review-fix loop to convergence — zero mandatory findings on the final round, and a promotion audit confirmed no deferred item undermines the canary→exit-2 guarantee.

## Follow-ups (out of scope — separate work)

- The HTTP drift run's vitest glob includes `agui-schema.drift.ts`, so AG-UI-only drift would exit-1 instead of exit-2 — needs `vitest.config.drift.ts`.
- `fix-drift.yml`: auto-fix `continue-on-error` can leave a crashed fix silently unremediated; the Slack message's `\n` renders literally; benign exit-4 isn't special-cased.
- Pre-existing collector-parse robustness (AG-UI phrasing regexes, CRLF handling in `parseDriftBlock`, provider-name matching).

Draft until reviewed.
