### PR TITLE
fix: release-gate exports check, fixture-load guard, and E2E doc lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "test:exports": "publint && attw --pack .",
     "lint": "eslint .",
     "format:check": "prettier --check .",
-    "release": "pnpm build && pnpm test && pnpm lint && npm publish",
+    "release": "pnpm format:check && pnpm build && pnpm test && pnpm lint && pnpm test:exports && npm publish",
     "prepare": "husky || true"
   },
   "lint-staged": {

--- a/skills/write-fixtures/SKILL.md
+++ b/skills/write-fixtures/SKILL.md
@@ -255,7 +255,7 @@ mock.on(
 mock.on({ userMessage: "status", sequenceIndex: 1 }, { content: "All systems operational." });
 ```
 
-Match counts are tracked per fixture group and reset with `reset()` or `resetMatchCounts()`.
+Match counts are tracked per fixture group. Use `resetMatchCounts()` between tests to reset counts while keeping loaded fixtures. `reset()` also clears the fixture pool, so avoid it between tests that share a loaded fixture set.
 
 ### Streaming physics (realistic timing)
 
@@ -500,7 +500,7 @@ These fields map correctly across all provider formats — for example, `finishR
 
 10. **Embeddings auto-generate if no fixture matches** — deterministic vectors are generated from the input text hash. You don't need a catch-all for embedding requests.
 
-11. **Sequential response counts are tracked per fixture** — counts reset with `reset()` or `resetMatchCounts()`. The count increments after each match of that fixture group (all fixtures sharing the same non-`sequenceIndex` match fields).
+11. **Sequential response counts are tracked per fixture** — use `resetMatchCounts()` between tests to reset counts while keeping loaded fixtures; `reset()` also clears the fixture pool, so don't use it between tests that share a loaded fixture set. The count increments after each match of that fixture group (all fixtures sharing the same non-`sequenceIndex` match fields).
 
 12. **Bedrock uses Anthropic Messages format internally** — the adapter normalizes Bedrock requests to `ChatCompletionRequest`, so the same fixtures work. Bedrock supports both non-streaming (`/invoke`, `/converse`) and streaming (`/invoke-with-response-stream`, `/converse-stream`) endpoints.
 
@@ -549,7 +549,7 @@ await suite.start();
 // suite.llm — the LLMock instance
 // suite.url — base URL
 
-afterEach(() => suite.reset()); // resets everything
+afterEach(() => suite.llm.resetMatchCounts()); // reset sequence counts, keep fixtures
 afterAll(() => suite.stop());
 ```
 
@@ -684,8 +684,8 @@ mock.loadFixtureDir("./fixtures");
 await mock.start();
 process.env.OPENAI_BASE_URL = `${mock.url}/v1`;
 
-// Per-test cleanup
-afterEach(() => mock.reset()); // clears fixtures AND journal
+// Per-test cleanup — reset sequence match counts, keep the loaded fixtures
+afterEach(() => mock.resetMatchCounts());
 
 // Teardown
 afterAll(async () => await mock.stop());
@@ -735,6 +735,8 @@ const mock = await LLMock.create({ port: 0 }); // creates + starts in one call
 | `mount(path, handler)`                   | Mount a Mountable (VectorMock, etc.)        |
 | `url` / `baseUrl`                        | Server URL (throws if not started)          |
 | `port`                                   | Server port number                          |
+
+Between tests that share a loaded fixture set, use `resetMatchCounts()` (not `reset()`, which also clears fixtures). For a `MockSuite`, call `suite.llm.resetMatchCounts()` — the suite itself has no `resetMatchCounts()`.
 
 Sequential responses use `on()` with `sequenceIndex` in the match — there is no dedicated convenience method.
 

--- a/src/__tests__/fixture-loader.test.ts
+++ b/src/__tests__/fixture-loader.test.ts
@@ -316,6 +316,32 @@ describe("loadFixtureFile", () => {
     expect(fixtures[0].disconnectAfterMs).toBeUndefined();
   });
 
+  it("loads sibling fixtures when one entry has a non-array interChunkDelaysMs", () => {
+    // Untrusted fixture JSON: interChunkDelaysMs is typed number[] but may be
+    // null/missing/non-array. Without an Array.isArray guard, .filter throws a
+    // TypeError inside entryToFixture, aborting the entire file's load and
+    // silently dropping every fixture in it.
+    const filePath = writeJson(tmpDir, "bad-timings.json", {
+      fixtures: [
+        {
+          match: { userMessage: "malformed" },
+          response: { content: "bad" },
+          recordedTimings: { ttftMs: 0, interChunkDelaysMs: null, totalDurationMs: 0 },
+        },
+        {
+          match: { userMessage: "valid" },
+          response: { content: "good" },
+        },
+      ],
+    });
+
+    const fixtures = loadFixtureFile(filePath);
+    expect(fixtures).toHaveLength(2);
+    expect(fixtures[1].match.userMessage).toBe("valid");
+    // The malformed entry is sanitized: non-array interChunkDelaysMs -> [].
+    expect(fixtures[0].recordedTimings?.interChunkDelaysMs).toEqual([]);
+  });
+
   it("warns and returns empty array for invalid JSON", () => {
     const filePath = join(tmpDir, "bad.json");
     writeFileSync(filePath, "{ not valid json", "utf-8");

--- a/src/fixture-loader.ts
+++ b/src/fixture-loader.ts
@@ -107,7 +107,9 @@ export function entryToFixture(entry: FixtureFileEntry, logger?: Logger): Fixtur
   if (fixture.recordedTimings) {
     const rt = fixture.recordedTimings;
     if (!Number.isFinite(rt.ttftMs) || rt.ttftMs < 0) rt.ttftMs = 0;
-    rt.interChunkDelaysMs = rt.interChunkDelaysMs.filter((d) => Number.isFinite(d) && d >= 0);
+    rt.interChunkDelaysMs = Array.isArray(rt.interChunkDelaysMs)
+      ? rt.interChunkDelaysMs.filter((d) => Number.isFinite(d) && d >= 0)
+      : [];
     if (!Number.isFinite(rt.totalDurationMs) || rt.totalDurationMs < 0) rt.totalDurationMs = 0;
   }
 


### PR DESCRIPTION
## Why

Three pre-existing issues surfaced while reviewing #299 (the `toolResultContains` gate). None block that PR; they're worth fixing on their own. Prioritized from the review backlog as the items with real teeth (a publish-safety gap, a fixture-load footgun, and a broken canonical test example).

## What

**1. Release gate now validates exports + formatting** (`ci:`)
`release` ran `build && test && lint && publish` — it skipped `test:exports` (publint + attw) and `format:check`, so a broken export map could publish (this class of failure recurred, see CHANGELOG #263). Now: `format:check && build && test && lint && test:exports && publish` (format up front, exports after build since it needs `dist/`).

**2. A malformed fixture no longer aborts the whole file** (`fix:`)
`recordedTimings.interChunkDelaysMs` was `.filter`-ed with no `Array.isArray` guard (its siblings `ttftMs`/`totalDurationMs` are guarded). Since `loadFixtureFile` maps entries with no try/catch, a single fixture with a non-array value threw a `TypeError` that took down every fixture in the file — silently, via the loader's warn-and-return-empty wrapper. Now coerced to `[]`.

Red-green on the real loader:
- RED: `TypeError: Cannot read properties of null (reading 'filter')` — sibling fixtures fail to load.
- GREEN: malformed entry sanitized, all fixtures load.

**3. Fixed the broken E2E lifecycle in the write-fixtures skill** (`docs:`)
The canonical setup examples loaded fixtures once, then called full `reset()` in `afterEach` — which clears the fixture pool, so every test after the first 404s. Switched to the narrow `resetMatchCounts()` (and `suite.llm.resetMatchCounts()` for the suite — `MockSuite` has no `resetMatchCounts`), and reworded the two prose spots that steered readers to `reset()` between tests.

A full sweep of every doc surface confirmed the anti-pattern was confined to `skills/write-fixtures/SKILL.md` — the `docs/*.html` pages are correct (`docs/test-plugins` and `docs/control-api` are the right reference and already warn about it), and pytest fixtures are function-scoped so they're immune.

## Test

`format:check`, `lint`, `tsc --noEmit`, `test:exports` (all 🟢), `build`, and the full suite (4446 tests) all pass locally.
