### PR TITLE
Fix Drift: authenticate via copilotkit-devops-bot app token

### DIFF
--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -28,6 +28,12 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: '1108748'
+          private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -136,14 +142,14 @@ jobs:
         if: steps.autofix.outcome == 'success' && success() && steps.check.outputs.skip != 'true'
         run: git config --local url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
 
       # Step 5: Create PR on success
       - name: Create PR
         id: pr
         if: steps.autofix.outcome == 'success' && success() && steps.check.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           npx tsx scripts/fix-drift.ts --create-pr
           PR_URL=$(gh pr list --head "$(git branch --show-current)" --json url --jq '.[0].url')
@@ -154,9 +160,34 @@ jobs:
       - name: Auto-merge PR
         if: success() && steps.pr.outputs.url != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ steps.pr.outputs.url }}
-        run: gh pr merge "$PR_URL" --merge --auto
+        run: |
+          # Wait for CI to register and pass before merging. A ruleset bypass
+          # actor bypasses the entire ruleset, so the green gate must live here,
+          # not in branch protection. `gh pr checks --watch` blocks until all
+          # checks complete and exits non-zero if any fail; --fail-fast bails on
+          # first failure. Treat "no checks" as NOT-green: require at least one.
+          #
+          # First poll until at least one check is registered (up to ~5 min).
+          count=0
+          for i in $(seq 1 10); do
+            count=$(gh pr checks "$PR_URL" 2>/dev/null | wc -l)
+            if [ "$count" -gt 0 ]; then
+              echo "CI checks registered ($count rows), proceeding to watch"
+              break
+            fi
+            echo "No checks registered yet (attempt $i/10), waiting 30s..."
+            sleep 30
+          done
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No CI checks ever registered — not merging"
+            exit 1
+          fi
+          gh pr checks "$PR_URL" --watch --fail-fast --interval 30 || {
+            echo "::error::CI checks failed or none present — not merging"; exit 1;
+          }
+          gh pr merge "$PR_URL" --merge
 
       # Step 7: Slack notification on successful fix
       - name: Notify Slack on fix success

--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -32,8 +32,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: '1108748'
+          app-id: "1108748"
           private-key: ${{ secrets.DEVOPS_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Problem

The Fix Drift workflow was using `GITHUB_TOKEN` for every authenticated operation (git push, PR create, auto-merge). This has two critical consequences:

1. **PRs created by `GITHUB_TOKEN` don't trigger `pull_request` events** — GitHub suppresses the event to prevent recursive workflows, so drift fix PRs never get CI checks.
2. **`github-actions[bot]` can't satisfy main's approval rule** — the bot identity is not a permitted bypass actor, so even if CI somehow ran, the PR couldn't auto-merge.

## Fix

Mint a copilotkit-devops-bot (app-id `1108748`) installation token early in the job using `actions/create-github-app-token`, then use that token for all three authenticated operations:

- `Configure git for push` — injects the token into the git URL so the fix branch push is attributable to the bot
- `Create PR` — `GH_TOKEN` is the bot token, so `gh pr create` runs as devops-bot; GitHub fires `pull_request` — CI triggers
- `Auto-merge PR` — `GH_TOKEN` is the bot token; devops-bot is a scoped Integration bypass actor on main's ruleset

**Required secret:** `DEVOPS_BOT_PRIVATE_KEY` must be added to the repo/org Actions secrets (being added separately).

**Required ruleset entry:** devops-bot must be added as an Integration bypass actor on main's ruleset (being added separately).

## In-workflow CI green gate

A ruleset bypass actor bypasses the **entire** ruleset — including any required-status-checks rule. This means a bypassing actor's PR can merge immediately without waiting for CI. To prevent merging on a red or empty build:

- Poll until at least one check is registered (up to 10 x 30 s = 5 min); fail hard if none ever appear
- Run `gh pr checks --watch --fail-fast` to block until all checks pass; exit non-zero kills the step
- Only then call `gh pr merge --merge` (no `--auto` — we do the waiting ourselves)

This makes CI-green a hard precondition enforced in the workflow, not the ruleset.

## Diff summary

| Location | Change |
|---|---|
| After `actions/checkout` | Add `Mint app token` step (id: `app-token`) using `actions/create-github-app-token` pinned to v3.2.0 |
| `Configure git for push` env | `GITHUB_TOKEN` replaced with `steps.app-token.outputs.token` |
| `Create PR` env | `GITHUB_TOKEN` replaced with `steps.app-token.outputs.token` |
| `Auto-merge PR` env + run | `GITHUB_TOKEN` replaced with `steps.app-token.outputs.token`; one-liner `gh pr merge --auto` replaced with poll-then-watch-then-merge guard |

🤖 Generated with [Claude Code](https://claude.com/claude-code)