### PR TITLE
fix(drift): route every provider surface to auto-fix via a surface registry

### DIFF
--- a/scripts/drift-report-collector.ts
+++ b/scripts/drift-report-collector.ts
@@ -22,7 +22,7 @@ import { existsSync, statSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { SURFACE_REGISTRY } from "../src/__tests__/drift/surface-registry.js";
+import { SURFACE_REGISTRY, isKnownSurface } from "../src/__tests__/drift/surface-registry.js";
 import type { SurfaceMapping } from "../src/__tests__/drift/surface-registry.js";
 
 import type {
@@ -763,19 +763,30 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
       let provider: string;
       let mapping: ProviderMapping;
       if (surfaceKey !== null) {
-        const registered = SURFACE_REGISTRY[surfaceKey];
-        if (!registered) {
+        // `surfaceKey` is untrusted text (extractSurfaceKey → `\S+`). Guard with
+        // own-property check BEFORE indexing: a plain-object bracket lookup walks
+        // the prototype chain, so a slug like `constructor`/`toString`/`__proto__`
+        // would otherwise resolve to a truthy inherited member and skip the throw,
+        // emitting a garbage entry (`builderFile: undefined`). isKnownSurface uses
+        // Object.prototype.hasOwnProperty.call — the same guard the emit side uses.
+        if (!isKnownSurface(surfaceKey)) {
           throw new Error(
             `Unknown drift surface "${surfaceKey}" — add it to SURFACE_REGISTRY ` +
               `in src/__tests__/drift/surface-registry.ts (test: ${testName})`,
           );
         }
+        const registered = SURFACE_REGISTRY[surfaceKey];
         provider = registered.provider;
         mapping = registered;
       } else {
         // Legacy no-marker fallback: match the human provider label.
         const label = extractProviderName(ancestorText) ?? extractProviderName(parsed.context);
-        const legacyMapping = label ? PROVIDER_LABEL_MAP[label] : undefined;
+        // Own-property guard for parity with the marker-path lookup above: even
+        // though extractProviderName only returns real PROVIDER_LABEL_MAP keys
+        // today, indexing without hasOwn would resolve prototype members
+        // (`constructor`, etc.) to a truthy value if such a label were ever added.
+        const legacyMapping =
+          label && Object.hasOwn(PROVIDER_LABEL_MAP, label) ? PROVIDER_LABEL_MAP[label] : undefined;
         if (!label || !legacyMapping) {
           // Parseable drift block we cannot route to a source file. Held for
           // review (exit 5) rather than crashing the whole run. O-1: capture the

--- a/scripts/drift-report-collector.ts
+++ b/scripts/drift-report-collector.ts
@@ -1088,6 +1088,25 @@ export function computeExitCode(
   return 0;
 }
 
+/**
+ * Map a collector exit code to the coarse `conclusion` written into the drift
+ * report, so the base-report reuse guard (`isBaseReportReusable`) can read
+ * `report.conclusion` directly. Only exit 0 ("clean") is a reusable baseline;
+ * "critical"/"quarantine" (and the exit-1 "skipped" case) are not.
+ */
+export function conclusionForExitCode(exitCode: 0 | 1 | 2 | 5): string {
+  switch (exitCode) {
+    case 0:
+      return "clean";
+    case 2:
+      return "critical";
+    case 5:
+      return "quarantine";
+    default:
+      return "skipped";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -1121,8 +1140,23 @@ function main(): void {
   const entries = [...httpEntries, ...agUiEntries];
   const quarantine = httpResult.quarantine;
 
+  const criticalCount = entries.reduce(
+    (sum, e) => sum + e.diffs.filter((d) => d.severity === "critical").length,
+    0,
+  );
+  const quarantineCount = quarantine.length;
+
+  // Compute the exit code BEFORE writing so the report can carry the coarse
+  // `conclusion` derived from it (base-report reuse contract).
+  const exitCode = computeExitCode(criticalCount, quarantineCount, agUiSkipped);
+
+  const timestamp = new Date().toISOString();
   const report: DriftReport = {
-    timestamp: new Date().toISOString(),
+    timestamp,
+    // Alias of `timestamp` read by the reuse guard; `timestamp` kept for
+    // back-compat with existing consumers.
+    generatedAt: timestamp,
+    conclusion: conclusionForExitCode(exitCode),
     entries,
     ...(quarantine.length > 0 ? { quarantine } : {}),
   };
@@ -1142,17 +1176,9 @@ function main(): void {
     console.log(`  AG-UI schema entries: ${agUiEntries.length}`);
   }
   console.log(`  Total entries: ${entries.length}`);
-
-  const criticalCount = entries.reduce(
-    (sum, e) => sum + e.diffs.filter((d) => d.severity === "critical").length,
-    0,
-  );
   console.log(`  Critical diffs: ${criticalCount}`);
-
-  const quarantineCount = quarantine.length;
   console.log(`  Quarantined failures: ${quarantineCount}`);
 
-  const exitCode = computeExitCode(criticalCount, quarantineCount, agUiSkipped);
   switch (exitCode) {
     case 2:
       console.log("Exiting with code 2 (critical diffs found).");

--- a/scripts/drift-report-collector.ts
+++ b/scripts/drift-report-collector.ts
@@ -22,6 +22,9 @@ import { existsSync, statSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { SURFACE_REGISTRY } from "../src/__tests__/drift/surface-registry.js";
+import type { SurfaceMapping } from "../src/__tests__/drift/surface-registry.js";
+
 import type {
   DriftEntry,
   DriftReport,
@@ -50,111 +53,45 @@ interface VitestAssertion {
 }
 
 // ---------------------------------------------------------------------------
-// Provider → file mapping
+// Surface → file mapping (single source of truth in surface-registry.ts)
 // ---------------------------------------------------------------------------
 
-interface ProviderMapping {
-  builderFile: string;
-  builderFunctions: string[];
-  typesFile: string | null;
-  sdkShapesFile?: string;
-}
+/**
+ * A resolved surface mapping. Structurally identical to the registry's
+ * `SurfaceMapping` (kept as a local alias so the rest of this module reads
+ * unchanged from the pre-registry `ProviderMapping`).
+ */
+type ProviderMapping = SurfaceMapping;
 
-const OPENAI_CHAT_MAPPING: ProviderMapping = {
-  builderFile: "src/helpers.ts",
-  builderFunctions: [
-    "buildTextCompletion",
-    "buildToolCallCompletion",
-    "buildTextChunks",
-    "buildToolCallChunks",
-  ],
-  typesFile: "src/types.ts",
-};
+const SDK_SHAPES_FILE = "src/__tests__/drift/sdk-shapes.ts";
 
-const OPENAI_RESPONSES_MAPPING: ProviderMapping = {
-  builderFile: "src/responses.ts",
-  builderFunctions: [
-    "buildTextResponse",
-    "buildToolCallResponse",
-    "buildTextStreamEvents",
-    "buildToolCallStreamEvents",
-  ],
-  typesFile: null,
-};
-
-const ANTHROPIC_MAPPING: ProviderMapping = {
-  builderFile: "src/messages.ts",
-  builderFunctions: [
-    "buildClaudeTextResponse",
-    "buildClaudeToolCallResponse",
-    "buildClaudeTextStreamEvents",
-    "buildClaudeToolCallStreamEvents",
-  ],
-  typesFile: null,
-};
-
-const GEMINI_MAPPING: ProviderMapping = {
-  builderFile: "src/gemini.ts",
-  builderFunctions: [
-    "buildGeminiTextResponse",
-    "buildGeminiToolCallResponse",
-    "buildGeminiTextStreamChunks",
-    "buildGeminiToolCallStreamChunks",
-  ],
-  typesFile: null,
-};
-
-const OPENAI_EMBEDDINGS_MAPPING: ProviderMapping = {
-  builderFile: "src/helpers.ts",
-  builderFunctions: ["buildEmbeddingResponse", "generateDeterministicEmbedding"],
-  typesFile: null,
-  sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
+/**
+ * Legacy label aliases → registry slug. The pre-WS-5 `PROVIDER_MAP` keyed some
+ * surfaces by SHORTER titles than the registry's canonical `provider` label
+ * (e.g. a bare `"Gemini"`/`"Anthropic"` describe-block title, or `"Bedrock
+ * Invoke"` prose without a colon suffix). These map onto the canonical slug so
+ * the LEGACY no-marker fallback keeps recognizing an unmigrated block whose
+ * prose title uses the shorter form. Newer blocks resolve structurally via the
+ * `Surface:` marker and never touch this table.
+ */
+const LEGACY_LABEL_ALIASES: Record<string, keyof typeof SURFACE_REGISTRY> = {
+  Gemini: "gemini",
+  Anthropic: "anthropic",
 };
 
 /**
- * Maps provider names (from drift test describe blocks) to source files
- * and builder function names. The function names are builder functions for
- * each provider (internal or exported) — they are included so Claude Code
- * can locate them via Read/Grep.
+ * Reverse index from a human provider label to its mapping, for the LEGACY
+ * no-marker fallback (`extractProviderName`). Built from the registry's
+ * canonical `provider` labels PLUS the legacy aliases above. Newer emitters
+ * declare a `Surface:` slug marker (resolved structurally); this table only
+ * serves blocks that predate the marker or a path not yet migrated.
  */
-const PROVIDER_MAP: Record<string, ProviderMapping> = {
-  "OpenAI Chat": OPENAI_CHAT_MAPPING,
-  "OpenAI Responses": OPENAI_RESPONSES_MAPPING,
-  Anthropic: ANTHROPIC_MAPPING,
-  "Anthropic Claude": ANTHROPIC_MAPPING,
-  "Google Gemini": GEMINI_MAPPING,
-  Gemini: GEMINI_MAPPING,
-  "OpenAI Realtime": {
-    builderFile: "src/ws-realtime.ts",
-    builderFunctions: ["handleWebSocketRealtime", "realtimeItemsToMessages"],
-    typesFile: null,
-  },
-  "OpenAI Responses WS": {
-    builderFile: "src/ws-responses.ts",
-    builderFunctions: ["handleWebSocketResponses"],
-    typesFile: null,
-  },
-  "Gemini Live": {
-    builderFile: "src/ws-gemini-live.ts",
-    builderFunctions: ["handleWebSocketGeminiLive"],
-    typesFile: null,
-  },
-  "OpenAI Embeddings": OPENAI_EMBEDDINGS_MAPPING,
-  "Gemini Interactions": {
-    builderFile: "src/gemini-interactions.ts",
-    builderFunctions: [
-      "buildInteractionsTextResponse",
-      "buildInteractionsToolCallResponse",
-      "buildInteractionsContentWithToolCallsResponse",
-      "buildInteractionsTextSSEEvents",
-      "buildInteractionsToolCallSSEEvents",
-      "buildInteractionsContentWithToolCallsSSEEvents",
-    ],
-    typesFile: null,
-  },
+const PROVIDER_LABEL_MAP: Record<string, ProviderMapping> = {
+  ...Object.fromEntries(Object.values(SURFACE_REGISTRY).map((m) => [m.provider, m])),
+  ...Object.fromEntries(
+    Object.entries(LEGACY_LABEL_ALIASES).map(([label, slug]) => [label, SURFACE_REGISTRY[slug]]),
+  ),
 };
-
-const SDK_SHAPES_FILE = "src/__tests__/drift/sdk-shapes.ts";
 
 // ---------------------------------------------------------------------------
 // AG-UI schema drift constants
@@ -230,16 +167,35 @@ export function parseDriftBlock(text: string): { context: string; diffs: ParsedD
 }
 
 /**
- * Extract provider name from the describe block title or the drift report context.
+ * Extract the machine-readable surface slug from a drift block's `Surface:`
+ * marker line (emitted by `formatDriftReport(context, diffs, surface)`), if
+ * present. Returns null when no marker line exists (a legacy/unmigrated block).
+ *
+ * The marker sits between the `API DRIFT DETECTED:` header and the numbered
+ * entries, e.g.:
+ *
+ *   API DRIFT DETECTED: Cohere /v2/chat (non-streaming)
+ *     Surface: cohere-chat
+ *     1. [critical] …
+ */
+export function extractSurfaceKey(text: string): string | null {
+  const match = text.match(/^\s*Surface:\s*(\S+)\s*$/m);
+  return match ? match[1] : null;
+}
+
+/**
+ * LEGACY provider-name fallback for a drift block that carries NO `Surface:`
+ * marker (predates the slug marker, or a path not yet migrated). Matches the
+ * text against the registry's human `provider` labels (longest first to avoid
+ * partial matches). Newer blocks resolve structurally via `extractSurfaceKey`;
+ * this exists only as a defensive back-compat net.
  *
  * Examples:
  *   "OpenAI Chat Completions drift" → "OpenAI Chat"
- *   "OpenAI Chat (non-streaming text)" → "OpenAI Chat"
  *   "Anthropic Claude drift" → "Anthropic Claude"
  */
 export function extractProviderName(text: string): string | null {
-  // Try matching against known provider keys (longest first to avoid partial matches)
-  const sorted = Object.keys(PROVIDER_MAP).sort((a, b) => b.length - a.length);
+  const sorted = Object.keys(PROVIDER_LABEL_MAP).sort((a, b) => b.length - a.length);
   for (const key of sorted) {
     if (text.includes(key)) return key;
   }
@@ -688,7 +644,7 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
         // never crashed as unparseable (exit 1).
         const canary = parseKnownModelsCanary(fullMessage);
         if (canary !== null) {
-          const mapping = PROVIDER_MAP["OpenAI Realtime"];
+          const mapping = SURFACE_REGISTRY["openai-realtime"];
 
           // Build the critical diffs. F4: severity MUST be "critical" — the Fix
           // Drift workflow (.github/workflows/fix-drift.yml) gates remediation
@@ -788,33 +744,52 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
         continue;
       }
 
-      // Determine provider from ancestor titles (describe block) or context
       const ancestorText = assertion.ancestorTitles.join(" ");
       const testName = `${ancestorText} > ${assertion.title}`;
-      const provider = extractProviderName(ancestorText) ?? extractProviderName(parsed.context);
-      if (!provider) {
-        // Unmapped provider: a parseable drift block whose provider we cannot
-        // route to a source file. Held for review (exit 5) rather than crashing
-        // the whole run (was exit 1). O-1: capture the raw frame location BEFORE
-        // any stack stripping.
-        quarantine.push({
-          provider: parsed.context || ancestorText || "unknown",
-          testName,
-          rawLocation: extractRawLocation(fullMessage),
-          message: fullMessage,
-        });
-        continue;
-      }
 
-      const mapping = PROVIDER_MAP[provider];
-      if (!mapping) {
-        quarantine.push({
-          provider,
-          testName,
-          rawLocation: extractRawLocation(fullMessage),
-          message: fullMessage,
-        });
-        continue;
+      // Resolution order (see WS-5 spec §3c):
+      //
+      //   1. `Surface:` marker present → structural lookup in SURFACE_REGISTRY.
+      //      - hit  → auto-fixable DriftEntry (exit-2 lane). THIS IS THE FIX.
+      //      - miss → a NEW surface whose author forgot the registry entry.
+      //               Do NOT silently quarantine — THROW (collector-fault, exit
+      //               1) so it is loud, distinct and actionable. fix-drift.yml
+      //               treats a non-{2,5} collector exit as a "collector crashed"
+      //               alert, so this cannot be ignored.
+      //   2. No marker (legacy/unmigrated block) → fall back to the human
+      //      provider-label match. Hit → entry; miss → quarantine (exit 5),
+      //      exactly as before this change.
+      const surfaceKey = extractSurfaceKey(fullMessage) ?? extractSurfaceKey(parsed.context);
+      let provider: string;
+      let mapping: ProviderMapping;
+      if (surfaceKey !== null) {
+        const registered = SURFACE_REGISTRY[surfaceKey];
+        if (!registered) {
+          throw new Error(
+            `Unknown drift surface "${surfaceKey}" — add it to SURFACE_REGISTRY ` +
+              `in src/__tests__/drift/surface-registry.ts (test: ${testName})`,
+          );
+        }
+        provider = registered.provider;
+        mapping = registered;
+      } else {
+        // Legacy no-marker fallback: match the human provider label.
+        const label = extractProviderName(ancestorText) ?? extractProviderName(parsed.context);
+        const legacyMapping = label ? PROVIDER_LABEL_MAP[label] : undefined;
+        if (!label || !legacyMapping) {
+          // Parseable drift block we cannot route to a source file. Held for
+          // review (exit 5) rather than crashing the whole run. O-1: capture the
+          // raw frame location BEFORE any stack stripping.
+          quarantine.push({
+            provider: label || parsed.context || ancestorText || "unknown",
+            testName,
+            rawLocation: extractRawLocation(fullMessage),
+            message: fullMessage,
+          });
+          continue;
+        }
+        provider = label;
+        mapping = legacyMapping;
       }
 
       entries.push({
@@ -823,7 +798,7 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
         builderFile: mapping.builderFile,
         builderFunctions: mapping.builderFunctions,
         typesFile: mapping.typesFile,
-        sdkShapesFile: SDK_SHAPES_FILE,
+        sdkShapesFile: mapping.sdkShapesFile ?? SDK_SHAPES_FILE,
         diffs: parsed.diffs,
       });
     }

--- a/scripts/drift-types.ts
+++ b/scripts/drift-types.ts
@@ -88,6 +88,20 @@ export interface DriftEntry {
 
 export interface DriftReport {
   timestamp: string;
+  /**
+   * ISO-8601 alias of `timestamp`, written so the base-report reuse guard
+   * (`isBaseReportReusable` via `test-drift.yml`) can read `report.generatedAt`.
+   * `timestamp` is retained for back-compat with existing consumers
+   * (drift-slack-summary.ts, etc.). Absent on legacy reports.
+   */
+  generatedAt?: string;
+  /**
+   * Coarse run outcome derived from the collector exit code
+   * (0→"clean", 2→"critical", 5→"quarantine"), written so the reuse guard can
+   * read `report.conclusion` instead of relying solely on the CI run
+   * conclusion. Absent on legacy reports.
+   */
+  conclusion?: string;
   entries: DriftEntry[];
   /**
    * Optional list of failures held aside for human review (see QuarantineEntry).

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -26,6 +26,7 @@ import {
   parseKnownModelsCanary,
   collectDriftEntries,
   computeExitCode,
+  conclusionForExitCode,
   classifyUnparseableAsInfra,
   INFRA_INDICATOR_SOURCES,
   infraIndicatorSample,
@@ -34,6 +35,8 @@ import type { DriftEntry, QuarantineEntry } from "../../scripts/drift-types.js";
 import { SURFACE_REGISTRY, KNOWN_SURFACE_SLUGS } from "./drift/surface-registry.js";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { isBaseReportReusable } from "../../scripts/drift-delta.js";
+import type { DriftReport } from "../../scripts/drift-types.js";
 
 // ---------------------------------------------------------------------------
 // Helpers for the A1.3 CollectResult shape ({ entries, quarantine }).
@@ -1493,6 +1496,58 @@ describe("WS-5 — unknown surface slug fails LOUD (throws), never silent quaran
     expect(() => formatDriftReport("X", [SAMPLE_DIFF], "not-a-real-surface")).toThrow(
       /unknown drift surface "not-a-real-surface"/,
     );
+  });
+});
+
+describe("WS-5 — base-report reuse contract (generatedAt + conclusion)", () => {
+  it("conclusionForExitCode maps exit codes to coarse conclusions", () => {
+    expect(conclusionForExitCode(0)).toBe("clean");
+    expect(conclusionForExitCode(2)).toBe("critical");
+    expect(conclusionForExitCode(5)).toBe("quarantine");
+    expect(conclusionForExitCode(1)).toBe("skipped");
+  });
+
+  it("isBaseReportReusable accepts a written clean report (reuse works)", () => {
+    // A report shaped like what main() now writes for a clean run.
+    const timestamp = new Date().toISOString();
+    const report: DriftReport = {
+      timestamp,
+      generatedAt: timestamp,
+      conclusion: conclusionForExitCode(0),
+      entries: [
+        {
+          provider: "OpenAI Chat",
+          scenario: "non-streaming text",
+          builderFile: "src/helpers.ts",
+          builderFunctions: ["buildTextCompletion"],
+          typesFile: "src/types.ts",
+          sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
+          diffs: [],
+        },
+      ],
+    };
+    // Same-UTC-day + known-good conclusion + non-empty entries → reusable.
+    expect(isBaseReportReusable(report, report.conclusion, true)).toBe(true);
+  });
+
+  it("a report WITHOUT conclusion is not reusable (documents the pre-fix gap)", () => {
+    const timestamp = new Date().toISOString();
+    const legacy: DriftReport = {
+      timestamp,
+      entries: [
+        {
+          provider: "OpenAI Chat",
+          scenario: "non-streaming text",
+          builderFile: "src/helpers.ts",
+          builderFunctions: ["buildTextCompletion"],
+          typesFile: "src/types.ts",
+          sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
+          diffs: [],
+        },
+      ],
+    };
+    // No conclusion field → falls back to undefined → not reusable.
+    expect(isBaseReportReusable(legacy, legacy.conclusion, true)).toBe(false);
   });
 });
 

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -21,6 +21,7 @@ import type { ShapeDiff } from "./drift/schema.js";
 import {
   parseDriftBlock,
   extractProviderName,
+  extractSurfaceKey,
   extractScenario,
   parseKnownModelsCanary,
   collectDriftEntries,
@@ -30,6 +31,9 @@ import {
   infraIndicatorSample,
 } from "../../scripts/drift-report-collector.js";
 import type { DriftEntry, QuarantineEntry } from "../../scripts/drift-types.js";
+import { SURFACE_REGISTRY, KNOWN_SURFACE_SLUGS } from "./drift/surface-registry.js";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Helpers for the A1.3 CollectResult shape ({ entries, quarantine }).
@@ -1347,5 +1351,181 @@ describe("D6.2 — per-item id on ParsedDiff", () => {
     for (const diff of parsed!.diffs) {
       expect(diff.id).toBe(diff.path);
     }
+  });
+});
+
+// ===========================================================================
+// WS-5 — structural surface keying via SURFACE_REGISTRY
+// ===========================================================================
+
+describe("WS-5 extractSurfaceKey", () => {
+  it("reads the Surface: marker line emitted by formatDriftReport(surface)", () => {
+    const block = formatDriftReport(
+      "Cohere /v2/chat (non-streaming)",
+      [SAMPLE_DIFF],
+      "cohere-chat",
+    );
+    expect(extractSurfaceKey(block)).toBe("cohere-chat");
+  });
+
+  it("returns null for a legacy block with no Surface: marker", () => {
+    const block = formatDriftReport("Cohere /v2/chat (non-streaming)", [SAMPLE_DIFF]);
+    expect(extractSurfaceKey(block)).toBeNull();
+  });
+});
+
+describe("WS-5 — previously-quarantined surfaces now route to exit-2 entries", () => {
+  // A drift block for a surface that today is NOT a PROVIDER_MAP key. On old
+  // code these route to a quarantine (exit 5) because extractProviderName
+  // returns null. With the surface marker + registry they become auto-fixable
+  // exit-2 entries. (≥3 surfaces to satisfy the ≥3-cell rule.)
+  const CASES: { surface: string; title: string; provider: string; builderFile: string }[] = [
+    {
+      surface: "cohere-chat",
+      title: "Cohere /v2/chat (non-streaming)",
+      provider: "Cohere Chat",
+      builderFile: "src/cohere.ts",
+    },
+    {
+      surface: "fal-sync",
+      title: "fal.ai sync-run (image payload)",
+      provider: "fal.ai sync-run",
+      builderFile: "src/fal.ts",
+    },
+    {
+      surface: "elevenlabs",
+      title: "ElevenLabs /v1/sound-generation 400 error",
+      provider: "ElevenLabs",
+      builderFile: "src/elevenlabs-audio.ts",
+    },
+  ];
+
+  for (const c of CASES) {
+    it(`RED→GREEN: "${c.surface}" drift → exit-2 entry (was exit-5 quarantine)`, () => {
+      const block = formatDriftReport(c.title, [SAMPLE_DIFF], c.surface);
+      const result = makeResult([
+        makeAssertion({
+          ancestorTitles: [`${c.title} drift`],
+          title: "shape matches SDK",
+          failureMessages: [`AssertionError: ${block}`],
+        }),
+      ]);
+
+      const { entries, quarantine } = collectDriftEntries(result);
+      // The fix: routed to a trustworthy entry, NOT quarantined.
+      expect(quarantine).toHaveLength(0);
+      expect(entries).toHaveLength(1);
+
+      const entry = entries[0];
+      expect(entry.provider).toBe(c.provider);
+      expect(entry.builderFile).toBe(c.builderFile);
+      expect(entry.builderFunctions.length).toBeGreaterThan(0);
+      expect(entry.sdkShapesFile.length).toBeGreaterThan(0);
+
+      // Exit code: 2 (auto-fixable), not 5 (quarantine).
+      expect(exitCodeOf(result)).toBe(2);
+    });
+  }
+
+  it("legacy no-marker fallback: a truly un-keyable block still quarantines (exit 5)", () => {
+    // A marker-less block whose prose title matches NO registry provider label
+    // routes to quarantine exactly as before WS-5 — the defensive legacy net is
+    // preserved for genuinely un-attributable output.
+    const block = formatDriftReport("SomeBrandNewProvider /v9/widgets", [SAMPLE_DIFF]);
+    const result = makeResult([
+      makeAssertion({
+        ancestorTitles: ["SomeBrandNewProvider drift"],
+        title: "shape matches SDK",
+        failureMessages: [`AssertionError: ${block}`],
+      }),
+    ]);
+    const { entries, quarantine } = collectDriftEntries(result);
+    expect(entries).toHaveLength(0);
+    expect(quarantine).toHaveLength(1);
+    expect(exitCodeOf(result)).toBe(5);
+  });
+
+  it("legacy no-marker fallback still resolves a known provider LABEL to an entry", () => {
+    // Back-compat: an unmigrated block that carries no Surface: marker but whose
+    // prose title contains a registered provider label still routes to an entry.
+    const block = formatDriftReport("Cohere Chat completions", [SAMPLE_DIFF]);
+    const result = makeResult([
+      makeAssertion({
+        ancestorTitles: ["Cohere Chat drift"],
+        title: "shape matches SDK",
+        failureMessages: [`AssertionError: ${block}`],
+      }),
+    ]);
+    const { entries, quarantine } = collectDriftEntries(result);
+    expect(quarantine).toHaveLength(0);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].builderFile).toBe("src/cohere.ts");
+  });
+});
+
+describe("WS-5 — unknown surface slug fails LOUD (throws), never silent quarantine", () => {
+  it("collectDriftEntries throws on a marker with a slug not in the registry", () => {
+    // Build the block manually — formatDriftReport(surface) would itself throw
+    // on an unknown slug, so synthesize the marker directly to exercise the
+    // COLLECTOR's runtime throw.
+    const block =
+      "\nAPI DRIFT DETECTED: Totally New Surface\n" +
+      "  Surface: totally-new-surface\n\n" +
+      "  1. [critical] LLMOCK DRIFT — mismatch detected\n" +
+      "     Path:    a.b.c\n" +
+      "     SDK:     null\n" +
+      "     Real:    null\n" +
+      "     Mock:    <absent>\n";
+    const result = makeResult([
+      makeAssertion({
+        ancestorTitles: ["Totally New Surface drift"],
+        title: "shape matches SDK",
+        failureMessages: [`AssertionError: ${block}`],
+      }),
+    ]);
+
+    expect(() => collectDriftEntries(result)).toThrow(
+      /Unknown drift surface "totally-new-surface"/,
+    );
+  });
+
+  it("formatDriftReport throws at emit time on an unknown slug", () => {
+    expect(() => formatDriftReport("X", [SAMPLE_DIFF], "not-a-real-surface")).toThrow(
+      /unknown drift surface "not-a-real-surface"/,
+    );
+  });
+});
+
+describe("WS-5 — SURFACE_REGISTRY coverage & integrity", () => {
+  it("every KNOWN_SURFACE_SLUGS entry is a registry key", () => {
+    for (const slug of KNOWN_SURFACE_SLUGS) {
+      expect(SURFACE_REGISTRY[slug]).toBeDefined();
+    }
+  });
+
+  it("every registry entry resolves to an existing builderFile with non-empty builderFunctions", () => {
+    // Mirrors the fix-drift.ts validation so a bad entry fails locally, not in CI.
+    const repoRoot = resolve(__dirname, "..", "..");
+    for (const [slug, mapping] of Object.entries(SURFACE_REGISTRY)) {
+      expect(mapping.provider.length, `${slug} provider`).toBeGreaterThan(0);
+      expect(mapping.builderFunctions.length, `${slug} builderFunctions`).toBeGreaterThan(0);
+      expect(
+        mapping.builderFunctions.every((f) => typeof f === "string" && f.length > 0),
+        `${slug} builderFunctions all non-empty strings`,
+      ).toBe(true);
+      const abs = resolve(repoRoot, mapping.builderFile);
+      expect(existsSync(abs), `${slug} builderFile exists: ${mapping.builderFile}`).toBe(true);
+      if (mapping.typesFile !== null) {
+        expect(
+          existsSync(resolve(repoRoot, mapping.typesFile)),
+          `${slug} typesFile exists: ${mapping.typesFile}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("provider labels are unique (legacy fallback reverse-index has no collisions)", () => {
+    const labels = Object.values(SURFACE_REGISTRY).map((m) => m.provider);
+    expect(new Set(labels).size).toBe(labels.length);
   });
 });

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -32,8 +32,8 @@ import {
   infraIndicatorSample,
 } from "../../scripts/drift-report-collector.js";
 import type { DriftEntry, QuarantineEntry } from "../../scripts/drift-types.js";
-import { SURFACE_REGISTRY, KNOWN_SURFACE_SLUGS } from "./drift/surface-registry.js";
-import { existsSync } from "node:fs";
+import { SURFACE_REGISTRY, KNOWN_SURFACE_SLUGS, isKnownSurface } from "./drift/surface-registry.js";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { isBaseReportReusable } from "../../scripts/drift-delta.js";
 import type { DriftReport } from "../../scripts/drift-types.js";
@@ -1381,30 +1381,45 @@ describe("WS-5 — previously-quarantined surfaces now route to exit-2 entries",
   // A drift block for a surface that today is NOT a PROVIDER_MAP key. On old
   // code these route to a quarantine (exit 5) because extractProviderName
   // returns null. With the surface marker + registry they become auto-fixable
-  // exit-2 entries. (≥3 surfaces to satisfy the ≥3-cell rule.)
+  // exit-2 entries.
+  //
+  // CRITICAL — each title below is NEUTRAL PROSE that contains NO registry
+  // provider label (nor a legacy alias) as a substring, in either the ancestor
+  // title OR the emitted context. That is deliberate: it means the legacy
+  // `extractProviderName` fallback returns null for every one of these, so the
+  // ONLY thing that can route them to an entry is the `Surface:` marker seam. If
+  // the WS-5 seam is reverted, ALL of these go RED (verified). This closes the
+  // F1 gap where fal/elevenlabs stayed green on revert because their titles
+  // happened to contain the legacy label substring. (≥3 cells; 4 for margin.)
   const CASES: { surface: string; title: string; provider: string; builderFile: string }[] = [
     {
-      surface: "cohere-chat",
-      title: "Cohere /v2/chat (non-streaming)",
-      provider: "Cohere Chat",
-      builderFile: "src/cohere.ts",
+      surface: "moderation",
+      title: "content-safety endpoint 400 payload",
+      provider: "OpenAI Moderations",
+      builderFile: "src/moderation.ts",
     },
     {
-      surface: "fal-sync",
-      title: "fal.ai sync-run (image payload)",
-      provider: "fal.ai sync-run",
-      builderFile: "src/fal.ts",
+      surface: "video",
+      title: "async media generation status poll",
+      provider: "OpenAI Video",
+      builderFile: "src/video.ts",
     },
     {
-      surface: "elevenlabs",
-      title: "ElevenLabs /v1/sound-generation 400 error",
-      provider: "ElevenLabs",
-      builderFile: "src/elevenlabs-audio.ts",
+      surface: "transcription",
+      title: "audio-to-text multipart upload",
+      provider: "Transcription",
+      builderFile: "src/transcription.ts",
+    },
+    {
+      surface: "rerank",
+      title: "document relevance scoring endpoint",
+      provider: "Cohere Rerank",
+      builderFile: "src/rerank.ts",
     },
   ];
 
   for (const c of CASES) {
-    it(`RED→GREEN: "${c.surface}" drift → exit-2 entry (was exit-5 quarantine)`, () => {
+    it(`RED→GREEN: "${c.surface}" drift → exit-2 entry (marker-only, legacy label CANNOT rescue)`, () => {
       const block = formatDriftReport(c.title, [SAMPLE_DIFF], c.surface);
       const result = makeResult([
         makeAssertion({
@@ -1413,6 +1428,12 @@ describe("WS-5 — previously-quarantined surfaces now route to exit-2 entries",
           failureMessages: [`AssertionError: ${block}`],
         }),
       ]);
+
+      // Guard the guard: the neutral prose title must NOT be resolvable via the
+      // legacy provider-label path, so the marker seam is genuinely required. If
+      // this ever starts returning non-null, the RED→GREEN below is a false lock.
+      expect(extractProviderName(`${c.title} drift`)).toBeNull();
+      expect(extractProviderName(c.title)).toBeNull();
 
       const { entries, quarantine } = collectDriftEntries(result);
       // The fix: routed to a trustworthy entry, NOT quarantined.
@@ -1497,6 +1518,35 @@ describe("WS-5 — unknown surface slug fails LOUD (throws), never silent quaran
       /unknown drift surface "not-a-real-surface"/,
     );
   });
+
+  it.each(["constructor", "__proto__", "hasOwnProperty", "toString", "valueOf"])(
+    "throws (not garbage entry) when the marker slug is the Object.prototype member %s",
+    (protoSlug) => {
+      // A prototype-chain bracket lookup (SURFACE_REGISTRY[slug]) would resolve
+      // these to a truthy INHERITED member and skip the throw, emitting a
+      // DriftEntry with builderFile: undefined. The Object.hasOwn / isKnownSurface
+      // guard must treat them as unknown and THROW loudly.
+      const block =
+        `\nAPI DRIFT DETECTED: Prototype Slug\n` +
+        `  Surface: ${protoSlug}\n\n` +
+        "  1. [critical] LLMOCK DRIFT — mismatch detected\n" +
+        "     Path:    a.b.c\n" +
+        "     SDK:     null\n" +
+        "     Real:    null\n" +
+        "     Mock:    <absent>\n";
+      const result = makeResult([
+        makeAssertion({
+          ancestorTitles: ["Prototype Slug drift"],
+          title: "shape matches SDK",
+          failureMessages: [`AssertionError: ${block}`],
+        }),
+      ]);
+
+      expect(() => collectDriftEntries(result)).toThrow(
+        new RegExp(`Unknown drift surface "${protoSlug.replace(/[$]/g, "\\$&")}"`),
+      );
+    },
+  );
 });
 
 describe("WS-5 — base-report reuse contract (generatedAt + conclusion)", () => {
@@ -1549,13 +1599,126 @@ describe("WS-5 — base-report reuse contract (generatedAt + conclusion)", () =>
     // No conclusion field → falls back to undefined → not reusable.
     expect(isBaseReportReusable(legacy, legacy.conclusion, true)).toBe(false);
   });
+
+  it("generatedAt drives sameUtcDay staleness: same-day report reuses, prior-day does not", () => {
+    // Mirrors the sameUtcDay derivation the drift workflow computes from
+    // report.generatedAt (.github/workflows/test-drift.yml). This locks the
+    // *semantics* of generatedAt (a stale-day base is rejected), not merely that
+    // the field is written. A clean report identical in every way EXCEPT its
+    // generatedAt day must flip reusability.
+    const sameUtcDay = (generatedAt: string, now: Date): boolean => {
+      const g = new Date(generatedAt);
+      return (
+        g.getUTCFullYear() === now.getUTCFullYear() &&
+        g.getUTCMonth() === now.getUTCMonth() &&
+        g.getUTCDate() === now.getUTCDate()
+      );
+    };
+
+    const now = new Date("2026-07-15T12:00:00.000Z");
+    const cleanReport = (generatedAt: string): DriftReport => ({
+      timestamp: generatedAt,
+      generatedAt,
+      conclusion: conclusionForExitCode(0),
+      entries: [
+        {
+          provider: "OpenAI Chat",
+          scenario: "non-streaming text",
+          builderFile: "src/helpers.ts",
+          builderFunctions: ["buildTextCompletion"],
+          typesFile: "src/types.ts",
+          sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
+          diffs: [],
+        },
+      ],
+    });
+
+    // Same UTC day (later hour, same date) → derivation true → reusable.
+    const today = cleanReport("2026-07-15T03:00:00.000Z");
+    expect(sameUtcDay(today.generatedAt!, now)).toBe(true);
+    expect(isBaseReportReusable(today, today.conclusion, sameUtcDay(today.generatedAt!, now))).toBe(
+      true,
+    );
+
+    // Prior UTC day → derivation false → NOT reusable, despite an otherwise
+    // identical clean report. generatedAt is what makes the difference.
+    const yesterday = cleanReport("2026-07-14T23:59:59.000Z");
+    expect(sameUtcDay(yesterday.generatedAt!, now)).toBe(false);
+    expect(
+      isBaseReportReusable(
+        yesterday,
+        yesterday.conclusion,
+        sameUtcDay(yesterday.generatedAt!, now),
+      ),
+    ).toBe(false);
+  });
 });
 
+/**
+ * Statically extract every `surface` slug that a `*.drift.ts` emitter passes as
+ * the THIRD argument of `formatDriftReport(context, diffs, surface)`.
+ *
+ * This scans the real source via the TypeScript AST (NOT regex/text lexing — a
+ * text scan would mis-hit `formatDriftReport` inside strings/comments and cannot
+ * reliably pick the 3rd argument across multiline calls). Only string-literal
+ * 3rd args are collected: a 2-arg call (legacy, no marker — e.g. models.drift.ts)
+ * or a non-literal arg contributes no slug and is intentionally skipped.
+ */
+function collectEmittedSurfaceSlugs(): { slugs: Set<string>; scannedFiles: string[] } {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const ts = require("typescript") as typeof import("typescript");
+  const driftDir = resolve(__dirname, "drift");
+  const files = readdirSync(driftDir).filter((f) => f.endsWith(".drift.ts"));
+  const slugs = new Set<string>();
+
+  for (const file of files) {
+    const abs = resolve(driftDir, file);
+    const source = readFileSync(abs, "utf8");
+    const sf = ts.createSourceFile(abs, source, ts.ScriptTarget.Latest, true);
+
+    const visit = (node: import("typescript").Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "formatDriftReport" &&
+        node.arguments.length >= 3
+      ) {
+        const third = node.arguments[2];
+        if (ts.isStringLiteral(third) || ts.isNoSubstitutionTemplateLiteral(third)) {
+          slugs.add(third.text);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+  return { slugs, scannedFiles: files };
+}
+
 describe("WS-5 — SURFACE_REGISTRY coverage & integrity", () => {
-  it("every KNOWN_SURFACE_SLUGS entry is a registry key", () => {
-    for (const slug of KNOWN_SURFACE_SLUGS) {
-      expect(SURFACE_REGISTRY[slug]).toBeDefined();
-    }
+  it("every slug an emitter passes to formatDriftReport is a registered surface", () => {
+    // Independent derivation (F2/F3): scan the ACTUAL emitter call sites rather
+    // than iterating the registry's own keys (which is a tautology). This locks
+    // the "every emitter is registered" invariant at TEST time, so a new
+    // unregistered emitter fails CI even on a credential-less run where no drift
+    // is ever emitted and the collector's runtime throw is never reached.
+    const { slugs, scannedFiles } = collectEmittedSurfaceSlugs();
+    expect(scannedFiles.length, "found *.drift.ts files to scan").toBeGreaterThan(0);
+    expect(slugs.size, "found at least one emitted surface slug").toBeGreaterThan(0);
+
+    const unregistered = [...slugs].filter((slug) => !isKnownSurface(slug));
+    expect(
+      unregistered,
+      `emitter slug(s) missing from SURFACE_REGISTRY: ${unregistered.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("SURFACE_REGISTRY has no orphan slugs (every registered surface is emitted)", () => {
+    // Reverse direction: an entry no emitter uses is dead weight. Kept as a
+    // separate assertion so a future intentional pre-registration is easy to see.
+    const { slugs } = collectEmittedSurfaceSlugs();
+    const orphans = KNOWN_SURFACE_SLUGS.filter((slug) => !slugs.has(slug));
+    expect(orphans, `registered but never emitted: ${orphans.join(", ")}`).toEqual([]);
   });
 
   it("every registry entry resolves to an existing builderFile with non-empty builderFunctions", () => {

--- a/src/__tests__/drift/anthropic.drift.ts
+++ b/src/__tests__/drift/anthropic.drift.ts
@@ -58,7 +58,7 @@ describe.skipIf(!ANTHROPIC_API_KEY)("Anthropic Claude Messages drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("Anthropic Claude (non-streaming text)", diffs);
+    const report = formatDriftReport("Anthropic Claude (non-streaming text)", diffs, "anthropic");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -90,7 +90,11 @@ describe.skipIf(!ANTHROPIC_API_KEY)("Anthropic Claude Messages drift", () => {
     }));
 
     const diffs = compareSSESequences(sdkEvents, realStream.events, mockSSEShapes);
-    const report = formatDriftReport("Anthropic Claude (streaming text events)", diffs);
+    const report = formatDriftReport(
+      "Anthropic Claude (streaming text events)",
+      diffs,
+      "anthropic",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -128,7 +132,11 @@ describe.skipIf(!ANTHROPIC_API_KEY)("Anthropic Claude Messages drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("Anthropic Claude (non-streaming tool call)", diffs);
+    const report = formatDriftReport(
+      "Anthropic Claude (non-streaming tool call)",
+      diffs,
+      "anthropic",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -179,7 +187,11 @@ describe.skipIf(!ANTHROPIC_API_KEY)("Anthropic Claude Messages drift", () => {
     }));
 
     const diffs = compareSSESequences(sdkEvents, realStream.events, mockSSEShapes);
-    const report = formatDriftReport("Anthropic Claude (streaming tool call events)", diffs);
+    const report = formatDriftReport(
+      "Anthropic Claude (streaming tool call events)",
+      diffs,
+      "anthropic",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -221,7 +233,11 @@ describe("Anthropic Claude extended thinking shapes", () => {
 
     // Shape triangulation (mock-only, no real API call for thinking)
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Anthropic Claude (non-streaming thinking)", diffs);
+    const report = formatDriftReport(
+      "Anthropic Claude (non-streaming thinking)",
+      diffs,
+      "anthropic",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -283,7 +299,11 @@ describe("Anthropic Claude extended thinking shapes", () => {
     }));
 
     const diffs = compareSSESequences(sdkEvents, sdkEvents, mockSSEShapes);
-    const report = formatDriftReport("Anthropic Claude (streaming thinking events)", diffs);
+    const report = formatDriftReport(
+      "Anthropic Claude (streaming thinking events)",
+      diffs,
+      "anthropic",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/bedrock-stream.drift.ts
+++ b/src/__tests__/drift/bedrock-stream.drift.ts
@@ -201,7 +201,7 @@ describe.skipIf(!HAS_CREDENTIALS)("Bedrock drift", () => {
     if (mockRes.status === 200) {
       const mockShape = extractShape(JSON.parse(mockRes.body));
       const diffs = triangulate(sdkShape, sdkShape, mockShape);
-      const report = formatDriftReport("Bedrock Invoke", diffs);
+      const report = formatDriftReport("Bedrock Invoke", diffs, "bedrock-invoke");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -261,7 +261,11 @@ describe.skipIf(!HAS_CREDENTIALS)("Bedrock drift", () => {
       if (!mockEvent) continue; // already asserted presence above
 
       const diffs = triangulate(sdkEvent.dataShape, sdkEvent.dataShape, mockEvent.dataShape);
-      const report = formatDriftReport(`Bedrock InvokeStream:${sdkEvent.type}`, diffs);
+      const report = formatDriftReport(
+        `Bedrock InvokeStream:${sdkEvent.type}`,
+        diffs,
+        "bedrock-invoke-stream",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -291,7 +295,7 @@ describe.skipIf(!HAS_CREDENTIALS)("Bedrock drift", () => {
     if (mockRes.status === 200) {
       const mockShape = extractShape(JSON.parse(mockRes.body));
       const diffs = triangulate(sdkShape, sdkShape, mockShape);
-      const report = formatDriftReport("Bedrock Converse", diffs);
+      const report = formatDriftReport("Bedrock Converse", diffs, "bedrock-converse");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -397,7 +401,11 @@ describe.skipIf(!HAS_CREDENTIALS)("Bedrock drift", () => {
       if (!mockEvent) continue; // already asserted presence above
 
       const diffs = triangulate(sdkEvent.dataShape, sdkEvent.dataShape, mockEvent.dataShape);
-      const report = formatDriftReport(`Bedrock ConverseStream:${sdkEvent.type}`, diffs);
+      const report = formatDriftReport(
+        `Bedrock ConverseStream:${sdkEvent.type}`,
+        diffs,
+        "bedrock-converse-stream",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -482,7 +490,11 @@ describe.skipIf(!HAS_CREDENTIALS)("Bedrock drift", () => {
       if (!mockEvent) continue;
 
       const diffs = triangulate(sdkEvent.dataShape, sdkEvent.dataShape, mockEvent.dataShape);
-      const report = formatDriftReport(`Bedrock ConverseStream Tool:${sdkEvent.type}`, diffs);
+      const report = formatDriftReport(
+        `Bedrock ConverseStream Tool:${sdkEvent.type}`,
+        diffs,
+        "bedrock-converse-stream",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -597,6 +609,7 @@ describe.skipIf(!HAS_CREDENTIALS)("Bedrock drift", () => {
         const report = formatDriftReport(
           `Bedrock ConverseStream Reasoning:${sdkEvent.type}`,
           diffs,
+          "bedrock-converse-stream",
         );
 
         expect(

--- a/src/__tests__/drift/cohere.drift.ts
+++ b/src/__tests__/drift/cohere.drift.ts
@@ -156,7 +156,7 @@ describe("Cohere error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Cohere /v2/chat malformed JSON error", diffs);
+    const report = formatDriftReport("Cohere /v2/chat malformed JSON error", diffs, "cohere-chat");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -176,7 +176,7 @@ describe("Cohere error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Cohere /v2/chat missing model error", diffs);
+    const report = formatDriftReport("Cohere /v2/chat missing model error", diffs, "cohere-chat");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -196,7 +196,11 @@ describe("Cohere error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Cohere /v2/chat missing messages error", diffs);
+    const report = formatDriftReport(
+      "Cohere /v2/chat missing messages error",
+      diffs,
+      "cohere-chat",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -217,7 +221,11 @@ describe("Cohere error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Cohere /v2/chat no fixture match error", diffs);
+    const report = formatDriftReport(
+      "Cohere /v2/chat no fixture match error",
+      diffs,
+      "cohere-chat",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -248,7 +256,7 @@ describe.skipIf(!HAS_CREDENTIALS)("Cohere drift", () => {
       const mockShape = extractShape(JSON.parse(mockRes.body));
 
       const diffs = triangulate(sdkShape, realShape, mockShape);
-      const report = formatDriftReport("Cohere /v2/chat (non-streaming)", diffs);
+      const report = formatDriftReport("Cohere /v2/chat (non-streaming)", diffs, "cohere-chat");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -284,7 +292,11 @@ describe.skipIf(!HAS_CREDENTIALS)("Cohere drift", () => {
         const mockChunkShape = extractShape(mockChunks[0]);
 
         const diffs = triangulate(sdkChunkShape, realChunkShape, mockChunkShape);
-        const report = formatDriftReport("Cohere /v2/chat (streaming first chunk)", diffs);
+        const report = formatDriftReport(
+          "Cohere /v2/chat (streaming first chunk)",
+          diffs,
+          "cohere-chat",
+        );
 
         expect(
           diffs.filter((d) => d.severity === "critical"),
@@ -308,7 +320,11 @@ describe.skipIf(!HAS_CREDENTIALS)("Cohere drift", () => {
         const mockLastShape = extractShape(mockChunks[mockChunks.length - 1]);
 
         const lastDiffs = triangulate(sdkLastChunkShape, realLastShape, mockLastShape);
-        const lastReport = formatDriftReport("Cohere /v2/chat (streaming last chunk)", lastDiffs);
+        const lastReport = formatDriftReport(
+          "Cohere /v2/chat (streaming last chunk)",
+          lastDiffs,
+          "cohere-chat",
+        );
 
         expect(
           lastDiffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/elevenlabs.drift.ts
+++ b/src/__tests__/drift/elevenlabs.drift.ts
@@ -174,7 +174,11 @@ describe("ElevenLabs drift — sound generation", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("ElevenLabs /v1/sound-generation 400 error", diffs);
+    const report = formatDriftReport(
+      "ElevenLabs /v1/sound-generation 400 error",
+      diffs,
+      "elevenlabs",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -241,7 +245,7 @@ describe("ElevenLabs drift — music endpoints", () => {
 
     // Three-way comparison: use SDK shape as both expected and real
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("ElevenLabs /v1/music/plan", diffs);
+    const report = formatDriftReport("ElevenLabs /v1/music/plan", diffs, "elevenlabs");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -265,7 +269,7 @@ describe("ElevenLabs drift — music endpoints", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(expectedShape, expectedShape, mockShape);
-    const report = formatDriftReport("ElevenLabs /v1/music 400 error", diffs);
+    const report = formatDriftReport("ElevenLabs /v1/music 400 error", diffs, "elevenlabs");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/fal-queue.drift.ts
+++ b/src/__tests__/drift/fal-queue.drift.ts
@@ -106,7 +106,7 @@ describe("fal.ai queue lifecycle shapes", () => {
     // Shape comparison
     const mockShape = extractShape(envelope);
     const diffs = compareShapes(expectedShape, mockShape);
-    const report = formatDriftReport("fal.ai queue submit envelope", diffs);
+    const report = formatDriftReport("fal.ai queue submit envelope", diffs, "fal-queue");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -145,7 +145,7 @@ describe("fal.ai queue lifecycle shapes", () => {
 
     const mockShape = extractShape(body);
     const diffs = compareShapes(expectedShape, mockShape);
-    const report = formatDriftReport("fal.ai queue status", diffs);
+    const report = formatDriftReport("fal.ai queue status", diffs, "fal-queue");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -182,7 +182,7 @@ describe("fal.ai queue lifecycle shapes", () => {
 
     const mockShape = extractShape(body);
     const diffs = compareShapes(expectedShape, mockShape);
-    const report = formatDriftReport("fal.ai queue result", diffs);
+    const report = formatDriftReport("fal.ai queue result", diffs, "fal-queue");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -219,7 +219,7 @@ describe("fal.ai queue lifecycle shapes", () => {
 
     const mockShape = extractShape(body);
     const diffs = compareShapes(expectedShape, mockShape);
-    const report = formatDriftReport("fal.ai queue cancel", diffs);
+    const report = formatDriftReport("fal.ai queue cancel", diffs, "fal-queue");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/fal.drift.ts
+++ b/src/__tests__/drift/fal.drift.ts
@@ -142,7 +142,7 @@ describe("fal.ai sync-run response shape", () => {
     // Two-way triangulation: expected shape is both the "SDK" and "real" reference
     // since fal passthrough should be identity.
     const diffs = triangulate(expectedShape, expectedShape, mockShape);
-    const report = formatDriftReport("fal.ai sync-run (image payload)", diffs);
+    const report = formatDriftReport("fal.ai sync-run (image payload)", diffs, "fal-sync");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -168,7 +168,7 @@ describe("fal.ai sync-run response shape", () => {
     // Shape match via triangulation
     const mockShape = extractShape(parsed);
     const diffs = triangulate(expectedShape, expectedShape, mockShape);
-    const report = formatDriftReport("fal.ai sync-run (flat payload)", diffs);
+    const report = formatDriftReport("fal.ai sync-run (flat payload)", diffs, "fal-sync");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/gemini-interactions.drift.ts
+++ b/src/__tests__/drift/gemini-interactions.drift.ts
@@ -77,7 +77,11 @@ describe.skipIf(!GOOGLE_API_KEY)("Gemini Interactions API drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("Gemini Interactions (non-streaming text)", diffs);
+    const report = formatDriftReport(
+      "Gemini Interactions (non-streaming text)",
+      diffs,
+      "gemini-interactions",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -120,6 +124,7 @@ describe.skipIf(!GOOGLE_API_KEY)("Gemini Interactions API drift", () => {
     const report = formatDriftReport(
       "Gemini Interactions (non-streaming text, Step[] input)",
       diffs,
+      "gemini-interactions",
     );
 
     expect(
@@ -162,7 +167,11 @@ describe.skipIf(!GOOGLE_API_KEY)("Gemini Interactions API drift", () => {
     }));
 
     const diffs = compareSSESequences(sdkEvents, realStream.events, mockSSEShapes);
-    const report = formatDriftReport("Gemini Interactions (streaming text events)", diffs);
+    const report = formatDriftReport(
+      "Gemini Interactions (streaming text events)",
+      diffs,
+      "gemini-interactions",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -218,7 +227,11 @@ describe.skipIf(!GOOGLE_API_KEY)("Gemini Interactions API drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("Gemini Interactions (non-streaming tool call)", diffs);
+    const report = formatDriftReport(
+      "Gemini Interactions (non-streaming tool call)",
+      diffs,
+      "gemini-interactions",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -276,7 +289,11 @@ describe.skipIf(!GOOGLE_API_KEY)("Gemini Interactions API drift", () => {
     }));
 
     const diffs = compareSSESequences(sdkEvents, realStream.events, mockSSEShapes);
-    const report = formatDriftReport("Gemini Interactions (streaming tool call events)", diffs);
+    const report = formatDriftReport(
+      "Gemini Interactions (streaming tool call events)",
+      diffs,
+      "gemini-interactions",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/gemini.drift.ts
+++ b/src/__tests__/drift/gemini.drift.ts
@@ -56,7 +56,7 @@ describe.skipIf(!GOOGLE_API_KEY)("Google Gemini drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("Gemini (non-streaming text)", diffs);
+    const report = formatDriftReport("Gemini (non-streaming text)", diffs, "gemini");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -86,7 +86,7 @@ describe.skipIf(!GOOGLE_API_KEY)("Google Gemini drift", () => {
       const mockChunkShape = extractShape(mockChunks[0]);
 
       const diffs = triangulate(sdkChunkShape, realChunkShape, mockChunkShape);
-      const report = formatDriftReport("Gemini (streaming intermediate chunk)", diffs);
+      const report = formatDriftReport("Gemini (streaming intermediate chunk)", diffs, "gemini");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -99,7 +99,7 @@ describe.skipIf(!GOOGLE_API_KEY)("Google Gemini drift", () => {
     const mockLastShape = extractShape(mockChunks[mockChunks.length - 1]);
 
     const lastDiffs = triangulate(sdkLastShape, realLastShape, mockLastShape);
-    const lastReport = formatDriftReport("Gemini (streaming last chunk)", lastDiffs);
+    const lastReport = formatDriftReport("Gemini (streaming last chunk)", lastDiffs, "gemini");
 
     expect(
       lastDiffs.filter((d) => d.severity === "critical"),
@@ -140,7 +140,7 @@ describe.skipIf(!GOOGLE_API_KEY)("Google Gemini drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("Gemini (non-streaming tool call)", diffs);
+    const report = formatDriftReport("Gemini (non-streaming tool call)", diffs, "gemini");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -186,7 +186,7 @@ describe.skipIf(!GOOGLE_API_KEY)("Google Gemini drift", () => {
     const mockLastShape = extractShape(mockChunks[mockChunks.length - 1]);
 
     const diffs = triangulate(sdkLastShape, realLastShape, mockLastShape);
-    const report = formatDriftReport("Gemini (streaming tool call)", diffs);
+    const report = formatDriftReport("Gemini (streaming tool call)", diffs, "gemini");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -288,7 +288,7 @@ describe("Gemini error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Gemini (RESOURCE_EXHAUSTED error)", diffs);
+    const report = formatDriftReport("Gemini (RESOURCE_EXHAUSTED error)", diffs, "gemini");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -318,7 +318,7 @@ describe("Gemini error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Gemini (NOT_FOUND error)", diffs);
+    const report = formatDriftReport("Gemini (NOT_FOUND error)", diffs, "gemini");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -344,7 +344,7 @@ describe("Gemini error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Gemini (INVALID_ARGUMENT error)", diffs);
+    const report = formatDriftReport("Gemini (INVALID_ARGUMENT error)", diffs, "gemini");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -392,7 +392,7 @@ describe("Gemini error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Gemini (no-fixture-match error)", diffs);
+    const report = formatDriftReport("Gemini (no-fixture-match error)", diffs, "gemini");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -433,7 +433,7 @@ describe("Gemini error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Gemini (malformed JSON error)", diffs);
+    const report = formatDriftReport("Gemini (malformed JSON error)", diffs, "gemini");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -486,7 +486,7 @@ describe("Gemini thinking token shapes", () => {
 
     // Shape comparison: SDK expected vs mock output
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Gemini (non-streaming thinking)", diffs);
+    const report = formatDriftReport("Gemini (non-streaming thinking)", diffs, "gemini");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -562,7 +562,11 @@ describe("Gemini thinking token shapes", () => {
       sdkThinkingChunkShape,
       mockThinkingShape,
     );
-    const thinkingReport = formatDriftReport("Gemini (streaming thinking chunk)", thinkingDiffs);
+    const thinkingReport = formatDriftReport(
+      "Gemini (streaming thinking chunk)",
+      thinkingDiffs,
+      "gemini",
+    );
 
     expect(
       thinkingDiffs.filter((d) => d.severity === "critical"),
@@ -575,6 +579,7 @@ describe("Gemini thinking token shapes", () => {
     const contentReport = formatDriftReport(
       "Gemini (streaming content chunk after thinking)",
       contentDiffs,
+      "gemini",
     );
 
     expect(

--- a/src/__tests__/drift/images.drift.ts
+++ b/src/__tests__/drift/images.drift.ts
@@ -116,7 +116,7 @@ describe("OpenAI Images API drift", () => {
 
     // Two-way: SDK vs mock (no real API call — DALL-E is expensive)
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("OpenAI Images (url variant)", diffs);
+    const report = formatDriftReport("OpenAI Images (url variant)", diffs, "images");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -138,7 +138,7 @@ describe("OpenAI Images API drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("OpenAI Images (b64_json variant)", diffs);
+    const report = formatDriftReport("OpenAI Images (b64_json variant)", diffs, "images");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -163,7 +163,7 @@ describe("OpenAI Images API drift", () => {
     const mockShape = extractShape(parsed);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("OpenAI Images (multi-image)", diffs);
+    const report = formatDriftReport("OpenAI Images (multi-image)", diffs, "images");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/moderation.drift.ts
+++ b/src/__tests__/drift/moderation.drift.ts
@@ -51,7 +51,7 @@ describe("OpenAI Moderations drift", () => {
 
     const mockShape = extractShape(mockBody);
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("OpenAI Moderations", diffs);
+    const report = formatDriftReport("OpenAI Moderations", diffs, "moderation");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/ollama.drift.ts
+++ b/src/__tests__/drift/ollama.drift.ts
@@ -130,7 +130,7 @@ describe.skipIf(!process.env.OLLAMA_HOST)("Ollama drift", () => {
       const mockShape = extractShape(JSON.parse(mockRes.body));
 
       const diffs = triangulate(sdkShape, realShape, mockShape);
-      const report = formatDriftReport("Ollama /api/chat", diffs);
+      const report = formatDriftReport("Ollama /api/chat", diffs, "ollama");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -168,7 +168,7 @@ describe.skipIf(!process.env.OLLAMA_HOST)("Ollama drift", () => {
       const mockFirstShape = extractShape(mockChunks[0]);
 
       const diffs = triangulate(sdkChunkShape, realFirstShape, mockFirstShape);
-      const report = formatDriftReport("Ollama /api/chat (streaming chunk)", diffs);
+      const report = formatDriftReport("Ollama /api/chat (streaming chunk)", diffs, "ollama");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -199,7 +199,7 @@ describe.skipIf(!process.env.OLLAMA_HOST)("Ollama drift", () => {
       const mockShape = extractShape(JSON.parse(mockRes.body));
 
       const diffs = triangulate(sdkShape, realShape, mockShape);
-      const report = formatDriftReport("Ollama /api/generate", diffs);
+      const report = formatDriftReport("Ollama /api/generate", diffs, "ollama");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/openai-chat.drift.ts
+++ b/src/__tests__/drift/openai-chat.drift.ts
@@ -58,7 +58,7 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Chat Completions drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("OpenAI Chat (non-streaming text)", diffs);
+    const report = formatDriftReport("OpenAI Chat (non-streaming text)", diffs, "openai-chat");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -87,7 +87,7 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Chat Completions drift", () => {
     const mockChunkShape = extractShape(mockChunks[0]);
 
     const diffs = triangulate(sdkChunkShape, realChunkShape, mockChunkShape);
-    const report = formatDriftReport("OpenAI Chat (streaming text chunks)", diffs);
+    const report = formatDriftReport("OpenAI Chat (streaming text chunks)", diffs, "openai-chat");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -127,7 +127,7 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Chat Completions drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("OpenAI Chat (non-streaming tool call)", diffs);
+    const report = formatDriftReport("OpenAI Chat (non-streaming tool call)", diffs, "openai-chat");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -172,7 +172,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Chat Completions drift", () => {
     const mockChunkShape = extractShape(mockChunks[0]);
 
     const diffs = triangulate(sdkChunkShape, realChunkShape, mockChunkShape);
-    const report = formatDriftReport("OpenAI Chat (streaming tool call chunks)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Chat (streaming tool call chunks)",
+      diffs,
+      "openai-chat",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -239,7 +243,7 @@ describe("OpenAI Chat Completions error shapes", () => {
       const mockShape = extractShape(body);
 
       const diffs = triangulate(sdkShape, sdkShape, mockShape);
-      const report = formatDriftReport("OpenAI Chat error fixture (400)", diffs);
+      const report = formatDriftReport("OpenAI Chat error fixture (400)", diffs, "openai-chat");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -274,7 +278,7 @@ describe("OpenAI Chat Completions error shapes", () => {
       const mockShape = extractShape(body);
 
       const diffs = triangulate(sdkShape, sdkShape, mockShape);
-      const report = formatDriftReport("OpenAI Chat no-fixture-match (404)", diffs);
+      const report = formatDriftReport("OpenAI Chat no-fixture-match (404)", diffs, "openai-chat");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -330,7 +334,7 @@ describe("OpenAI Chat Completions error shapes", () => {
       const mockShape = extractShape(body);
 
       const diffs = triangulate(sdkShape, sdkShape, mockShape);
-      const report = formatDriftReport("OpenAI Chat malformed JSON (400)", diffs);
+      const report = formatDriftReport("OpenAI Chat malformed JSON (400)", diffs, "openai-chat");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -387,7 +391,11 @@ describe("OpenAI Chat Completions reasoning shapes", () => {
       const mockShape = extractShape(body);
 
       const diffs = triangulate(sdkShape, sdkShape, mockShape);
-      const report = formatDriftReport("OpenAI Chat (non-streaming reasoning)", diffs);
+      const report = formatDriftReport(
+        "OpenAI Chat (non-streaming reasoning)",
+        diffs,
+        "openai-chat",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -462,7 +470,11 @@ describe("OpenAI Chat Completions reasoning shapes", () => {
       const mockChunkShape = extractShape(reasoningChunks[0]);
 
       const diffs = triangulate(sdkChunkShape, sdkChunkShape, mockChunkShape);
-      const report = formatDriftReport("OpenAI Chat (streaming reasoning chunks)", diffs);
+      const report = formatDriftReport(
+        "OpenAI Chat (streaming reasoning chunks)",
+        diffs,
+        "openai-chat",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/openai-embeddings.drift.ts
+++ b/src/__tests__/drift/openai-embeddings.drift.ts
@@ -48,7 +48,7 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Embeddings drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("OpenAI Embeddings", diffs);
+    const report = formatDriftReport("OpenAI Embeddings", diffs, "openai-embeddings");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -71,7 +71,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Embeddings drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("OpenAI Embeddings (multiple inputs)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Embeddings (multiple inputs)",
+      diffs,
+      "openai-embeddings",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/openai-responses.drift.ts
+++ b/src/__tests__/drift/openai-responses.drift.ts
@@ -61,7 +61,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Responses API drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("OpenAI Responses (non-streaming text)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Responses (non-streaming text)",
+      diffs,
+      "openai-responses",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -92,7 +96,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Responses API drift", () => {
     }));
 
     const diffs = compareSSESequences(sdkEvents, realStream.events, mockSSEShapes);
-    const report = formatDriftReport("OpenAI Responses (streaming text events)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Responses (streaming text events)",
+      diffs,
+      "openai-responses",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -130,7 +138,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Responses API drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("OpenAI Responses (non-streaming tool call)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Responses (non-streaming tool call)",
+      diffs,
+      "openai-responses",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -180,7 +192,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Responses API drift", () => {
     }));
 
     const diffs = compareSSESequences(sdkEvents, realStream.events, mockSSEShapes);
-    const report = formatDriftReport("OpenAI Responses (streaming tool call events)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Responses (streaming tool call events)",
+      diffs,
+      "openai-responses",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -243,7 +259,11 @@ describe("OpenAI Responses API error shapes", () => {
       const mockShape = extractShape(body);
 
       const diffs = triangulate(sdkShape, sdkShape, mockShape);
-      const report = formatDriftReport("OpenAI Responses (error fixture shape)", diffs);
+      const report = formatDriftReport(
+        "OpenAI Responses (error fixture shape)",
+        diffs,
+        "openai-responses",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -273,7 +293,11 @@ describe("OpenAI Responses API error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("OpenAI Responses (no-fixture-match error shape)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Responses (no-fixture-match error shape)",
+      diffs,
+      "openai-responses",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -296,7 +320,11 @@ describe("OpenAI Responses API error shapes", () => {
     const mockShape = extractShape(body);
 
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("OpenAI Responses (malformed request error shape)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Responses (malformed request error shape)",
+      diffs,
+      "openai-responses",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -459,7 +487,11 @@ describe("OpenAI Responses API reasoning drift", () => {
       }
 
       const diffs = triangulate(sdkEvent.dataShape, sdkEvent.dataShape, mockEvent.dataShape);
-      const report = formatDriftReport(`OpenAI Responses Reasoning:${sdkEvent.type}`, diffs);
+      const report = formatDriftReport(
+        `OpenAI Responses Reasoning:${sdkEvent.type}`,
+        diffs,
+        "openai-responses",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/rerank.drift.ts
+++ b/src/__tests__/drift/rerank.drift.ts
@@ -123,7 +123,7 @@ describe.skipIf(!HAS_CREDENTIALS)("Cohere Rerank drift", () => {
     const mockShape = extractShape(JSON.parse(mockRes.body));
 
     const diffs = triangulate(sdkShape, realShape, mockShape);
-    const report = formatDriftReport("Cohere /v2/rerank", diffs);
+    const report = formatDriftReport("Cohere /v2/rerank", diffs, "rerank");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -199,7 +199,7 @@ describe("Cohere Rerank mock-only shape validation", () => {
 
     // Two-way: SDK vs mock (no real API needed)
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Cohere /v2/rerank (mock vs SDK)", diffs);
+    const report = formatDriftReport("Cohere /v2/rerank (mock vs SDK)", diffs, "rerank");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/schema.ts
+++ b/src/__tests__/drift/schema.ts
@@ -3,6 +3,8 @@
  * for drift detection between SDK types, real API responses, and aimock output.
  */
 
+import { isKnownSurface } from "./surface-registry.js";
+
 // ---------------------------------------------------------------------------
 // Shape types
 // ---------------------------------------------------------------------------
@@ -451,11 +453,35 @@ export function compareSSESequences(
 // Report formatting
 // ---------------------------------------------------------------------------
 
-export function formatDriftReport(context: string, diffs: ShapeDiff[]): string {
+/**
+ * Format a drift report block for a vitest failure message.
+ *
+ * @param context Human-readable prose title (kept for humans + the legacy
+ *   no-marker collector fallback).
+ * @param diffs   The shape diffs to render.
+ * @param surface Optional stable surface slug (see `surface-registry.ts`). When
+ *   provided it MUST be a registered slug — an unknown slug throws at emit time
+ *   so a typo/forgotten registry entry fails loudly locally. When present, a
+ *   machine-readable `Surface: <slug>` marker line is emitted so the collector
+ *   resolves the block structurally (→ auto-fixable exit 2) instead of
+ *   substring-matching the prose title.
+ */
+export function formatDriftReport(context: string, diffs: ShapeDiff[], surface?: string): string {
+  if (surface !== undefined && !isKnownSurface(surface)) {
+    throw new Error(
+      `formatDriftReport: unknown drift surface "${surface}" — add it to SURFACE_REGISTRY ` +
+        `in src/__tests__/drift/surface-registry.ts`,
+    );
+  }
+
   if (diffs.length === 0) return `No drift detected: ${context}`;
 
   const lines: string[] = [];
-  lines.push(`\nAPI DRIFT DETECTED: ${context}\n`);
+  lines.push(`\nAPI DRIFT DETECTED: ${context}`);
+  if (surface !== undefined) {
+    lines.push(`  Surface: ${surface}`);
+  }
+  lines.push("");
 
   for (let i = 0; i < diffs.length; i++) {
     const d = diffs[i];

--- a/src/__tests__/drift/surface-registry.ts
+++ b/src/__tests__/drift/surface-registry.ts
@@ -1,0 +1,271 @@
+/**
+ * Single source of truth for drift *surfaces*.
+ *
+ * A "surface" is one provider-endpoint shape that emits an `API DRIFT
+ * DETECTED:` block (e.g. Cohere /v2/chat, Bedrock Invoke, OpenAI Images). Each
+ * surface is identified by a stable machine slug (e.g. `"cohere-chat"`) that the
+ * emitter declares via `formatDriftReport(context, diffs, surface)` and the
+ * drift-report collector resolves back to the source file(s) that must be fixed.
+ *
+ * WHY a registry (not title-substring matching): the collector historically
+ * keyed a drift block by `text.includes(<PROVIDER_MAP key>)` against ~9
+ * hardcoded provider names. ~15 additional surfaces emit valid, fully-parseable
+ * drift blocks whose PROSE titles are not keys, so they resolved to `null` →
+ * quarantine (exit 5) → the auto-fix workflow (which gates on exit 2) never ran
+ * for them. A slug-keyed registry shared by BOTH the emitter (schema.ts) and the
+ * collector makes adding a surface a single edit that both consumers see, and
+ * lets an unkeyed-but-emitting surface fail LOUDLY instead of silently
+ * quarantining.
+ *
+ * This module is imported by:
+ *   - `schema.ts` — validates a passed `surface` slug at emit time.
+ *   - `scripts/drift-report-collector.ts` — resolves a slug to a source file.
+ *   - `scripts/drift-report-collector.ts` legacy fallback — matches a no-marker
+ *     block against the `provider` labels below (back-compat).
+ */
+
+/**
+ * How a surface slug maps onto the source file(s) an auto-fixer must edit.
+ *
+ * Mirrors the fields the collector needs to build a `DriftEntry`. `fix-drift.ts`
+ * hard-requires `builderFile` (non-empty string), `builderFunctions` (non-empty
+ * string array), and `sdkShapesFile` (non-empty string) — so every entry here
+ * must resolve to a real file with real, non-invented function names.
+ */
+export interface SurfaceMapping {
+  /** Human-readable label used in the report/prompt and the legacy fallback. */
+  provider: string;
+  /** Source file the fixer edits, e.g. `"src/cohere.ts"`. */
+  builderFile: string;
+  /**
+   * Builder/handler function names in `builderFile` (or across the surface's
+   * source files) — non-empty. Steer the fixer's Read/Grep; NEVER invented.
+   */
+  builderFunctions: string[];
+  /** Types file for the surface, or null if shapes are inline. */
+  typesFile: string | null;
+  /**
+   * Optional override for the SDK-shapes reference file. Defaults to the
+   * collector's `SDK_SHAPES_FILE` when omitted.
+   */
+  sdkShapesFile?: string;
+}
+
+const SDK_SHAPES_FILE = "src/__tests__/drift/sdk-shapes.ts";
+
+/**
+ * Slug → surface mapping. ONE table, two consumers. Adding a new provider
+ * surface is a single edit here plus passing the slug at the emit site.
+ *
+ * Keys are stable machine slugs. Open-ended prose title suffixes (e.g.
+ * `Bedrock ConverseStream:<eventType>`) do NOT affect the slug — the emitter
+ * passes the stable slug and keeps the suffix in the prose `context`.
+ */
+export const SURFACE_REGISTRY: Record<string, SurfaceMapping> = {
+  // --- Existing PROVIDER_MAP surfaces, migrated to slugs (unchanged mappings) ---
+  "openai-chat": {
+    provider: "OpenAI Chat",
+    builderFile: "src/helpers.ts",
+    builderFunctions: [
+      "buildTextCompletion",
+      "buildToolCallCompletion",
+      "buildTextChunks",
+      "buildToolCallChunks",
+    ],
+    typesFile: "src/types.ts",
+  },
+  "openai-responses": {
+    provider: "OpenAI Responses",
+    builderFile: "src/responses.ts",
+    builderFunctions: [
+      "buildTextResponse",
+      "buildToolCallResponse",
+      "buildTextStreamEvents",
+      "buildToolCallStreamEvents",
+    ],
+    typesFile: null,
+  },
+  anthropic: {
+    provider: "Anthropic Claude",
+    builderFile: "src/messages.ts",
+    builderFunctions: [
+      "buildClaudeTextResponse",
+      "buildClaudeToolCallResponse",
+      "buildClaudeTextStreamEvents",
+      "buildClaudeToolCallStreamEvents",
+    ],
+    typesFile: null,
+  },
+  gemini: {
+    provider: "Google Gemini",
+    builderFile: "src/gemini.ts",
+    builderFunctions: [
+      "buildGeminiTextResponse",
+      "buildGeminiToolCallResponse",
+      "buildGeminiTextStreamChunks",
+      "buildGeminiToolCallStreamChunks",
+    ],
+    typesFile: null,
+  },
+  "openai-realtime": {
+    provider: "OpenAI Realtime",
+    builderFile: "src/ws-realtime.ts",
+    builderFunctions: ["handleWebSocketRealtime", "realtimeItemsToMessages"],
+    typesFile: null,
+  },
+  "openai-responses-ws": {
+    provider: "OpenAI Responses WS",
+    builderFile: "src/ws-responses.ts",
+    builderFunctions: ["handleWebSocketResponses"],
+    typesFile: null,
+  },
+  "gemini-live": {
+    provider: "Gemini Live",
+    builderFile: "src/ws-gemini-live.ts",
+    builderFunctions: ["handleWebSocketGeminiLive"],
+    typesFile: null,
+  },
+  "openai-embeddings": {
+    provider: "OpenAI Embeddings",
+    builderFile: "src/helpers.ts",
+    builderFunctions: ["buildEmbeddingResponse", "generateDeterministicEmbedding"],
+    typesFile: null,
+    sdkShapesFile: SDK_SHAPES_FILE,
+  },
+  "gemini-interactions": {
+    provider: "Gemini Interactions",
+    builderFile: "src/gemini-interactions.ts",
+    builderFunctions: [
+      "buildInteractionsTextResponse",
+      "buildInteractionsToolCallResponse",
+      "buildInteractionsContentWithToolCallsResponse",
+      "buildInteractionsTextSSEEvents",
+      "buildInteractionsToolCallSSEEvents",
+      "buildInteractionsContentWithToolCallsSSEEvents",
+    ],
+    typesFile: null,
+  },
+
+  // --- Previously unmapped surfaces (the hole) — now keyed. -------------------
+  "cohere-chat": {
+    provider: "Cohere Chat",
+    builderFile: "src/cohere.ts",
+    builderFunctions: ["handleCohere", "cohereToCompletionRequest"],
+    typesFile: null,
+  },
+  rerank: {
+    provider: "Cohere Rerank",
+    builderFile: "src/rerank.ts",
+    builderFunctions: ["handleRerank"],
+    typesFile: null,
+  },
+  "bedrock-invoke": {
+    provider: "Bedrock Invoke",
+    builderFile: "src/bedrock.ts",
+    builderFunctions: [
+      "handleBedrock",
+      "handleBedrockStream",
+      "bedrockToCompletionRequest",
+      "buildBedrockStreamTextEvents",
+      "buildBedrockStreamToolCallEvents",
+      "buildBedrockStreamContentWithToolCallsEvents",
+    ],
+    typesFile: null,
+  },
+  "bedrock-invoke-stream": {
+    provider: "Bedrock InvokeStream",
+    builderFile: "src/bedrock.ts",
+    builderFunctions: [
+      "handleBedrockStream",
+      "buildBedrockStreamTextEvents",
+      "buildBedrockStreamToolCallEvents",
+      "buildBedrockStreamContentWithToolCallsEvents",
+    ],
+    typesFile: null,
+  },
+  "bedrock-converse": {
+    provider: "Bedrock Converse",
+    builderFile: "src/bedrock-converse.ts",
+    builderFunctions: ["handleConverse", "converseToCompletionRequest"],
+    typesFile: null,
+  },
+  "bedrock-converse-stream": {
+    provider: "Bedrock ConverseStream",
+    builderFile: "src/bedrock-converse.ts",
+    builderFunctions: ["handleConverseStream", "converseToCompletionRequest"],
+    typesFile: null,
+  },
+  ollama: {
+    provider: "Ollama",
+    builderFile: "src/ollama.ts",
+    builderFunctions: ["handleOllama", "handleOllamaGenerate", "ollamaToCompletionRequest"],
+    typesFile: null,
+  },
+  "fal-sync": {
+    provider: "fal.ai sync-run",
+    builderFile: "src/fal.ts",
+    builderFunctions: ["handleFal", "imageResponseToFalJson", "videoResponseToFalJson"],
+    typesFile: null,
+  },
+  "fal-queue": {
+    provider: "fal.ai queue",
+    builderFile: "src/fal.ts",
+    builderFunctions: ["handleFal", "walkFalQueue", "resolveProgression"],
+    typesFile: null,
+  },
+  elevenlabs: {
+    provider: "ElevenLabs",
+    builderFile: "src/elevenlabs-audio.ts",
+    builderFunctions: ["handleElevenLabsTTS", "handleElevenLabsAudio"],
+    typesFile: null,
+  },
+  images: {
+    provider: "OpenAI Images",
+    builderFile: "src/images.ts",
+    builderFunctions: ["handleImages", "handleImageEdit", "handleImageVariations"],
+    typesFile: null,
+  },
+  video: {
+    provider: "OpenAI Video",
+    builderFile: "src/video.ts",
+    builderFunctions: ["handleVideoCreate", "handleVideoStatus"],
+    typesFile: null,
+  },
+  moderation: {
+    provider: "OpenAI Moderations",
+    builderFile: "src/moderation.ts",
+    builderFunctions: ["handleModeration"],
+    typesFile: null,
+  },
+  transcription: {
+    provider: "Transcription",
+    builderFile: "src/transcription.ts",
+    builderFunctions: ["handleTranscription", "extractFormField", "extractBoundary"],
+    typesFile: null,
+  },
+  "vertex-ai": {
+    provider: "Vertex AI",
+    builderFile: "src/gemini.ts",
+    builderFunctions: [
+      "handleGemini",
+      "buildGeminiTextResponse",
+      "buildGeminiToolCallResponse",
+      "buildGeminiTextStreamChunks",
+      "buildGeminiToolCallStreamChunks",
+    ],
+    typesFile: null,
+  },
+};
+
+/**
+ * Every slug the emitter (`schema.ts` call sites) may pass. Exported so the
+ * registry-coverage test can assert each is a key of `SURFACE_REGISTRY` — a new
+ * surface either has an entry or fails the drift run loudly (belt-and-braces
+ * with the collector's runtime throw on an unknown marker slug).
+ */
+export const KNOWN_SURFACE_SLUGS: readonly string[] = Object.keys(SURFACE_REGISTRY);
+
+/** True when `slug` is a registered surface. */
+export function isKnownSurface(slug: string): slug is keyof typeof SURFACE_REGISTRY {
+  return Object.prototype.hasOwnProperty.call(SURFACE_REGISTRY, slug);
+}

--- a/src/__tests__/drift/transcription.drift.ts
+++ b/src/__tests__/drift/transcription.drift.ts
@@ -117,7 +117,7 @@ describe("Transcription API shape validation", () => {
     const mockShape = extractShape(mockRes.body);
     // Two-way comparison: SDK vs mock (no real API call needed)
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Transcription basic JSON", diffs);
+    const report = formatDriftReport("Transcription basic JSON", diffs, "transcription");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -145,7 +145,7 @@ describe("Transcription API shape validation", () => {
 
     const mockShape = extractShape(body);
     const diffs = triangulate(sdkShape, sdkShape, mockShape);
-    const report = formatDriftReport("Transcription verbose JSON", diffs);
+    const report = formatDriftReport("Transcription verbose JSON", diffs, "transcription");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -302,7 +302,7 @@ describe.skipIf(!OPENAI_API_KEY)("Transcription drift (three-way)", () => {
       const mockShape = extractShape(mockRes.body);
 
       const diffs = triangulate(sdkShape, realShape, mockShape);
-      const report = formatDriftReport("Transcription basic (three-way)", diffs);
+      const report = formatDriftReport("Transcription basic (three-way)", diffs, "transcription");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -327,7 +327,7 @@ describe.skipIf(!OPENAI_API_KEY)("Transcription drift (three-way)", () => {
       const mockShape = extractShape(mockRes.body);
 
       const diffs = triangulate(sdkShape, realShape, mockShape);
-      const report = formatDriftReport("Transcription verbose (three-way)", diffs);
+      const report = formatDriftReport("Transcription verbose (three-way)", diffs, "transcription");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/vertex-ai.drift.ts
+++ b/src/__tests__/drift/vertex-ai.drift.ts
@@ -91,7 +91,7 @@ describe.skipIf(!HAS_CREDENTIALS)("Vertex AI drift", () => {
     if (mockRes.status === 200) {
       const mockShape = extractShape(JSON.parse(mockRes.body));
       const diffs = triangulate(sdkShape, sdkShape, mockShape);
-      const report = formatDriftReport("Vertex AI generateContent", diffs);
+      const report = formatDriftReport("Vertex AI generateContent", diffs, "vertex-ai");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -156,7 +156,11 @@ describe.skipIf(!HAS_CREDENTIALS)("Vertex AI drift", () => {
       const lastChunk = chunks[chunks.length - 1];
       const lastShape = extractShape(lastChunk);
       const diffs = triangulate(sdkChunkShape, sdkChunkShape, lastShape);
-      const report = formatDriftReport("Vertex AI streamGenerateContent (last chunk)", diffs);
+      const report = formatDriftReport(
+        "Vertex AI streamGenerateContent (last chunk)",
+        diffs,
+        "vertex-ai",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/video.drift.ts
+++ b/src/__tests__/drift/video.drift.ts
@@ -127,7 +127,7 @@ describe("Video API drift", () => {
       expect(res.status).toBe(200);
       const mockShape = extractShape(JSON.parse(res.body));
       const diffs = compareShapes(expected, mockShape);
-      const report = formatDriftReport("Video create (completed)", diffs);
+      const report = formatDriftReport("Video create (completed)", diffs, "video");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -147,7 +147,7 @@ describe("Video API drift", () => {
       const body = JSON.parse(res.body);
       const mockShape = extractShape(body);
       const diffs = compareShapes(expected, mockShape);
-      const report = formatDriftReport("Video create (processing)", diffs);
+      const report = formatDriftReport("Video create (processing)", diffs, "video");
 
       // Processing response must NOT include url
       expect(body.url).toBeUndefined();
@@ -173,7 +173,7 @@ describe("Video API drift", () => {
       expect(res.status).toBe(200);
       const mockShape = extractShape(JSON.parse(res.body));
       const diffs = compareShapes(expected, mockShape);
-      const report = formatDriftReport("Video status (completed)", diffs);
+      const report = formatDriftReport("Video status (completed)", diffs, "video");
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -195,7 +195,7 @@ describe("Video API drift", () => {
       const body = JSON.parse(res.body);
       const mockShape = extractShape(body);
       const diffs = compareShapes(expected, mockShape);
-      const report = formatDriftReport("Video status (processing)", diffs);
+      const report = formatDriftReport("Video status (processing)", diffs, "video");
 
       // Processing status must NOT include url
       expect(body.url).toBeUndefined();

--- a/src/__tests__/drift/ws-gemini-live.drift.ts
+++ b/src/__tests__/drift/ws-gemini-live.drift.ts
@@ -141,7 +141,7 @@ describe.skipIf(!GOOGLE_API_KEY)("Gemini Live WS drift", () => {
     expect(mockEvents.length, "Mock returned no WS messages").toBeGreaterThan(0);
 
     const diffs = compareSSESequences(sdkEvents, realResult.events, mockEvents);
-    const report = formatDriftReport("Gemini Live WS (text events)", diffs);
+    const report = formatDriftReport("Gemini Live WS (text events)", diffs, "gemini-live");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -218,7 +218,7 @@ describe.skipIf(!GOOGLE_API_KEY)("Gemini Live WS drift", () => {
     expect(mockEvents.length, "Mock returned no WS messages").toBeGreaterThan(0);
 
     const diffs = compareSSESequences(sdkEvents, realResult.events, mockEvents);
-    const report = formatDriftReport("Gemini Live WS (tool call events)", diffs);
+    const report = formatDriftReport("Gemini Live WS (tool call events)", diffs, "gemini-live");
 
     expect(
       diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/ws-realtime.drift.ts
+++ b/src/__tests__/drift/ws-realtime.drift.ts
@@ -182,7 +182,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Realtime API drift", () => {
       expect(mockEvents.length, "Mock returned no WS messages").toBeGreaterThan(0);
 
       const diffs = compareSSESequences(sdkEvents, realResult.events, mockEvents);
-      const report = formatDriftReport("OpenAI Realtime WS (GA text events)", diffs);
+      const report = formatDriftReport(
+        "OpenAI Realtime WS (GA text events)",
+        diffs,
+        "openai-realtime",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),
@@ -279,7 +283,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Realtime API drift", () => {
       expect(mockEvents.length, "Mock returned no WS messages").toBeGreaterThan(0);
 
       const diffs = compareSSESequences(sdkEvents, realResult.events, mockEvents);
-      const report = formatDriftReport("OpenAI Realtime WS (GA tool call events)", diffs);
+      const report = formatDriftReport(
+        "OpenAI Realtime WS (GA tool call events)",
+        diffs,
+        "openai-realtime",
+      );
 
       expect(
         diffs.filter((d) => d.severity === "critical"),

--- a/src/__tests__/drift/ws-responses.drift.ts
+++ b/src/__tests__/drift/ws-responses.drift.ts
@@ -63,7 +63,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Responses WS drift", () => {
     expect(mockResult.events.length, "Mock returned no WS messages").toBeGreaterThan(0);
 
     const diffs = compareSSESequences(sdkEvents, realResult.events, mockResult.events);
-    const report = formatDriftReport("OpenAI Responses WS (text events)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Responses WS (text events)",
+      diffs,
+      "openai-responses-ws",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),
@@ -119,7 +123,11 @@ describe.skipIf(!OPENAI_API_KEY)("OpenAI Responses WS drift", () => {
     expect(mockResult.events.length, "Mock returned no WS messages").toBeGreaterThan(0);
 
     const diffs = compareSSESequences(sdkEvents, realResult.events, mockResult.events);
-    const report = formatDriftReport("OpenAI Responses WS (tool call events)", diffs);
+    const report = formatDriftReport(
+      "OpenAI Responses WS (tool call events)",
+      diffs,
+      "openai-responses-ws",
+    );
 
     expect(
       diffs.filter((d) => d.severity === "critical"),


### PR DESCRIPTION
## The hole

`extractProviderName` matched drift-block titles against ~9 hardcoded
`PROVIDER_MAP` keys via `text.includes()`. ~15 additional provider surfaces
(Cohere, Bedrock, Ollama, fal, ElevenLabs, images, video, moderation,
transcription, rerank, vertex-ai, ...) emit valid, fully-parseable
`API DRIFT DETECTED:` blocks whose PROSE titles are not keys → `extractProviderName`
returns null → the block is **quarantined** (exit 5) → `fix-drift.yml` gates
auto-remediation on exit **2** only, so those surfaces were **never auto-fixed**
(mislabeled "manual triage"). `models.drift.ts` is left as-is (deliberate
PROVIDER_MAP-matching canaries).

## The design — structural keying via a single-source-of-truth registry

- **`SURFACE_REGISTRY`** (`src/__tests__/drift/surface-registry.ts`), slug-keyed,
  imported by BOTH `schema.ts` (validate a slug at emit time) and the collector
  (resolve slug → builderFile/builderFunctions). One table, two consumers —
  adding a surface is a single edit both see.
- **`formatDriftReport(context, diffs, surface?)`** emits a machine-readable
  `Surface: <slug>` marker line. An unknown slug **throws at emit time**.
- **Collector resolution:**
  - marker present + known slug → **exit-2 entry (auto-fixable)** — the fix.
  - marker present + **UNKNOWN slug → THROW (loud, exit 1)**, never silent
    quarantine — a future unkeyed surface fails loudly instead of silently
    routing to manual triage.
  - no-marker legacy block → today's provider-label fallback (exit 5 only for
    truly un-attributable output).
- Every currently-unmapped `*.drift.ts` emitter now passes its slug;
  `builderFunctions` filled from the **real source exports** (not invented).
  Bedrock is split per the spec: `bedrock-invoke`/`bedrock-invoke-stream` →
  `bedrock.ts`, `bedrock-converse`/`bedrock-converse-stream` →
  `bedrock-converse.ts`. Vertex AI keys onto the Gemini path (`gemini.ts`).
- A **registry-coverage test** asserts every entry resolves to an existing
  `builderFile` with non-empty `builderFunctions` (mirrors `fix-drift.ts`
  validation, so a bad entry fails locally, not in CI).

## Base-report reuse fix (own commit — efficiency, not safety)

The collector wrote only `{ timestamp, entries, quarantine? }`, but the reuse
guard reads `report.generatedAt` + `report.conclusion`, so reuse **always
failed** and every PR ran a fresh ~30-min live base. The collector now writes
`generatedAt` (ISO alias of `timestamp`, kept for back-compat) and `conclusion`
(derived from the exit code: 0→clean, 2→critical, 5→quarantine).

## Red-green (fixtures only, no live SDK)

**RED (original code)** — a Cohere/fal/ElevenLabs drift block routes to
`quarantine` (len 1, exit 5), never an entry:

```
× "Cohere /v2/chat (non-streaming)" → exit-2 auto-fix entry (EXPECTED to FAIL)
  → expected [ { …(4) } ] to have a length of +0 but got 1
× "fal.ai sync-run (image payload)" → exit-2 auto-fix entry (EXPECTED to FAIL)
  → expected [ { …(4) } ] to have a length of +0 but got 1
× "ElevenLabs /v1/sound-generation 400 error" → exit-2 auto-fix entry (EXPECTED to FAIL)
  → expected [ { …(4) } ] to have a length of +0 but got 1
Tests  3 failed (3)
```

**GREEN (new code, with the `Surface:` marker)** — all three route to an
exit-2 entry, `quarantine` empty:

```
✓ src/__tests__/ws5-red-proof.test.ts (3 tests) 3ms
Tests  3 passed (3)
```

Surfaces flipped **5 → 2**: `cohere-chat`, `fal-sync`, `elevenlabs` (plus every
other previously-unmapped surface: rerank, bedrock-*, ollama, images, video,
moderation, transcription, vertex-ai, fal-queue).

Additional in-suite coverage: unknown-slug marker **throws** (not quarantine);
`isBaseReportReusable` accepts a written clean report; registry-coverage test.
Full suite: **4637 passed**. `format:check`, `lint`, `tsc` (both tsconfigs),
`build`, `commitlint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)