### PR TITLE
fix: cap uncapped string accumulators (RangeError: Invalid string length)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @copilotkit/aimock
 
+## [1.37.1] - 2026-07-16
+
+### Fixed
+
+- Capped the uncapped in-memory record buffers that could grow a string past V8's ~512 MiB max string length and throw `RangeError: Invalid string length` (the ~1/sec production crash, amplified once the real-key fixture-miss passthrough landed). The AG-UI recorder, the generic recorder, and the stream-collapse path now bound the buffer they `Buffer.concat(chunks).toString()` for fixture construction to a configurable `maxRecordBufferBytes` (default 64 MiB) clamped to a 256 MiB hard ceiling. Once the cap is crossed the recorder frees the buffer, marks the recording truncated, and skips fixture construction — the full upstream response is still relayed to the client byte-for-byte in real time, so capping never truncates what the client receives ("don't journal", not "don't answer") (#307)
+
 ## [1.37.0] - 2026-07-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/src/__tests__/agui-record-buffer-cap.test.ts
+++ b/src/__tests__/agui-record-buffer-cap.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import * as http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AGUIMock } from "../agui-mock.js";
+import { setAGUIRecordBufferCeilingForTests } from "../agui-recorder.js";
+import { Logger } from "../logger.js";
+
+// ---------------------------------------------------------------------------
+// AG-UI record-buffer cap.
+//
+// The AG-UI recorder tees every upstream SSE chunk to the client AND buffers a
+// copy so it can `Buffer.concat(chunks).toString()` + parse the events into a
+// fixture once the stream ends. With no cap, a large upstream response builds a
+// string past V8's ~512 MiB max string length and throws
+// `RangeError: Invalid string length` (the ~1/sec prod crash). These tests
+// exercise the REAL proxyAndRecordAGUI/teeUpstreamStream path via a raw local
+// upstream streaming a large SSE body, with a low test-only cap so the run
+// stays fast: the client must still receive every relayed byte, the server must
+// not crash, and recording must be skipped (no fixture written).
+// ---------------------------------------------------------------------------
+
+let upstream: http.Server | undefined;
+let agui: AGUIMock | undefined;
+let tmpDir: string | undefined;
+
+afterEach(async () => {
+  if (agui) {
+    try {
+      await agui.stop();
+    } catch {
+      /* already stopped */
+    }
+    agui = undefined;
+  }
+  if (upstream) {
+    await new Promise<void>((resolve) => upstream!.close(() => resolve()));
+    upstream = undefined;
+  }
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = undefined;
+  }
+  setAGUIRecordBufferCeilingForTests(undefined);
+  vi.restoreAllMocks();
+});
+
+/**
+ * A raw upstream that streams `totalBytes` of valid AG-UI SSE frames in
+ * `chunkBytes`-sized frames, then closes. Each frame is a TEXT_MESSAGE_CONTENT
+ * event so the recorder's SSE parser exercises normally under the cap.
+ */
+function createLargeAguiUpstream(totalBytes: number, chunkBytes: number): Promise<string> {
+  return new Promise((resolve) => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      let sent = 0;
+      const writeNext = () => {
+        if (res.writableEnded || res.destroyed) return;
+        if (sent >= totalBytes) {
+          res.end();
+          return;
+        }
+        const payload = JSON.stringify({
+          type: "TEXT_MESSAGE_CONTENT",
+          messageId: "m1",
+          delta: "x".repeat(Math.max(1, chunkBytes)),
+        });
+        const frame = `data: ${payload}\n\n`;
+        sent += Buffer.byteLength(frame);
+        if (res.write(frame)) {
+          setImmediate(writeNext);
+        } else {
+          res.once("drain", writeNext);
+        }
+      };
+      writeNext();
+    });
+    upstream.listen(0, "127.0.0.1", () => {
+      const { port } = upstream!.address() as { port: number };
+      resolve(`http://127.0.0.1:${port}`);
+    });
+  });
+}
+
+/** Stream a POST and count relayed bytes without buffering a huge string. */
+function postStreaming(url: string): Promise<{ status: number; bytesReceived: number }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify({
+      threadId: "t1",
+      runId: "r1",
+      messages: [{ id: "u1", role: "user", content: "stream me a lot" }],
+      tools: [],
+      context: [],
+      state: {},
+      forwardedProps: {},
+    });
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        let bytesReceived = 0;
+        res.on("data", (c: Buffer) => {
+          bytesReceived += c.length;
+        });
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, bytesReceived }));
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+describe("AG-UI record-buffer cap", () => {
+  it("relays the full streamed body, does not throw, and skips recording when over the cap", async () => {
+    // 4 MB total, ~4 KB frames, with a low 256 KB test-only ceiling so the
+    // buffer must truncate well before the full body accumulates. The client
+    // must still receive every relayed byte.
+    const TOTAL = 4 * 1024 * 1024;
+    const CHUNK = 4 * 1024;
+    setAGUIRecordBufferCeilingForTests(256 * 1024);
+
+    const upstreamUrl = await createLargeAguiUpstream(TOTAL, CHUNK);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agui-bufcap-"));
+
+    const warnings: string[] = [];
+    vi.spyOn(Logger.prototype, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    });
+
+    agui = new AGUIMock({ port: 0, logLevel: "warn" });
+    agui.enableRecording({ upstream: upstreamUrl, proxyOnly: false, fixturePath: tmpDir });
+    await agui.start();
+
+    const resp = await postStreaming(agui.url);
+
+    // Client correctness: full relay regardless of the cap. If the server had
+    // crashed with Invalid string length the relay would have been cut short.
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThanOrEqual(TOTAL);
+
+    // The record-buffer cap tripped and recording was skipped.
+    expect(warnings.some((w) => /record buffer cap/i.test(w))).toBe(true);
+
+    // No fixture written (the partial buffer was dropped, not journaled).
+    const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith(".json"));
+    expect(files).toHaveLength(0);
+  });
+
+  it("records normally when the response stays under the cap", async () => {
+    const TOTAL = 32 * 1024;
+    const CHUNK = 4 * 1024;
+    setAGUIRecordBufferCeilingForTests(4 * 1024 * 1024);
+
+    const upstreamUrl = await createLargeAguiUpstream(TOTAL, CHUNK);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agui-bufcap-ok-"));
+
+    agui = new AGUIMock({ port: 0 });
+    agui.enableRecording({ upstream: upstreamUrl, proxyOnly: false, fixturePath: tmpDir });
+    await agui.start();
+
+    const resp = await postStreaming(agui.url);
+    expect(resp.status).toBe(200);
+    expect(resp.bytesReceived).toBeGreaterThanOrEqual(TOTAL);
+
+    // Under the cap → a fixture IS written.
+    const files = fs.readdirSync(tmpDir).filter((f) => f.endsWith(".json"));
+    expect(files.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/stream-collapse-string-cap.test.ts
+++ b/src/__tests__/stream-collapse-string-cap.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  collapseOpenAISSE,
+  collapseAnthropicSSE,
+  collapseGeminiSSE,
+  collapseCohereSSE,
+  collapseOllamaNDJSON,
+  collapseGeminiInteractionsSSE,
+  collapseBedrockEventStream,
+  setCollapseStringLimitForTests,
+  MAX_COLLAPSE_STRING_LENGTH,
+} from "../stream-collapse.js";
+
+// ---------------------------------------------------------------------------
+// Accumulated-string cap on the stream collapsers.
+//
+// Each collapser accumulates per-channel strings (`content`, `reasoning`, a
+// tool call's `arguments`, `audioB64`, ...) from stream fragments with `+=`.
+// With no cap a large upstream response builds a string past V8's ~512 MiB max
+// string length and throws `RangeError: Invalid string length` — the ~1/sec
+// prod crash, caught at server.ts:1230. These tests use a tiny test-only limit
+// so they exercise the REAL accumulator/guard code without allocating 512 MiB:
+// the collapser must NOT throw, must clamp `content` at the ceiling, and must
+// stamp `truncated: true` so the recorder skips journaling a partial fixture.
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  setCollapseStringLimitForTests(undefined);
+});
+
+/** Build an OpenAI SSE body whose accumulated `content` is `totalChars` long. */
+function openAiSseBody(totalChars: number, perFrame: number): string {
+  const frames: string[] = [];
+  let emitted = 0;
+  while (emitted < totalChars) {
+    const n = Math.min(perFrame, totalChars - emitted);
+    frames.push(
+      `data: ${JSON.stringify({ choices: [{ delta: { content: "a".repeat(n) } }] })}\n\n`,
+    );
+    emitted += n;
+  }
+  frames.push("data: [DONE]\n\n");
+  return frames.join("");
+}
+
+describe("stream-collapse accumulated-string cap", () => {
+  it("has a real ceiling comfortably below V8's max string length", () => {
+    // V8 max string length on 64-bit is 2^29 - 1 (~536.87M). The ceiling must
+    // be strictly below it so an accumulator clamped at the ceiling can never
+    // reach the throwing boundary.
+    expect(MAX_COLLAPSE_STRING_LENGTH).toBeLessThan(2 ** 29 - 1);
+    expect(MAX_COLLAPSE_STRING_LENGTH).toBeGreaterThan(0);
+  });
+
+  it("clamps OpenAI content at the ceiling, marks truncated, and never throws", () => {
+    setCollapseStringLimitForTests(1000);
+    // 5000 chars of content across 100-char frames — 5x over the 1000 ceiling.
+    const body = openAiSseBody(5000, 100);
+
+    let result: ReturnType<typeof collapseOpenAISSE> | undefined;
+    expect(() => {
+      result = collapseOpenAISSE(body);
+    }).not.toThrow();
+
+    // content clamped at (or below) the ceiling — never past it.
+    expect(result!.content!.length).toBeLessThanOrEqual(1000);
+    // The over-ceiling input is flagged so the recorder skips journaling.
+    expect(result!.truncated).toBe(true);
+  });
+
+  it("does not truncate when content stays under the ceiling", () => {
+    setCollapseStringLimitForTests(1_000_000);
+    const body = openAiSseBody(500, 100);
+    const result = collapseOpenAISSE(body);
+    expect(result.content).toBe("a".repeat(500));
+    expect(result.truncated).toBeUndefined();
+  });
+
+  it("caps Anthropic content and marks truncated without throwing", () => {
+    setCollapseStringLimitForTests(1000);
+    const frames: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      frames.push(
+        `event: content_block_delta\ndata: ${JSON.stringify({
+          delta: { type: "text_delta", text: "b".repeat(100) },
+        })}\n\n`,
+      );
+    }
+    const body = frames.join("");
+    let result: ReturnType<typeof collapseAnthropicSSE> | undefined;
+    expect(() => {
+      result = collapseAnthropicSSE(body);
+    }).not.toThrow();
+    expect(result!.content!.length).toBeLessThanOrEqual(1000);
+    expect(result!.truncated).toBe(true);
+  });
+
+  it("caps Gemini, Cohere, Ollama, and Gemini-Interactions without throwing", () => {
+    setCollapseStringLimitForTests(500);
+
+    const gemini = collapseGeminiSSE(
+      Array.from(
+        { length: 20 },
+        () =>
+          `data: ${JSON.stringify({
+            candidates: [{ content: { parts: [{ text: "g".repeat(100) }] } }],
+          })}\n\n`,
+      ).join(""),
+    );
+    expect(gemini.content!.length).toBeLessThanOrEqual(500);
+    expect(gemini.truncated).toBe(true);
+
+    const cohere = collapseCohereSSE(
+      Array.from(
+        { length: 20 },
+        () =>
+          `event: content-delta\ndata: ${JSON.stringify({
+            delta: { message: { content: { text: "c".repeat(100) } } },
+          })}\n\n`,
+      ).join(""),
+    );
+    expect(cohere.content!.length).toBeLessThanOrEqual(500);
+    expect(cohere.truncated).toBe(true);
+
+    const ollama = collapseOllamaNDJSON(
+      Array.from(
+        { length: 20 },
+        () => `${JSON.stringify({ message: { content: "o".repeat(100) } })}\n`,
+      ).join(""),
+    );
+    expect(ollama.content!.length).toBeLessThanOrEqual(500);
+    expect(ollama.truncated).toBe(true);
+
+    const geminiInteractions = collapseGeminiInteractionsSSE(
+      Array.from(
+        { length: 20 },
+        () =>
+          `data: ${JSON.stringify({
+            event_type: "step.delta",
+            index: 0,
+            delta: { type: "text", text: "i".repeat(100) },
+          })}\n\n`,
+      ).join(""),
+    );
+    expect(geminiInteractions.content!.length).toBeLessThanOrEqual(500);
+    expect(geminiInteractions.truncated).toBe(true);
+  });
+
+  it("caps Bedrock EventStream input by byte length and marks truncated", () => {
+    setCollapseStringLimitForTests(64);
+    // A raw buffer over the (byte) ceiling — even garbage bytes must be bounded
+    // and flagged truncated rather than fed unbounded into the accumulators.
+    const big = Buffer.alloc(4096, 0x41); // 4 KiB of 'A'
+    let result: ReturnType<typeof collapseBedrockEventStream> | undefined;
+    expect(() => {
+      result = collapseBedrockEventStream(big);
+    }).not.toThrow();
+    expect(result!.truncated).toBe(true);
+  });
+});

--- a/src/agui-recorder.ts
+++ b/src/agui-recorder.ts
@@ -21,6 +21,55 @@ import type { Logger } from "./logger.js";
 export const NO_USER_MESSAGE_SENTINEL = "__NO_USER_MESSAGE__";
 
 /**
+ * Default ceiling (bytes) for the in-memory AG-UI record buffer. The recorder
+ * tees every upstream SSE chunk straight to the client AND buffers a copy so it
+ * can `Buffer.concat(chunks).toString()` + parse the SSE events into a fixture
+ * once the stream ends. With no cap, a large upstream response (amplified since
+ * the real-key fixture-miss passthrough landed) builds a string past V8's
+ * ~512 MiB max string length and throws `RangeError: Invalid string length`.
+ * 64 MiB mirrors the generic proxy path's `DEFAULT_MAX_PROXY_BUFFER_BYTES` and
+ * is generous for any real agent turn. Overridable via
+ * `AGUIRecordConfig.maxRecordBufferBytes`.
+ */
+export const DEFAULT_AGUI_RECORD_BUFFER_BYTES = 64 * 1024 * 1024; // 64 MiB
+
+/**
+ * Absolute hard ceiling (bytes) for the AG-UI record buffer, independent of the
+ * configurable `maxRecordBufferBytes`, mirroring the generic proxy path's
+ * `PROXY_BUFFER_HARD_CEILING`. 256 MiB of bytes can never decode to more than
+ * 256 Mi UTF-16 code units, comfortably below V8's 2^29 - 1 string-length limit,
+ * so the eventual `Buffer.concat(chunks).toString()` can never throw.
+ */
+export const AGUI_RECORD_BUFFER_HARD_CEILING = 256 * 1024 * 1024; // 256 MiB
+
+/**
+ * Test-only override of the effective AG-UI record-buffer ceiling. Lets the cap
+ * suite exercise the over-cap truncation path with a small body instead of
+ * streaming hundreds of MB. `undefined` (the default) uses the configured /
+ * default cap. NEVER set from production code.
+ */
+let aguiRecordBufferCeilingOverride: number | undefined;
+
+/** @internal test-only — see {@link aguiRecordBufferCeilingOverride}. */
+export function setAGUIRecordBufferCeilingForTests(value: number | undefined): void {
+  aguiRecordBufferCeilingOverride = value;
+}
+
+/**
+ * Resolve the effective AG-UI record-buffer byte cap: honor a test-only
+ * override, else the configured `maxRecordBufferBytes` (clamped to the hard
+ * ceiling), else the default. Non-finite / non-positive configured values fall
+ * back to the default.
+ */
+function resolveAGUIRecordBufferCap(configured: number | undefined): number {
+  if (aguiRecordBufferCeilingOverride !== undefined) return aguiRecordBufferCeilingOverride;
+  if (configured == null || !Number.isFinite(configured) || configured <= 0) {
+    return DEFAULT_AGUI_RECORD_BUFFER_BYTES;
+  }
+  return Math.min(configured, AGUI_RECORD_BUFFER_HARD_CEILING);
+}
+
+/**
  * Proxy an unmatched AG-UI request to a real upstream agent, record the
  * SSE event stream as a fixture on disk and in memory, and relay the
  * response back to the original client in real time.
@@ -152,6 +201,15 @@ function teeUpstreamStream(
 
         const chunks: Buffer[] = [];
         let clientWriteFailed = false;
+        // Bound the in-memory record buffer so a single huge upstream response
+        // cannot build a string past V8's ~512 MiB limit
+        // (RangeError: Invalid string length) when we `Buffer.concat`+stringify
+        // it below. The client relay above is INDEPENDENT of this buffer, so
+        // capping it never truncates what the client receives — the cap means
+        // "don't journal", not "don't answer" (mirrors the generic proxy path).
+        const recordBufferCap = resolveAGUIRecordBufferCap(config.maxRecordBufferBytes);
+        let bufferedBytes = 0;
+        let recordTruncated = false;
 
         upstreamRes.on("data", (chunk: Buffer) => {
           // Relay to client in real time
@@ -166,8 +224,21 @@ function teeUpstreamStream(
               );
             }
           }
-          // Buffer for fixture construction
+          // Buffer for fixture construction, bounded by the record-buffer cap.
+          // Once the cap is crossed we stop accumulating and free the buffer so
+          // heap growth is bounded and the end-handler skips concat/stringify.
+          if (recordTruncated) return;
+          if (bufferedBytes + chunk.length > recordBufferCap) {
+            recordTruncated = true;
+            chunks.length = 0;
+            bufferedBytes = 0;
+            logger?.warn(
+              `AG-UI upstream response exceeded the ${recordBufferCap}-byte record buffer cap — relaying full body to client, but skipping fixture recording to bound memory`,
+            );
+            return;
+          }
           chunks.push(chunk);
+          bufferedBytes += chunk.length;
         });
 
         let settled = false;
@@ -215,6 +286,20 @@ function teeUpstreamStream(
               "Failed to end client response:",
               writeErr instanceof Error ? writeErr.message : String(writeErr),
             );
+          }
+
+          // Record buffer cap tripped: the buffered copy is partial (and was
+          // freed), so we cannot faithfully build a fixture. The client already
+          // received every byte via the live tee above, so just skip recording
+          // — never stringify the (now-empty) buffer, never persist a truncated
+          // fixture. Mirrors the generic proxy path's over-cap "skip recording,
+          // still answer the client" behavior.
+          if (recordTruncated) {
+            logger.warn(
+              "AG-UI record buffer cap exceeded — response relayed to client, recording skipped",
+            );
+            resolve(clientStatus);
+            return;
           }
 
           // Parse buffered SSE events

--- a/src/agui-types.ts
+++ b/src/agui-types.ts
@@ -411,4 +411,17 @@ export interface AGUIRecordConfig {
   upstream: string;
   fixturePath?: string;
   proxyOnly?: boolean;
+  /**
+   * Maximum number of bytes the AG-UI recorder will accumulate in memory from a
+   * single proxied upstream SSE stream in order to parse + journal it. The full
+   * stream is still relayed to the client byte-for-byte in real time; this cap
+   * only bounds the in-memory buffer that is later `Buffer.concat`-ed and
+   * stringified for fixture construction. Once exceeded the recorder stops
+   * appending to the buffer, marks the recording truncated, and skips fixture
+   * construction — preventing both unbounded heap growth and the
+   * `RangeError: Invalid string length` a >512MB `Buffer.concat(chunks).toString()`
+   * would otherwise throw. Clamped to `AGUI_RECORD_BUFFER_HARD_CEILING`.
+   * Default: 64 MiB.
+   */
+  maxRecordBufferBytes?: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,8 @@ export {
   collapseCohereSSE,
   collapseBedrockEventStream,
   collapseStreamingResponse,
+  MAX_COLLAPSE_STRING_LENGTH,
+  setCollapseStringLimitForTests,
 } from "./stream-collapse.js";
 export type { CollapseResult } from "./stream-collapse.js";
 
@@ -224,7 +226,12 @@ export type {
 
 // AG-UI
 export { AGUIMock } from "./agui-mock.js";
-export { proxyAndRecordAGUI } from "./agui-recorder.js";
+export {
+  proxyAndRecordAGUI,
+  DEFAULT_AGUI_RECORD_BUFFER_BYTES,
+  AGUI_RECORD_BUFFER_HARD_CEILING,
+  setAGUIRecordBufferCeilingForTests,
+} from "./agui-recorder.js";
 export type {
   AGUIMockOptions,
   AGUIRunAgentInput,

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -27,10 +27,18 @@ import { DEFAULT_TEST_ID } from "./constants.js";
 /** Headers to strip when proxying — hop-by-hop (RFC 2616 §13.5.1) + client-set. */
 /**
  * Default ceiling (bytes) for the in-memory proxy-path buffer. Chosen well
- * under V8's ~512 MiB max string length so `rawBuffer.toString()` /
- * stream-collapse never throws `RangeError: Invalid string length`, and so a
- * single huge proxied response cannot spike the heap unbounded. Overridable
- * via `RecordConfig.maxProxyBufferBytes` / `--max-proxy-buffer-bytes`.
+ * under V8's ~512 MiB max string length so `rawBuffer.toString()` cannot throw
+ * `RangeError: Invalid string length`, and so a single huge proxied response
+ * cannot spike the heap unbounded. Overridable via
+ * `RecordConfig.maxProxyBufferBytes` / `--max-proxy-buffer-bytes`.
+ *
+ * NOTE: this byte cap bounds the RAW BUFFER only. `stream-collapse` accumulates
+ * its own per-channel strings (`content`/`reasoning`/tool `arguments`/etc.) from
+ * that buffer and is ALSO reachable directly (exported from index.ts), so it
+ * carries its OWN independent guard (`MAX_COLLAPSE_STRING_LENGTH`) rather than
+ * relying on this cap — an earlier version of this comment wrongly asserted
+ * stream-collapse "never throws Invalid string length", which was false for the
+ * unbounded `content += delta` accumulators (the ~1/sec prod RangeError).
  */
 export const DEFAULT_MAX_PROXY_BUFFER_BYTES = 64 * 1024 * 1024; // 64 MiB
 

--- a/src/stream-collapse.ts
+++ b/src/stream-collapse.ts
@@ -13,6 +13,85 @@ import type { Logger } from "./logger.js";
 import { isHarmonyContent, parseHarmonyContent } from "./harmony.js";
 
 // ---------------------------------------------------------------------------
+// Accumulated-string cap (RangeError: Invalid string length guard)
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard ceiling (UTF-16 code units) for any SINGLE string a collapser
+ * accumulates across deltas (`content`, `reasoning`, a tool call's
+ * `arguments`, `audioB64`, `argsStr`, and the coalesced text of `orderAtoms`).
+ *
+ * V8's maximum string length on 64-bit is 2^29 - 1 (~536.8M UTF-16 code
+ * units); appending past it throws `RangeError: Invalid string length`. The
+ * proxy path bounds the raw BYTE buffer under `PROXY_BUFFER_HARD_CEILING`
+ * (256 MiB) before collapse, but the collapser is ALSO reachable directly
+ * (exported from index.ts) and — even on the proxy path — a single accumulator
+ * can approach the byte budget in code units, so it needs its own guard rather
+ * than relying on the byte cap alone. 256Mi code units is comfortably below
+ * V8's limit while leaving huge headroom for any real completion (whose
+ * accumulated content can never exceed the total streamed body).
+ *
+ * When an append would cross the ceiling the accumulator keeps the ceiling's
+ * worth of characters, drops the overflow, and marks itself truncated — never
+ * throwing — mirroring the proxy buffer's "bound then mark truncated, never
+ * fail the client" discipline.
+ */
+export const MAX_COLLAPSE_STRING_LENGTH = 256 * 1024 * 1024; // 256 Mi UTF-16 code units
+
+/**
+ * Test-only override of {@link MAX_COLLAPSE_STRING_LENGTH}. Lets the cap suite
+ * exercise the truncation path with a tiny budget instead of building a
+ * multi-hundred-MB string. `undefined` (the default) uses the real ceiling.
+ * NEVER set from production code.
+ */
+let collapseStringLimitOverride: number | undefined;
+
+/** @internal test-only — see {@link collapseStringLimitOverride}. */
+export function setCollapseStringLimitForTests(value: number | undefined): void {
+  collapseStringLimitOverride = value;
+}
+
+/** Effective accumulated-string ceiling, honoring any active test-only override. */
+function effectiveCollapseStringLimit(): number {
+  return collapseStringLimitOverride ?? MAX_COLLAPSE_STRING_LENGTH;
+}
+
+/**
+ * Guard a raw collapse-input body against V8's max string length BEFORE any
+ * per-delta accumulation begins. Every collapser accumulates `content` /
+ * `reasoning` / a tool call's `arguments` / `audioB64` / `argsStr` (and the
+ * coalesced text of `orderAtoms`) from fragments of `body`; the sum of any one
+ * of those accumulators can never exceed the total input length, so bounding
+ * the INPUT under the ceiling bounds EVERY accumulator at once — no per-`+=`
+ * site can then build a string past the limit and throw
+ * `RangeError: Invalid string length` (the ~1/sec prod crash).
+ *
+ * Returns the body UNCHANGED when it is within the ceiling. When it exceeds the
+ * ceiling this returns a hard-truncated prefix (never throwing) — the collapse
+ * result the caller builds from it is marked incomplete via `truncated: true`
+ * (see {@link isCollapseInputTruncated}). This mirrors the proxy buffer's
+ * "bound then mark truncated, never fail the client" discipline: on the proxy
+ * path a body this large has already tripped the byte cap and skipped recording,
+ * so this is a defense-in-depth backstop that also covers the direct (exported)
+ * collapse callers where no byte cap ran.
+ */
+function guardCollapseBody(body: string): string {
+  const limit = effectiveCollapseStringLimit();
+  if (body.length <= limit) return body;
+  return body.slice(0, limit);
+}
+
+/**
+ * True when a body exceeded the accumulated-string ceiling and had to be
+ * truncated by {@link guardCollapseBody}. Collapsers stamp `truncated: true` on
+ * their result in this case so the recorder skips journaling a partial fixture,
+ * exactly like a transport-truncated stream.
+ */
+function isCollapseInputTruncated(body: string): boolean {
+  return body.length > effectiveCollapseStringLimit();
+}
+
+// ---------------------------------------------------------------------------
 // Result type shared by all collapse functions
 // ---------------------------------------------------------------------------
 
@@ -277,7 +356,9 @@ function extractSSEData(lines: string[]): string | undefined {
  *   data: {"id":"chatcmpl-123","choices":[{"delta":{"content":"Hello"}}]}\n\n
  *   data: [DONE]\n\n
  */
-export function collapseOpenAISSE(body: string): CollapseResult {
+export function collapseOpenAISSE(rawBody: string): CollapseResult {
+  const inputTruncated = isCollapseInputTruncated(rawBody);
+  const body = guardCollapseBody(rawBody);
   const lines = splitSSEEvents(body);
   let content = "";
   let reasoning = "";
@@ -487,6 +568,7 @@ export function collapseOpenAISSE(body: string): CollapseResult {
       ...(firstDroppedSample ? { firstDroppedSample } : {}),
       ...(harmonyUnparsed ? { harmonyUnparsed: true } : {}),
       ...(harmonyNote ? { harmonyNote } : {}),
+      ...(inputTruncated ? { truncated: true } : {}),
     };
   }
 
@@ -498,6 +580,7 @@ export function collapseOpenAISSE(body: string): CollapseResult {
     ...(firstDroppedSample ? { firstDroppedSample } : {}),
     ...(harmonyUnparsed ? { harmonyUnparsed: true } : {}),
     ...(harmonyNote ? { harmonyNote } : {}),
+    ...(inputTruncated ? { truncated: true } : {}),
   };
 }
 
@@ -512,7 +595,9 @@ export function collapseOpenAISSE(body: string): CollapseResult {
  *   event: message_start\ndata: {...}\n\n
  *   event: content_block_delta\ndata: {"delta":{"type":"text_delta","text":"Hello"}}\n\n
  */
-export function collapseAnthropicSSE(body: string): CollapseResult {
+export function collapseAnthropicSSE(rawBody: string): CollapseResult {
+  const inputTruncated = isCollapseInputTruncated(rawBody);
+  const body = guardCollapseBody(rawBody);
   const blocks = splitSSEEvents(body);
   let content = "";
   let reasoning = "";
@@ -679,6 +764,7 @@ export function collapseAnthropicSSE(body: string): CollapseResult {
       ...(redactedThinking.length > 0 ? { redactedThinking } : {}),
       ...(droppedChunks > 0 ? { droppedChunks } : {}),
       ...(firstDroppedSample ? { firstDroppedSample } : {}),
+      ...(inputTruncated ? { truncated: true } : {}),
     };
   }
 
@@ -689,6 +775,7 @@ export function collapseAnthropicSSE(body: string): CollapseResult {
     ...(redactedThinking.length > 0 ? { redactedThinking } : {}),
     ...(droppedChunks > 0 ? { droppedChunks } : {}),
     ...(firstDroppedSample ? { firstDroppedSample } : {}),
+    ...(inputTruncated ? { truncated: true } : {}),
   };
 }
 
@@ -702,7 +789,9 @@ export function collapseAnthropicSSE(body: string): CollapseResult {
  * Format (data-only, no event prefix, no [DONE]):
  *   data: {"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]}\n\n
  */
-export function collapseGeminiSSE(body: string): CollapseResult {
+export function collapseGeminiSSE(rawBody: string): CollapseResult {
+  const inputTruncated = isCollapseInputTruncated(rawBody);
+  const body = guardCollapseBody(rawBody);
   const lines = splitSSEEvents(body);
   let content = "";
   let reasoning = "";
@@ -809,6 +898,7 @@ export function collapseGeminiSSE(body: string): CollapseResult {
       ...(normalizedToolCalls.length > 0 ? { toolCalls: normalizedToolCalls } : {}),
       ...(droppedChunks > 0 ? { droppedChunks } : {}),
       ...(firstDroppedSample ? { firstDroppedSample } : {}),
+      ...(inputTruncated ? { truncated: true } : {}),
     };
   }
 
@@ -821,6 +911,7 @@ export function collapseGeminiSSE(body: string): CollapseResult {
       ...(reasoning ? { reasoning } : {}),
       ...(droppedChunks > 0 ? { droppedChunks } : {}),
       ...(firstDroppedSample ? { firstDroppedSample } : {}),
+      ...(inputTruncated ? { truncated: true } : {}),
     };
   }
 
@@ -829,6 +920,7 @@ export function collapseGeminiSSE(body: string): CollapseResult {
     ...(reasoning ? { reasoning } : {}),
     ...(droppedChunks > 0 ? { droppedChunks } : {}),
     ...(firstDroppedSample ? { firstDroppedSample } : {}),
+    ...(inputTruncated ? { truncated: true } : {}),
   };
 }
 
@@ -850,7 +942,9 @@ export function collapseGeminiSSE(body: string): CollapseResult {
  * content is run through the same fail-safe {@link parseHarmonyContent} gate to
  * capture structured tool calls / reasoning instead of leaking raw tokens.
  */
-export function collapseOllamaNDJSON(body: string): CollapseResult {
+export function collapseOllamaNDJSON(rawBody: string): CollapseResult {
+  const inputTruncated = isCollapseInputTruncated(rawBody);
+  const body = guardCollapseBody(rawBody);
   const lines = body.split("\n").filter((l) => l.trim().length > 0);
   let content = "";
   let reasoning = "";
@@ -954,6 +1048,7 @@ export function collapseOllamaNDJSON(body: string): CollapseResult {
       ...(firstDroppedSample ? { firstDroppedSample } : {}),
       ...(harmonyUnparsed ? { harmonyUnparsed: true } : {}),
       ...(harmonyNote ? { harmonyNote } : {}),
+      ...(inputTruncated ? { truncated: true } : {}),
     };
   }
 
@@ -964,6 +1059,7 @@ export function collapseOllamaNDJSON(body: string): CollapseResult {
     ...(firstDroppedSample ? { firstDroppedSample } : {}),
     ...(harmonyUnparsed ? { harmonyUnparsed: true } : {}),
     ...(harmonyNote ? { harmonyNote } : {}),
+    ...(inputTruncated ? { truncated: true } : {}),
   };
 }
 
@@ -977,7 +1073,9 @@ export function collapseOllamaNDJSON(body: string): CollapseResult {
  * Format:
  *   event: content-delta\ndata: {"type":"content-delta","delta":{"message":{"content":{"text":"Hello"}}}}\n\n
  */
-export function collapseCohereSSE(body: string): CollapseResult {
+export function collapseCohereSSE(rawBody: string): CollapseResult {
+  const inputTruncated = isCollapseInputTruncated(rawBody);
+  const body = guardCollapseBody(rawBody);
   const blocks = splitSSEEvents(body);
   let content = "";
   // Reasoning text assembled from `thinking` content-delta blocks. Cohere's
@@ -1129,6 +1227,7 @@ export function collapseCohereSSE(body: string): CollapseResult {
       ...(reasoning ? { reasoning } : {}),
       ...(droppedChunks > 0 ? { droppedChunks } : {}),
       ...(firstDroppedSample ? { firstDroppedSample } : {}),
+      ...(inputTruncated ? { truncated: true } : {}),
     };
   }
 
@@ -1137,6 +1236,7 @@ export function collapseCohereSSE(body: string): CollapseResult {
     ...(reasoning ? { reasoning } : {}),
     ...(droppedChunks > 0 ? { droppedChunks } : {}),
     ...(firstDroppedSample ? { firstDroppedSample } : {}),
+    ...(inputTruncated ? { truncated: true } : {}),
   };
 }
 
@@ -1254,8 +1354,18 @@ function decodeEventStreamFrames(buf: Buffer): {
  * Each frame contains a JSON payload with event types like:
  *   contentBlockDelta, contentBlockStart, etc.
  */
-export function collapseBedrockEventStream(body: Buffer): CollapseResult {
-  const { frames, truncated } = decodeEventStreamFrames(body);
+export function collapseBedrockEventStream(rawBody: Buffer): CollapseResult {
+  // Bound the input under V8's max string length before decoding: `content` /
+  // `reasoning` / a tool call's `arguments` accumulate across frames and can
+  // never exceed the total decoded bytes, so capping the input buffer bounds
+  // every accumulator and prevents `RangeError: Invalid string length`. An
+  // over-ceiling buffer is truncated (a partial trailing frame simply fails CRC
+  // and stops parsing) and the result is marked `truncated`.
+  const limit = effectiveCollapseStringLimit();
+  const inputTruncated = rawBody.byteLength > limit;
+  const body = inputTruncated ? rawBody.subarray(0, limit) : rawBody;
+  const { frames, truncated: frameTruncated } = decodeEventStreamFrames(body);
+  const truncated = frameTruncated || inputTruncated;
   let content = "";
   // Reasoning text assembled from Converse `reasoningContent.text` deltas. The
   // Bedrock Converse stream interleaves a `delta.reasoningContent` block carrying
@@ -1498,7 +1608,9 @@ export function collapseBedrockEventStream(body: Buffer): CollapseResult {
  * delta) are still accepted for backward compatibility with previously
  * recorded fixtures.
  */
-export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
+export function collapseGeminiInteractionsSSE(rawBody: string): CollapseResult {
+  const inputTruncated = isCollapseInputTruncated(rawBody);
+  const body = guardCollapseBody(rawBody);
   const lines = splitSSEEvents(body);
   let content = "";
   let reasoning = "";
@@ -1658,6 +1770,7 @@ export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
       ...(reasoning ? { reasoning } : {}),
       ...(droppedChunks > 0 ? { droppedChunks } : {}),
       ...(firstDroppedSample ? { firstDroppedSample } : {}),
+      ...(inputTruncated ? { truncated: true } : {}),
     };
   }
 
@@ -1666,6 +1779,7 @@ export function collapseGeminiInteractionsSSE(body: string): CollapseResult {
     ...(reasoning ? { reasoning } : {}),
     ...(droppedChunks > 0 ? { droppedChunks } : {}),
     ...(firstDroppedSample ? { firstDroppedSample } : {}),
+    ...(inputTruncated ? { truncated: true } : {}),
   };
 }
 


### PR DESCRIPTION
## Problem

`RangeError: Invalid string length` was firing ~1/sec in prod (caught at `server.ts:1230`). V8's max string length on 64-bit is `2^29-1` (~512MiB of UTF-16 code units); appending past it throws.

Two **uncapped** in-memory string accumulators in the aimock binary build a JS string past that limit:

1. **`src/agui-recorder.ts`** — on stream end the recorder does `Buffer.concat(chunks).toString()` over every buffered upstream SSE chunk with **no byte cap** (unlike the generic proxy path in `recorder.ts`, which is capped at 64MiB `maxProxyBufferBytes` / 256MiB `PROXY_BUFFER_HARD_CEILING`).
2. **`src/stream-collapse.ts`** — the `content += delta` / `reasoning += delta` / `entry.arguments += delta` / `audioB64 += …` / `argsStr += …` accumulators (plus `orderAtoms` coalescing) grow unbounded across every collapser.

Amplified 07-13 by the real-key fixture-miss passthrough (`b2ef945`): large **real** upstream responses now flow into these accumulators. The `recorder.ts` comment claiming "stream-collapse never throws Invalid string length" was **false** for these paths and is fixed here.

## Fix

Mirrors the existing `PROXY_BUFFER_HARD_CEILING` / `maxProxyBufferBytes` discipline — **bound then mark truncated, never fail the client**. The client always receives its full response; only the *recording* is degraded to a clean skip.

- **agui-recorder.ts**: new configurable record-buffer cap (`AGUIRecordConfig.maxRecordBufferBytes`, default 64MiB, clamped to a 256MiB `AGUI_RECORD_BUFFER_HARD_CEILING`). On trip: stop accumulating, free the buffer, skip fixture construction, keep the live client relay untouched — never `Buffer.concat().toString()` the oversized buffer.
- **stream-collapse.ts**: guard each collapser's input under `MAX_COLLAPSE_STRING_LENGTH` (256Mi code units) *before* accumulation. The sum of any single accumulator can never exceed the total input, so bounding the input bounds every accumulator at one chokepoint (no per-`+=` whack-a-mole). Over-ceiling input is truncated and the result stamped `truncated: true` so the recorder skips journaling a partial fixture. Also covers the **exported direct-call** collapse entry points where no byte cap ran.
- Fixed the false `recorder.ts:31` comment.
- Test-only overrides (`setAGUIRecordBufferCeilingForTests` / `setCollapseStringLimitForTests`) let the cap suites exercise truncation without allocating hundreds of MB.

## Local red-green proof (real failure surface)

**RED — AG-UI recorder** (streaming ~535MiB of real SSE through `proxyAndRecordAGUI` on the *unmodified* build):
```
[repro] streaming ~535 MiB through the AG-UI recorder…
[aimock] NO AG-UI FIXTURE MATCH — proxying to http://127.0.0.1:49292
[RED] uncaughtException in recorder: Error: Cannot create a string longer than 0x1fffffe8 characters
RED EXIT: 1
```
(`0x1fffffe8` = `2^29-1` — the exact V8 max-string-length boundary, i.e. the prod `Invalid string length`.)

**GREEN — same repro, post-fix:**
```
[repro] streaming ~535 MiB through the AG-UI recorder…
[aimock] AG-UI upstream response exceeded the 67108864-byte record buffer cap — relaying full body to client, but skipping fixture recording to bound memory
[aimock] AG-UI record buffer cap exceeded — response relayed to client, recording skipped
[repro] client got status=200, bytesReceived=562041225
[GREEN] client received full body and recorder did not throw
```
Client received **all 562,041,225 bytes** — relay unaffected, only recording skipped.

**stream-collapse mutation-guard** (real `collapseOpenAISSE`, input just over the 256Mi ceiling):
- pre-fix: `content.length=276824064, truncated=undefined` (unbounded, no clamp)
- post-fix: `content.length=260046848, truncated=true` (clamped at ceiling, flagged)

## Tests

- `src/__tests__/agui-record-buffer-cap.test.ts` (2) — full relay + no crash + recording skipped over cap; normal recording under cap.
- `src/__tests__/stream-collapse-string-cap.test.ts` (6) — every collapser clamps + flags `truncated`, never throws; no truncation under cap; Bedrock byte-cap.
- Full suite: **4501 passed (153 files)**. Lint + prettier + build + tsc clean.