### PR TITLE
ci(drift): make drift-live-pr head/base legs treat collector exit-2 as non-fatal

### DIFF
--- a/.github/workflows/test-drift.yml
+++ b/.github/workflows/test-drift.yml
@@ -544,17 +544,25 @@ jobs:
             cd ../base-main
             pnpm install --frozen-lockfile
             # The collector exits 2 when it finds critical drift — that is the
-            # NORMAL "drift present" signal, NOT a step failure. The delta gate
-            # (not this leg) decides block-vs-advisory, so exit 2 here must be
-            # tolerated. Exit 5 (quarantine) and any other non-zero are genuine
-            # collector faults and DO fail the leg. `set +e` around the run so an
-            # exit 2 does not abort under `set -euo pipefail`.
+            # NORMAL "drift present" signal that feeds the delta gate, NOT a step
+            # failure. The delta gate (not this leg) decides block-vs-advisory,
+            # so exit 2 here must be tolerated. `set +e`/`set -e` around the run
+            # captures the exit code as DATA so an exit 2 does not abort under
+            # the step's `set -euo pipefail`:
+            #   exit 0 → clean, continue.
+            #   exit 2 → drift present, NON-FATAL (report feeds the delta gate).
+            #   exit 5 → quarantine (unparseable output) — genuine fault, FAIL.
+            #   any other non-{0,2} → genuine collector fault, FAIL.
             set +e
             npx tsx scripts/drift-report-collector.ts \
               --out "$GITHUB_WORKSPACE/drift-report-base.json"
             BASE_EXIT=$?
             set -e
             cd "$GITHUB_WORKSPACE"
+            if [ "$BASE_EXIT" -eq 5 ]; then
+              echo "::error::Base collector quarantined unparseable output (exit 5) — manual triage required"
+              exit "$BASE_EXIT"
+            fi
             if [ "$BASE_EXIT" -ne 0 ] && [ "$BASE_EXIT" -ne 2 ]; then
               echo "::error::Base collector faulted (exit $BASE_EXIT) — not a drift signal"
               exit "$BASE_EXIT"
@@ -592,8 +600,25 @@ jobs:
               > drift-report-head.json
             exit 0
           fi
+          # The collector exits 2 when it finds critical drift — that is the
+          # NORMAL "drift present" signal that feeds the delta gate below, NOT a
+          # step failure. GitHub runs `run:` under `bash -e`, so without an
+          # explicit `set +e` guard the `-e` would abort THIS step the instant
+          # the collector returns 2 (never reaching the capture below) — that is
+          # the #297 wiring bug this leg must avoid. So capture the exit code
+          # with `set +e`/`set -e` and treat it as DATA:
+          #   exit 0 → clean, continue.
+          #   exit 2 → drift present, NON-FATAL (report feeds the delta gate).
+          #   exit 5 → quarantine (unparseable output) — genuine fault, FAIL.
+          #   any other non-{0,2} → genuine collector fault, FAIL.
+          set +e
           npx tsx scripts/drift-report-collector.ts --out drift-report-head.json
           HEAD_EXIT=$?
+          set -e
+          if [ "$HEAD_EXIT" -eq 5 ]; then
+            echo "::error::Head collector quarantined unparseable output (exit 5) — manual triage required"
+            exit "$HEAD_EXIT"
+          fi
           if [ "$HEAD_EXIT" -ne 0 ] && [ "$HEAD_EXIT" -ne 2 ]; then
             echo "::error::Head collector faulted (exit $HEAD_EXIT) — not a drift signal"
             exit "$HEAD_EXIT"


### PR DESCRIPTION
## The bug

The `drift-live-pr` job's **head leg** let the drift collector's exit code 2 (critical drift found) propagate as a **step failure**. But exit-2 is the *expected* "drift present" signal that must feed the delta gate — it has to be **non-fatal** for the leg so the delta gate can decide block-vs-advisory by key presence.

GitHub Actions runs `run:` blocks under `bash -e`. The head-leg step's `set -uo pipefail` line does **not** clear that `-e`, and there was no `set +e` guard around the collector call. So the instant the collector returned 2, `-e` aborted the step at the `npx` line — before `HEAD_EXIT=$?` was even captured — and the delta gate never ran.

On PR #297 the head leg logged `Exiting with code 2 (critical diffs found)` then `##[error]Process completed with exit code 2`. The prior fix (#297) only hardened the *base* leg (which already wrapped the collector in `set +e`/`set -e`) and the no-keys degradation path; the keys-present head-leg live run still propagated exit-2.

Makes drift-live-pr functional on drift-code PRs (was merged non-functional in #297).

## The fix (scoped only to `.github/workflows/test-drift.yml`)

Both the base-leg and head-leg keys-present (`LIVE_LEGS_RAN=true`) live-run steps now capture the collector's exit code with `set +e`/`set -e` and treat it as **data**:

- **exit 0** → clean, continue.
- **exit 2** → drift present → **non-fatal**, continue (the `drift-report-{base,head}.json` report feeds the delta gate).
- **exit 5** (quarantine) → genuine fault → **fail the leg** (explicit classification).
- **any other non-{0,2}** → genuine collector fault → **fail the leg**.

Report filenames/paths are unchanged (`drift-report-base.json` / `drift-report-head.json`), so the delta gate contract is untouched. The head leg was the actual #297 bug (it lacked the `set +e` guard); the base leg already tolerated exit-2, and gains only the explicit exit-5 classification for symmetry.

### Diff hunk

```diff
@@ head leg ("Head drift report — run live on PR ref") @@
+          # ... capture exit as DATA (see comment) ...
+          set +e
           npx tsx scripts/drift-report-collector.ts --out drift-report-head.json
           HEAD_EXIT=$?
+          set -e
+          if [ "$HEAD_EXIT" -eq 5 ]; then
+            echo "::error::Head collector quarantined unparseable output (exit 5) — manual triage required"
+            exit "$HEAD_EXIT"
+          fi
           if [ "$HEAD_EXIT" -ne 0 ] && [ "$HEAD_EXIT" -ne 2 ]; then
             echo "::error::Head collector faulted (exit $HEAD_EXIT) — not a drift signal"
             exit "$HEAD_EXIT"
           fi
           echo "head: collector exit $HEAD_EXIT (0 clean / 2 drift-present — both non-fatal here)"
```

(The base leg gains the same explicit `exit 5` classification block ahead of its existing `-ne 0 && -ne 2` fault check.)

## Red-green proof (keys-present live-run path)

The harness programmatically extracts the **real** base-/head-leg `run:` bash from the YAML (python YAML parse — not hand-reconstructed), then drives it under GitHub's exact default shell (`bash --noprofile --norc -e -o pipefail`) with a fake `npx` collector on PATH that writes the expected `drift-report-{base,head}.json` and returns a configurable exit code. `LIVE_LEGS_RAN=true` forces the keys-present branch.

### RED — current `main` YAML, head leg, fake collector exit 2 (reproduces #297)

```
=== RED: HEAD leg, current main YAML, fake collector exit 2 ===
===== STEP STDOUT =====
fake-collector: writing report, exiting 2 (critical diffs found)
===== STEP STDERR =====
===== STEP EXIT CODE: 2 =====
REPORT PRESENT: drift-report-head.json (103 bytes)
HARNESS RC (RED): 2
```

The step FAILS with exit 2 (the `head: collector exit ...` line never prints — `-e` killed the step at the `npx` line). This is the #297 failure.

### GREEN — fixed YAML, head leg

```
=== HEAD leg, fake collector exit 2 ===
fake-collector: writing report, exiting 2 (critical diffs found)
head: collector exit 2 (0 clean / 2 drift-present — both non-fatal here)
===== STEP EXIT CODE: 0 =====
REPORT PRESENT: drift-report-head.json (103 bytes)
HARNESS RC (head exit 2): 0

=== HEAD leg, fake collector exit 5 ===
fake-collector: writing report, exiting 5 (critical diffs found)
::error::Head collector quarantined unparseable output (exit 5) — manual triage required
===== STEP EXIT CODE: 5 =====
HARNESS RC (head exit 5): 5

=== HEAD leg, fake collector exit 0 ===
fake-collector: writing report, exiting 0 (critical diffs found)
head: collector exit 0 (0 clean / 2 drift-present — both non-fatal here)
===== STEP EXIT CODE: 0 =====
HARNESS RC (head exit 0): 0
```

- exit 2 → step **succeeds** (rc captured, non-fatal), report present, control reaches the post-collector line (delta gate runs).
- exit 5 → step **still fails** the leg (quarantine).
- exit 0 → clean.

### GREEN — fixed YAML, base leg (same three)

```
=== BASE leg, fake collector exit 2 ===
base: no reusable same-UTC-day main report — running fresh live base
fake-collector(base): writing report, exiting 2
===== STEP EXIT CODE: 0 =====
REPORT PRESENT: drift-report-base.json (103 bytes)

=== BASE leg, fake collector exit 5 ===
fake-collector(base): writing report, exiting 5
::error::Base collector quarantined unparseable output (exit 5) — manual triage required
===== STEP EXIT CODE: 5 =====

=== BASE leg, fake collector exit 0 ===
fake-collector(base): writing report, exiting 0
===== STEP EXIT CODE: 0 =====
```

## Quality

- `actionlint` clean on my changed steps. (The one reported SC2086 is at the pre-existing notify-job "Check previous run status" step — not part of this change.)
- `pnpm run format:check` — clean.
- `pnpm run lint` — clean.
- `git status` — only `.github/workflows/test-drift.yml` modified. Harness is a scratch tool under `/tmp`, not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
