### PR TITLE
chore: release v1.37.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @copilotkit/aimock
 
+## [1.37.2] - 2026-07-17
+
+### Fixed
+
+- Prevent `Invalid string length` crash on `GET /__aimock/journal` by capping retained request bodies at 64 KB (#308)
+
+### Changed
+
+- Log full error stack on unhandled request errors for prod diagnosis (#308)
+
 ## [1.37.1] - 2026-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.37.1",
+  "version": "1.37.2",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [

--- a/packages/aimock-pytest/src/aimock_pytest/_version.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_version.py
@@ -8,4 +8,4 @@ contains any new server routes/features the client calls (e.g. the reset-split
 control routes ship in the next release). Keep it tracking npm releases.
 """
 
-AIMOCK_VERSION = "1.37.0"
+AIMOCK_VERSION = "1.37.2"


### PR DESCRIPTION
## Release v1.37.2 (patch)

Cuts a patch release for the journal body cap + error stack instrumentation fix merged in #308.

### Version bump

`package.json` `1.37.1` → `1.37.2`. Also bumps `packages/aimock-pytest/src/aimock_pytest/_version.py` `AIMOCK_VERSION` to `1.37.2` (pins the pytest harness to the released npm version).

### CHANGELOG

## [1.37.2] - 2026-07-17

### Fixed

- Prevent `Invalid string length` crash on `GET /__aimock/journal` by capping retained request bodies at 64 KB (#308)

### Changed

- Log full error stack on unhandled request errors for prod diagnosis (#308)

### Quality gate

- `pnpm run format:check` — pass
- `pnpm run lint` — pass
- `tsc --noEmit` — pass
- `pnpm test` — 4549 passed (154 files)
- `pnpm run build` — pass