### PR TITLE
fix: cap journal body at 64KB to prevent Invalid string length crash on GET /__aimock/journal

### DIFF
--- a/src/__tests__/journal.test.ts
+++ b/src/__tests__/journal.test.ts
@@ -495,6 +495,35 @@ describe("Journal", () => {
       expect(entry.body).toEqual(smallBody);
     });
 
+    it("truncates multibyte (CJK) bodies whose UTF-8 byte size exceeds 64 KB even when code-unit length does not", () => {
+      // Regression: the original gate used serialized.length (UTF-16 code units).
+      // CJK characters are 3 bytes in UTF-8 but 1 JS code unit, so a body whose
+      // byte size > 64 KB can have code-unit length << 64 K.
+      // This test proves the byte-based gate catches what the code-unit gate missed.
+      //
+      // 22,000 CJK chars × 3 UTF-8 bytes = 66,000 bytes, plus ~60 bytes of JSON
+      // envelope → ~66,060 bytes total (> 65,536 cap).
+      // Code-unit length: 22,000 + ~60 = ~22,060 (well under 65,536).
+      const journal = new Journal();
+      // U+4E2D (中) is a 3-byte UTF-8 character; repeat 22,000 times.
+      const cjkContent = "中".repeat(22_000);
+      const body = {
+        model: "gpt-4o",
+        messages: [{ role: "user" as const, content: cjkContent }],
+      };
+      // Verify our test invariant: byte size > cap, code-unit length < cap.
+      const serialized = JSON.stringify(body);
+      expect(serialized.length).toBeLessThan(BODY_CAP); // code-unit gate would MISS this
+      expect(Buffer.byteLength(serialized, "utf8")).toBeGreaterThan(BODY_CAP); // byte gate catches it
+
+      const entry = journal.add(makeEntry({ body }));
+
+      // With a byte-based gate, the body MUST be truncated.
+      const stored = entry.body as Record<string, unknown>;
+      expect(stored.__aimock_truncated).toBe(true);
+      expect(stored.originalByteSize as number).toBeGreaterThan(BODY_CAP);
+    });
+
     it("JSON.stringify(journal.getAll()) does not throw with 1000 large-body entries", () => {
       // Regression anchor for RangeError: Invalid string length (ISL).
       // 1000 entries × 100 KB body each = 100 MB without cap → exceeds V8 limit.

--- a/src/__tests__/journal.test.ts
+++ b/src/__tests__/journal.test.ts
@@ -457,4 +457,70 @@ describe("Journal", () => {
       expect(journal.getFixtureMatchCount(fixture, "t-9999")).toBe(1);
     });
   });
+
+  describe("journal body cap (ISL regression)", () => {
+    const BODY_CAP = 64 * 1024; // 64 KB — must match journal.ts constant
+
+    it("replaces oversized bodies with a truncation marker", () => {
+      const journal = new Journal();
+      // Build a body that serializes to well over 64 KB (100 KB of content)
+      const bigContent = "A".repeat(100 * 1024);
+      const entry = journal.add(
+        makeEntry({
+          body: {
+            model: "gpt-4o",
+            messages: [{ role: "user", content: bigContent }],
+          },
+        }),
+      );
+
+      // The stored body must be the truncation marker, not the original
+      const body = entry.body as Record<string, unknown>;
+      expect(body.__aimock_truncated).toBe(true);
+      expect(typeof body.originalByteSize).toBe("number");
+      expect(body.originalByteSize as number).toBeGreaterThan(BODY_CAP);
+      expect(typeof body.note).toBe("string");
+    });
+
+    it("retains bodies that are within the 64 KB cap", () => {
+      const journal = new Journal();
+      const smallBody = {
+        model: "gpt-4o",
+        messages: [{ role: "user" as const, content: "hello" }],
+      };
+      const entry = journal.add(makeEntry({ body: smallBody }));
+
+      // Small body must be stored as-is (no truncation marker)
+      expect((entry.body as Record<string, unknown>).__aimock_truncated).toBeUndefined();
+      expect(entry.body).toEqual(smallBody);
+    });
+
+    it("JSON.stringify(journal.getAll()) does not throw with 1000 large-body entries", () => {
+      // Regression anchor for RangeError: Invalid string length (ISL).
+      // 1000 entries × 100 KB body each = 100 MB without cap → exceeds V8 limit.
+      // With cap, each entry stores only the ~200-byte marker → <1 MB total.
+      const journal = new Journal({ maxEntries: 1000 });
+      const bigContent = "B".repeat(100 * 1024);
+      for (let i = 0; i < 1000; i++) {
+        journal.add(
+          makeEntry({
+            body: {
+              model: "gpt-4o",
+              messages: [{ role: "user", content: bigContent }],
+            },
+          }),
+        );
+      }
+
+      expect(journal.size).toBe(1000);
+      // This must not throw RangeError: Invalid string length
+      let serialized: string;
+      expect(() => {
+        serialized = JSON.stringify(journal.getAll());
+      }).not.toThrow();
+      // Sanity-check: valid JSON, 1000 entries
+      const parsed = JSON.parse(serialized!) as unknown[];
+      expect(parsed).toHaveLength(1000);
+    });
+  });
 });

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -4,22 +4,33 @@ import { DEFAULT_TEST_ID } from "./constants.js";
 export { DEFAULT_TEST_ID } from "./constants.js";
 
 /**
- * Maximum byte length of a serialized request body retained in a journal
- * entry. Bodies exceeding this cap are replaced with a truncation marker so
- * that `JSON.stringify(journal.getAll())` never exceeds V8's 512 MB string
- * limit (64 KB × 1000 entries = ~64 MB aggregate, well within the limit).
+ * Maximum UTF-8 byte length of a serialized request body retained in a
+ * journal entry. Bodies whose JSON serialization exceeds this byte size are
+ * replaced with a truncation marker.
+ *
+ * Only the request `body` field is capped here. `headers` and `path` are
+ * retained uncapped, but they are naturally bounded by Node's default ~16 KB
+ * maximum HTTP header size, so the per-entry overhead beyond the body cap
+ * remains small. Combined with the journal's maxEntries limit (default 1000),
+ * the total `JSON.stringify(journal.getAll())` output stays well under V8's
+ * ~512 MB string limit even at maximum capacity.
  */
 const JOURNAL_BODY_CAP_BYTES = 64 * 1024; // 64 KB
 
 /**
- * If `body` serializes to more than JOURNAL_BODY_CAP_BYTES, replace it with
- * a truncation marker. Returns the original body when within the cap, or null
- * when `body` is null.
+ * If `body` serializes to more than JOURNAL_BODY_CAP_BYTES (in UTF-8 bytes),
+ * replace it with a truncation marker. Returns the original body when within
+ * the cap, or null when `body` is null.
+ *
+ * The gate uses Buffer.byteLength (UTF-8 bytes) rather than .length (UTF-16
+ * code units) to match the constant name and to correctly cap multibyte
+ * content (e.g. CJK/emoji) whose code-unit count falls under the threshold
+ * but whose byte size does not.
  */
 function capBody(body: ChatCompletionRequest | null): ChatCompletionRequest | null {
   if (body === null) return null;
   const serialized = JSON.stringify(body);
-  if (serialized.length <= JOURNAL_BODY_CAP_BYTES) return body;
+  if (Buffer.byteLength(serialized, "utf8") <= JOURNAL_BODY_CAP_BYTES) return body;
   // Cast: the marker is not a real ChatCompletionRequest, but the field type
   // is already nullable-union and downstream consumers (e.g. GET /journal)
   // treat the body as opaque JSON — the truncation marker is safe to store.

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -1,7 +1,34 @@
 import { generateId } from "./helpers.js";
-import type { Fixture, FixtureMatch, JournalEntry } from "./types.js";
+import type { ChatCompletionRequest, Fixture, FixtureMatch, JournalEntry } from "./types.js";
 import { DEFAULT_TEST_ID } from "./constants.js";
 export { DEFAULT_TEST_ID } from "./constants.js";
+
+/**
+ * Maximum byte length of a serialized request body retained in a journal
+ * entry. Bodies exceeding this cap are replaced with a truncation marker so
+ * that `JSON.stringify(journal.getAll())` never exceeds V8's 512 MB string
+ * limit (64 KB × 1000 entries = ~64 MB aggregate, well within the limit).
+ */
+const JOURNAL_BODY_CAP_BYTES = 64 * 1024; // 64 KB
+
+/**
+ * If `body` serializes to more than JOURNAL_BODY_CAP_BYTES, replace it with
+ * a truncation marker. Returns the original body when within the cap, or null
+ * when `body` is null.
+ */
+function capBody(body: ChatCompletionRequest | null): ChatCompletionRequest | null {
+  if (body === null) return null;
+  const serialized = JSON.stringify(body);
+  if (serialized.length <= JOURNAL_BODY_CAP_BYTES) return body;
+  // Cast: the marker is not a real ChatCompletionRequest, but the field type
+  // is already nullable-union and downstream consumers (e.g. GET /journal)
+  // treat the body as opaque JSON — the truncation marker is safe to store.
+  return {
+    __aimock_truncated: true,
+    originalByteSize: Buffer.byteLength(serialized, "utf8"),
+    note: "body truncated by aimock journal cap (64 KB limit)",
+  } as unknown as ChatCompletionRequest;
+}
 
 /**
  * Compare two field values, handling RegExp by source+flags rather than reference.
@@ -101,6 +128,7 @@ export class Journal {
       id: generateId("req"),
       timestamp: Date.now(),
       ...entry,
+      body: capBody(entry.body),
     };
     this.entries.push(full);
     // FIFO eviction when over capacity. Array.prototype.shift() is O(n)

--- a/src/server.ts
+++ b/src/server.ts
@@ -1227,7 +1227,10 @@ export async function createServer(
     // Delegate to async handler — catch unhandled rejections to prevent Node.js crashes
     handleHttpRequest(req, res).catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : "Internal error";
-      defaults.logger.warn(`Unhandled request error: ${msg}`);
+      const stack = err instanceof Error ? (err.stack ?? msg) : msg;
+      const method = req.method ?? "?";
+      const url = req.url ?? "?";
+      defaults.logger.warn(`Unhandled request error on ${method} ${url}: ${msg}\n${stack}`);
       if (!res.headersSent) {
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: { message: msg, type: "server_error" } }));


### PR DESCRIPTION
## Problem

`GET /__aimock/journal` serializes the full journal (up to 1000 entries) via `JSON.stringify`. When LLM request bodies are large (~530 KB each in prod-like agentic traffic), the aggregate JSON string exceeds V8's 512 MB limit → `RangeError: Invalid string length`. The catch-all logged only `err.message`, so no stack ever appeared in prod logs.

**Real stack (locally reproduced):**
```
[aimock] [DIAG] Unhandled RangeError on GET /__aimock/journal:
RangeError: Invalid string length
    at JSON.stringify (<anonymous>)
    at handleControlAPI (file:///Users/jpr5/dev/aimock/dist/server.js:177:16)
    at handleHttpRequest (file:///Users/jpr5/dev/aimock/dist/server.js:822:10)
    at Server.<anonymous> (file:///Users/jpr5/dev/aimock/dist/server.js:778:3)
    at Server.emit (node:events:508:20)
    at parserOnIncoming (node:_http_server:1216:12)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:125:17)
[aimock] Unhandled request error: Invalid string length
```

## Fix

Cap the retained request-body size at **64 KB per journal entry** at the journal source (`journal.add()`). Bodies exceeding the cap are replaced with a truncation marker `{ "__aimock_truncated": true, "originalByteSize": N, "note": "..." }`. This bounds aggregate journal memory to ~64 MB at maxEntries=1000 (well under 256 MB), and protects all downstream consumers of `journal.getAll()`, not just `/journal`.

Also unifies the catch-all error log to include `err.stack` unconditionally for production observability (removes `[DIAG]` debug tag from the diagnosis branch).

## RED (pre-fix, crash confirmed locally)

```
$ curl -s http://127.0.0.1:4010/__aimock/journal > /tmp/response.txt
$ wc -c /tmp/response.txt
       0 /tmp/response.txt   # empty — crash returned 500

$ grep -A 10 "RangeError" /tmp/aimock-fix-red.log
[aimock] [DIAG] Unhandled RangeError on GET /__aimock/journal:
RangeError: Invalid string length
    at JSON.stringify (<anonymous>)
    at handleControlAPI (file:///Users/jpr5/dev/aimock/dist/server.js:177:16)
    at handleHttpRequest (file:///Users/jpr5/dev/aimock/dist/server.js:822:10)
[aimock] Unhandled request error: Invalid string length
```

Repro: 1000 × 530 KB POST bodies → `GET /__aimock/journal` → `RangeError: Invalid string length`

## GREEN (post-fix, no crash)

```
$ curl -s http://127.0.0.1:4010/__aimock/journal | wc -c
  520001   # 520 KB of valid JSON — NOT empty

$ curl -s http://127.0.0.1:4010/__aimock/journal | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'entries={len(d)}, ok')"
entries=1000, ok

$ grep "RangeError\|Invalid string length" /tmp/aimock-fix-green.log | wc -l
       0   # no errors

# Truncation markers present in entries:
# entry[0]: __aimock_truncated=True, originalByteSize=542854
# entry[1]: __aimock_truncated=True, originalByteSize=542854
# entry[2]: __aimock_truncated=True, originalByteSize=542854
# Total truncated: 1000/1000
```

## Regression test

Added to `src/__tests__/journal.test.ts` — `"journal body cap (ISL regression)"` describe block with 3 tests:
1. `replaces oversized bodies with a truncation marker` — 100 KB body → marker stored
2. `retains bodies that are within the 64 KB cap` — small body → stored as-is
3. `JSON.stringify(journal.getAll()) does not throw with 1000 large-body entries` — 1000 × 100 KB bodies, must not throw

## Pre-push checks

- format: pass
- lint: pass
- tests: 4548 passed (154 test files)
- build: pass

---
⚠️ Draft — do not merge. aimock is deployed to prod on Railway. A human must authorize merge + deploy.