### PR TITLE
fix(drift): cap auto-remediation PR/issue body under GitHub's 65536-char limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ packages/.claude/
 docs/superpowers/
 docs/plans/
 docs/specs/
+
+# fix-drift.ts workflow artifacts (regenerated each run; uploaded via fix-drift.yml)
+claude-code-output.log
+drift-report.json

--- a/scripts/fix-drift.ts
+++ b/scripts/fix-drift.ts
@@ -73,6 +73,29 @@ export function todayStamp(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+/** GitHub hard limit on PR/issue body length. */
+export const GH_BODY_MAX = 65536;
+/** Safety margin below the hard limit. */
+export const GH_BODY_SAFE_MAX = 60000;
+
+/**
+ * Truncate `body` to at most `max` characters. When truncation occurs, the
+ * HEAD of the body (summary/diffs) is preserved and the tail is replaced with a
+ * marker. The full detail is always available as a workflow artifact.
+ */
+export function truncateBody(body: string, max: number = GH_BODY_SAFE_MAX): string {
+  // Never exceed the hard GitHub limit, even if a caller passes a larger max.
+  const effectiveMax = Math.min(max, GH_BODY_MAX);
+  if (body.length <= effectiveMax) return body;
+  const marker =
+    "\n\n---\n" +
+    "_Body truncated to fit GitHub's 65536-character limit. " +
+    "Full drift report is attached as the `drift-report` workflow artifact._\n";
+  // When the budget can't even fit the marker, hard-cut instead of overflowing.
+  if (effectiveMax <= marker.length) return body.slice(0, effectiveMax);
+  return body.slice(0, effectiveMax - marker.length) + marker;
+}
+
 /**
  * Format an exec error into a human-readable Error object.
  * Includes exit status, signal, and stderr when available.
@@ -553,7 +576,7 @@ export function buildPrBody(report: DriftReport, changedFiles?: string[]): strin
     "</details>",
   );
 
-  return sections.join("\n");
+  return truncateBody(sections.join("\n"));
 }
 
 /**
@@ -706,29 +729,31 @@ function createIssue(report: DriftReport | null): void {
   const claudeOutput =
     readFileIfExists(resolve("claude-code-output.log")) ?? "(no output captured)";
 
-  const issueBody = [
-    "## Drift detected but auto-fix failed",
-    "",
-    "The automated drift remediation pipeline detected API drift but was unable",
-    "to fix it automatically. Manual intervention is required.",
-    "",
-    "### Drift Report",
-    "",
-    "```json",
-    reportJson,
-    "```",
-    "",
-    "### Claude Code Output",
-    "",
-    "<details>",
-    "<summary>Full output</summary>",
-    "",
-    "```",
-    claudeOutput,
-    "```",
-    "",
-    "</details>",
-  ].join("\n");
+  const issueBody = truncateBody(
+    [
+      "## Drift detected but auto-fix failed",
+      "",
+      "The automated drift remediation pipeline detected API drift but was unable",
+      "to fix it automatically. Manual intervention is required.",
+      "",
+      "### Drift Report",
+      "",
+      "```json",
+      reportJson,
+      "```",
+      "",
+      "### Claude Code Output",
+      "",
+      "<details>",
+      "<summary>Full output</summary>",
+      "",
+      "```",
+      claudeOutput,
+      "```",
+      "",
+      "</details>",
+    ].join("\n"),
+  );
 
   const issueTitle = `Drift detected — auto-fix failed (${stamp})`;
 

--- a/src/__tests__/fix-drift.test.ts
+++ b/src/__tests__/fix-drift.test.ts
@@ -42,6 +42,9 @@ import {
   getChangedFiles,
   affectedSkillSections,
   BUILDER_TO_SKILL_SECTION,
+  truncateBody,
+  GH_BODY_MAX,
+  GH_BODY_SAFE_MAX,
 } from "../../scripts/fix-drift.js";
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
@@ -600,6 +603,66 @@ describe("buildPrBody", () => {
     const body = buildPrBody(report);
     const expectedJson = JSON.stringify(report, null, 2);
     expect(body).toContain(expectedJson);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// truncateBody
+// ---------------------------------------------------------------------------
+
+describe("truncateBody", () => {
+  it("exports GH_BODY_MAX and GH_BODY_SAFE_MAX with sensible values", () => {
+    expect(GH_BODY_MAX).toBe(65536);
+    expect(GH_BODY_SAFE_MAX).toBeLessThan(GH_BODY_MAX);
+  });
+
+  it("passes through when under max", () => {
+    expect(truncateBody("hello", 60000)).toBe("hello");
+  });
+
+  it("truncates and appends marker when over max", () => {
+    const out = truncateBody("a".repeat(70000));
+    expect(out.length).toBeLessThanOrEqual(60000);
+    expect(out).toContain("Body truncated");
+  });
+
+  it("never exceeds max when max is smaller than the marker", () => {
+    expect(truncateBody("x".repeat(100), 10).length).toBeLessThanOrEqual(10);
+  });
+
+  it("never exceeds the hard GH_BODY_MAX even when caller passes a larger max", () => {
+    expect(truncateBody("x".repeat(70000), 100000).length).toBeLessThanOrEqual(GH_BODY_MAX);
+  });
+
+  it("returns under-limit input unchanged", () => {
+    expect(truncateBody("hello", 10)).toBe("hello");
+  });
+
+  it("appends marker and stays within effectiveMax when over-limit", () => {
+    const out = truncateBody("x".repeat(70000), 100000);
+    expect(out).toContain("Body truncated");
+    expect(out.length).toBeLessThanOrEqual(GH_BODY_MAX);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPrBody — body length cap
+// ---------------------------------------------------------------------------
+
+describe("buildPrBody — body length cap", () => {
+  it("caps the PR body under GitHub's 65536-char limit for huge reports", () => {
+    const entries = Array.from({ length: 400 }, (_, i) =>
+      makeEntry({ scenario: "x".repeat(500) + String(i) }),
+    );
+    const body = buildPrBody(makeReport({ entries }));
+    expect(body.length).toBeLessThanOrEqual(65536);
+    expect(body).toContain("## Summary");
+    expect(body).toContain("Body truncated");
+  });
+
+  it("leaves small bodies unchanged (no marker)", () => {
+    const body = buildPrBody(makeReport());
+    expect(body).not.toContain("Body truncated");
   });
 });
 


### PR DESCRIPTION
The **Fix Drift** workflow failed at PR creation on [run 29478043559](https://github.com/CopilotKit/aimock/actions/runs/29478043559): `gh pr create` rejected the body with `Body is too long (maximum is 65536 characters)`.

## Root cause
`buildPrBody` in `scripts/fix-drift.ts` inlines the entire drift report (`JSON.stringify(report, null, 2)`) into a `<details>` block. A wide-drift run produced a ~642 KB body — roughly 10× GitHub's 65536-char hard limit. No length guard existed anywhere on the path. `createIssue` inlines the same report plus the full Claude log and shares the identical limit.

## Fix
- **Cap the body.** New `truncateBody(s, max)` (safe cap 60000, under the 65536 limit): keeps the summary head, replaces the overflow tail with a truncation marker plus a pointer to the workflow run/artifacts. Applied at the two choke points — `buildPrBody`'s return and `createIssue`'s body.
- **Stop committing artifact noise.** `claude-code-output.log` and `drift-report.json` are now gitignored. The catch-all `git add` was sweeping them into the fix branch (the 1013-insertion noise), even though both are already uploaded as workflow artifacts.

## Testing
Red-green: pre-fix the oversized-body test fails (actual body measured at 642,426 chars); post-fix all 82 fix-drift tests pass and the body is ≤ 65536. Full suite green (4444 passed), lint / typecheck / build clean. No version bump — the release bump stays manual.
