### PR TITLE
chore: release v1.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @copilotkit/aimock
 
-## [Unreleased]
+## [1.36.1] - 2026-07-14
 
 ### Fixed
 

--- a/docs/aimock-cli/index.html
+++ b/docs/aimock-cli/index.html
@@ -102,6 +102,7 @@ $ docker run -d -p 4010:4010 \
     <span class="prop">"fixtures"</span>: <span class="str">"./fixtures"</span>,
     <span class="prop">"latency"</span>: <span class="num">0</span>,
     <span class="prop">"chunkSize"</span>: <span class="num">20</span>,
+    <span class="prop">"replaySpeed"</span>: <span class="num">1</span>,
     <span class="prop">"logLevel"</span>: <span class="str">"info"</span>,
     <span class="prop">"validateOnLoad"</span>: <span class="kw">true</span>,
     <span class="prop">"metrics"</span>: <span class="kw">true</span>,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Release v1.36.1 (patch)

Cuts a patch release for the `llm` config passthrough fix merged in #294.

### Version bump

`package.json` `1.36.0` → `1.36.1`. (Matches this repo's practiced release convention: only `package.json` + `CHANGELOG.md` are version-carrying for aimock — `charts/aimock/Chart.yaml`, `.claude-plugin/*`, and `src/cli.ts` are not bumped per release here, as v1.36.0 also demonstrated, and no CI parity check enforces them.)

### CHANGELOG

Rolled the existing `[Unreleased]` entry into `## [1.36.1] - 2026-07-14`:

> ### Fixed
> - `aimock.json` now honours `llm.latency`, `llm.chunkSize`, `llm.replaySpeed` and `llm.logLevel`, which the config loader previously accepted and ignored. Each behaves as its `llmock` CLI flag and `createMockSuite({ llm })` equivalent. `llm.replaySpeed` divides every delay source (recorded timings, streaming profiles, `latency`), so a fixture suite can replay recorded inter-chunk timings faster than they were recorded; a fixture's own `replaySpeed` still takes precedence. A non-positive `llm.replaySpeed` is ignored with a warning, matching the existing fixture-level guard (#294)

### Docs completeness audit

Checked every place the `llm` config is described:

| Location | Before | Action |
|---|---|---|
| `docs/aimock-cli/index.html` — Config Fields prose row | all four fields listed (fixed in #294) | already complete |
| `docs/aimock-cli/index.html` — `aimock.json` JSON example | showed `latency`, `chunkSize`, `logLevel`; **missing `replaySpeed`** | **added `"replaySpeed": 1`** so the example matches the documented field set |
| `src/config-loader.ts` — `AimockConfig.llm` type | all four typed; no per-field JSDoc (existing style) | no change (would not force JSDoc where none exists) |
| `docs/index.html` landing example | illustrative marketing snippet (`providers` array, stale banner), not a field reference | no change |
| `docs/chat-completions/index.html`, `packages/aimock-pytest/README.md`, `README.md` | partial illustrative examples, not a full `llm` field reference | no change |

Net: one real gap fixed (JSON example ↔ prose consistency on the canonical config-reference page); everywhere else was already complete or is deliberately illustrative.

### Quality gate

- `pnpm run format:check` — pass (changed files clean; only a gitignored `.impeccable/hook.cache.json` local artifact warns)
- `pnpm run lint` — pass
- `pnpm test` — 4364 passed (147 files)
- `pnpm run build` — pass

Draft until you're ready to merge; merging to `main` triggers `publish-release.yml` (npm publish + tag + GitHub Release + Slack).