### PR TITLE
fix(drift): classify full live /models family wave + durable preview-exclude rule

### DIFF
--- a/src/__tests__/drift/model-registry.test.ts
+++ b/src/__tests__/drift/model-registry.test.ts
@@ -32,6 +32,7 @@ import {
   NON_MODEL_TOKENS,
   isClassifiedFamily,
   PREVIEW_FAMILY,
+  GEMMA_FAMILY,
 } from "./model-registry.js";
 
 // ─── Part 1: registry shape invariants ───────────────────────────────────────
@@ -87,15 +88,16 @@ describe("isClassifiedFamily / PREVIEW_FAMILY", () => {
     expect(isClassifiedFamily("deep-research-pro-preview-12", "gemini")).toBe(true);
   });
 
-  it("INCLUDE WINS: an included family ending in -preview is classified as included", () => {
-    const included = normalizeModelFamily("gemini-x-chat-preview", "gemini");
-    includeFamilies.gemini.add(included);
-    try {
-      expect(isClassifiedFamily(included, "gemini")).toBe(true);
-      expect(includeFamilies.gemini.has(included)).toBe(true);
-    } finally {
-      includeFamilies.gemini.delete(included);
-    }
+  it("classifies a future Gemma variant by rule (no literal registry entry)", () => {
+    // A synthetic future Gemma id normalizes to itself (no numeric-only build
+    // tag to strip) and is on NEITHER include nor exclude — it is classified
+    // purely by the GEMMA_FAMILY rule. Red against the old literal-names-only
+    // exclude set; green with the pattern.
+    const family = normalizeModelFamily("gemma-9-foo", "gemini");
+    expect(includeFamilies.gemini.has(family)).toBe(false);
+    expect(excludeFamilies.gemini.has(family)).toBe(false);
+    expect(GEMMA_FAMILY.test(family)).toBe(true);
+    expect(isClassifiedFamily(family, "gemini")).toBe(true);
   });
 
   it("does NOT match interior -preview-<word> suffixes (stay enumerated)", () => {
@@ -199,11 +201,11 @@ describe("§6.1c builder/fixture cross-check (no live keys)", () => {
     for (const { id, provider } of BUILDER_FIXTURE_MODEL_IDS) {
       const family = normalizeModelFamily(id, provider);
       // Use the SAME classification predicate the live drift check uses
-      // (include ∪ exclude ∪ the PREVIEW_FAMILY rule, include-wins) so the two
-      // classification surfaces cannot drift apart.
+      // (include ∪ exclude ∪ the PREVIEW_FAMILY / GEMMA_FAMILY exclude-by-rule
+      // patterns) so the two classification surfaces cannot drift apart.
       if (!isClassifiedFamily(family, provider)) {
         failures.push(
-          `${id} (${provider}): normalized to "${family}" which is classified by NEITHER includeFamilies, excludeFamilies, NOR the preview rule`,
+          `${id} (${provider}): normalized to "${family}" which is classified by NEITHER includeFamilies, excludeFamilies, NOR the preview/gemma rules`,
         );
       }
     }

--- a/src/__tests__/drift/model-registry.test.ts
+++ b/src/__tests__/drift/model-registry.test.ts
@@ -26,7 +26,13 @@
  */
 import { describe, it, expect } from "vitest";
 import { normalizeModelFamily } from "./model-family.js";
-import { includeFamilies, excludeFamilies, NON_MODEL_TOKENS } from "./model-registry.js";
+import {
+  includeFamilies,
+  excludeFamilies,
+  NON_MODEL_TOKENS,
+  isClassifiedFamily,
+  PREVIEW_FAMILY,
+} from "./model-registry.js";
 
 // ─── Part 1: registry shape invariants ───────────────────────────────────────
 
@@ -62,6 +68,44 @@ describe("model-registry", () => {
         expect(normalizeModelFamily(family, provider)).toBe(family);
       }
     }
+  });
+});
+
+// ─── PREVIEW_FAMILY exclude-by-rule predicate ────────────────────────────────
+
+describe("isClassifiedFamily / PREVIEW_FAMILY", () => {
+  it("classifies a brand-new -preview family by rule (no registry entry)", () => {
+    const family = normalizeModelFamily("gemini-9-pro-preview", "gemini");
+    expect(includeFamilies.gemini.has(family)).toBe(false);
+    expect(excludeFamilies.gemini.has(family)).toBe(false);
+    expect(PREVIEW_FAMILY.test(family)).toBe(true);
+    expect(isClassifiedFamily(family, "gemini")).toBe(true);
+  });
+
+  it("matches a trailing short numeric preview build tag (-preview-NN)", () => {
+    expect(PREVIEW_FAMILY.test("antigravity-preview-05")).toBe(true);
+    expect(isClassifiedFamily("deep-research-pro-preview-12", "gemini")).toBe(true);
+  });
+
+  it("INCLUDE WINS: an included family ending in -preview is classified as included", () => {
+    const included = normalizeModelFamily("gemini-x-chat-preview", "gemini");
+    includeFamilies.gemini.add(included);
+    try {
+      expect(isClassifiedFamily(included, "gemini")).toBe(true);
+      expect(includeFamilies.gemini.has(included)).toBe(true);
+    } finally {
+      includeFamilies.gemini.delete(included);
+    }
+  });
+
+  it("does NOT match interior -preview-<word> suffixes (stay enumerated)", () => {
+    expect(PREVIEW_FAMILY.test("gemini-2.5-flash-preview-tts")).toBe(false);
+    expect(PREVIEW_FAMILY.test("gemini-3.1-pro-preview-customtools")).toBe(false);
+    // Those two ARE classified — but via explicit excludeFamilies enumeration.
+    expect(isClassifiedFamily("gemini-2.5-flash-preview-tts", "gemini")).toBe(true);
+    expect(isClassifiedFamily("gemini-3.1-pro-preview-customtools", "gemini")).toBe(true);
+    // A NON-enumerated interior-suffix family stays unclassified (still drift).
+    expect(isClassifiedFamily("gemini-x-flash-preview-widgets", "gemini")).toBe(false);
   });
 });
 
@@ -154,12 +198,12 @@ describe("§6.1c builder/fixture cross-check (no live keys)", () => {
 
     for (const { id, provider } of BUILDER_FIXTURE_MODEL_IDS) {
       const family = normalizeModelFamily(id, provider);
-      const inInclude = includeFamilies[provider].has(family);
-      const inExclude = excludeFamilies[provider].has(family);
-
-      if (!inInclude && !inExclude) {
+      // Use the SAME classification predicate the live drift check uses
+      // (include ∪ exclude ∪ the PREVIEW_FAMILY rule, include-wins) so the two
+      // classification surfaces cannot drift apart.
+      if (!isClassifiedFamily(family, provider)) {
         failures.push(
-          `${id} (${provider}): normalized to "${family}" which is in NEITHER includeFamilies NOR excludeFamilies`,
+          `${id} (${provider}): normalized to "${family}" which is classified by NEITHER includeFamilies, excludeFamilies, NOR the preview rule`,
         );
       }
     }

--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -71,6 +71,41 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     "gpt-4.1-nano",
     "gpt-5",
     "gpt-5-mini",
+    // gpt-5 tier: additional sizes + chat surfaces
+    "gpt-5-nano",
+    "gpt-5-pro",
+    "gpt-5-chat-latest",
+    // gpt-5.x point releases (text chat)
+    "gpt-5.1",
+    "gpt-5.1-chat-latest",
+    "gpt-5.2",
+    "gpt-5.2-pro",
+    "gpt-5.2-chat-latest",
+    "gpt-5.3-chat-latest",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
+    "gpt-5.4-pro",
+    "gpt-5.5",
+    "gpt-5.5-pro",
+    // gpt-5.6 named variants (text chat)
+    "gpt-5.6-luna",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    // Codex line (coding chat; text output)
+    "gpt-5-codex",
+    "gpt-5.1-codex",
+    "gpt-5.1-codex-max",
+    "gpt-5.1-codex-mini",
+    "gpt-5.2-codex",
+    "gpt-5.3-codex",
+    // o-series reasoning (text)
+    "o1",
+    "o1-pro",
+    "o3",
+    "o3-mini",
+    "o3-pro",
+    "o4-mini",
   ]),
   anthropic: familySet("anthropic", [
     // Claude 3 / 3.5 / 3.7 families
@@ -84,6 +119,18 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     "claude-opus-4",
     "claude-sonnet-4",
     "claude-haiku-4",
+    // Claude 4.x point releases (text chat)
+    "claude-haiku-4-5",
+    "claude-opus-4-1",
+    "claude-opus-4-5",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
+    // Claude 5 families (text chat)
+    "claude-sonnet-5",
+    "claude-fable-5",
   ]),
   gemini: familySet("gemini", [
     // Gemini 1.5 / 2.0 / 2.5 text families
@@ -92,6 +139,11 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     "gemini-2.0-flash",
     "gemini-2.5-flash",
     "gemini-2.5-pro",
+    // Additional stable flash/pro tiers (text)
+    "gemini-2.0-flash-lite",
+    "gemini-2.5-flash-lite",
+    "gemini-3.1-flash-lite",
+    "gemini-3.5-flash",
   ]),
 };
 
@@ -103,9 +155,13 @@ export const includeFamilies: Record<Provider, Set<string>> = {
  */
 export const excludeFamilies: Record<Provider, Set<string>> = {
   openai: familySet("openai", [
-    // Retired / legacy chat
+    // Retired / legacy chat + base-completion
     "gpt-3",
     "gpt-3.5",
+    "gpt-3.5-turbo-16k",
+    "gpt-3.5-turbo-instruct",
+    "babbage",
+    "davinci",
     // Embeddings (non-text-generation)
     "text-embedding-3-small",
     "text-embedding-3-large",
@@ -114,6 +170,21 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     "dall-e-2",
     "dall-e-3",
     "gpt-image-1",
+    "gpt-image-1-mini",
+    "gpt-image-1.5",
+    "gpt-image-2",
+    "chatgpt-image-latest",
+    // Video generation (non-text)
+    "sora-2",
+    "sora-2-pro",
+    // Moderation classifier (non-text-generation)
+    "omni-moderation",
+    "omni-moderation-latest",
+    // Deep-research / search specialty surfaces (text output, not plain chat).
+    // Enumerated because they carry no trailing `-preview` (see PREVIEW_FAMILY).
+    "o3-deep-research",
+    "o4-mini-deep-research",
+    "gpt-5-search-api",
     // Voice / audio / tts / transcribe — owned by the realtime canary
     "tts-1",
     "tts-1-hd",
@@ -133,9 +204,10 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     "gpt-realtime-1.5",
     "gpt-realtime-translate",
     "gpt-realtime-whisper",
-    // Preview-only realtime
-    "gpt-4o-realtime-preview",
-    "gpt-4o-mini-realtime-preview",
+    // NOTE: `-preview` families (gpt-4o-realtime-preview,
+    // gpt-4o-mini-realtime-preview, gpt-4o-search-preview,
+    // gpt-4o-mini-search-preview, computer-use-preview, …) are auto-excluded by
+    // the PREVIEW_FAMILY rule (see isClassifiedFamily below) — no enumeration.
   ]),
   anthropic: familySet("anthropic", [
     // Retired / legacy Claude ids
@@ -144,15 +216,46 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     "claude-instant-1",
   ]),
   gemini: familySet("gemini", [
-    // Retired / legacy
+    // Retired / legacy specialty
     "gemini-pro",
+    "aqa",
     // Embeddings (non-text-generation)
     "text-embedding-004",
-    // Experimental / preview / thinking-preview
+    "gemini-embedding",
+    "gemini-embedding-2",
+    // Image models (non-text)
+    "gemini-2.5-flash-image",
+    "gemini-3-pro-image",
+    "gemini-3.1-flash-image",
+    "gemini-3.1-flash-lite-image",
+    "imagen-4.0-fast-generate",
+    "imagen-4.0-generate",
+    "imagen-4.0-ultra-generate",
+    // Audio / native-audio (realtime canary domain)
+    "gemini-2.5-flash-native-audio-latest",
+    // Open-weight Gemma line — aimock does NOT mock Gemma (no code/fixtures);
+    // it only rides the shared Gemini /models listing. Exclude, not include.
+    "gemma-4-26b-a4b-it",
+    "gemma-4-31b-it",
+    // Moving aliases (not families aimock commits to as stable text surfaces)
+    "gemini-flash-latest",
+    "gemini-flash-lite-latest",
+    "gemini-pro-latest",
+    // Interior `-preview-<word>` specialty suffixes the PREVIEW_FAMILY rule does
+    // NOT match (it only matches trailing `-preview` / `-preview-<digits>`).
+    // Enumerated so their category (tts / custom-tools) stays documented.
+    "gemini-2.5-flash-preview-tts",
+    "gemini-2.5-pro-preview-tts",
+    "gemini-3.1-pro-preview-customtools",
+    // Experimental / thinking (kept explicit — historic `-exp`, not `-preview`)
     "gemini-2.0-flash-exp",
     "gemini-2.0-flash-thinking-exp",
     // Live/full-duplex voice — owned by the realtime canary, not this text check
     "gemini-live",
+    // NOTE: every `-preview` family (gemini-3.x preview tiers, deep-research
+    // previews, antigravity-preview-05, computer-use-preview-10, image/tts/robotics
+    // previews, lyria/veo/nano-banana previews, gemini-embedding-2-preview, …) is
+    // auto-excluded by the PREVIEW_FAMILY rule (see isClassifiedFamily below).
   ]),
 };
 
@@ -163,3 +266,49 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
  * cross-check exclude the exact same tokens (never false-positive drift).
  */
 export const NON_MODEL_TOKENS: Set<string> = new Set(["gemini-interactions"]);
+
+/**
+ * Durable EXCLUDE-BY-RULE predicate for preview/experimental families.
+ *
+ * Preview tiers (`gemini-3-pro-preview`, `gpt-4o-search-preview`,
+ * `antigravity-preview-05`, …) are unstable and short-lived: providers ship a
+ * new one on nearly every release wave, and each one that lands would otherwise
+ * re-fire the daily drift canary as a brand-new UNCLASSIFIED family, forcing a
+ * registry edit per preview forever (that is exactly how the Gemini-3.x wave
+ * surfaced — the exclude set was a hand-maintained list with no preview rule).
+ * A pattern rule auto-excludes every current AND future `-preview` family with
+ * zero registry churn, and re-alerting on each new preview tier is precisely the
+ * whack-a-mole this hardening removes.
+ *
+ * The pattern intentionally matches ONLY a trailing `-preview` token, optionally
+ * followed by a short numeric build tag the normalizer does not strip
+ * (`-preview-04`, `-preview-05`, `-preview-10`, `-preview-12` — 2-digit, below
+ * `BUILD_TAG_SUFFIX`'s 3-4 digit floor). It deliberately does NOT match interior
+ * `-preview-<word>` suffixes like `-preview-tts` / `-preview-customtools`; those
+ * are non-text specialty surfaces enumerated explicitly in `excludeFamilies` so
+ * their category (tts / custom-tools) stays documented rather than swept under a
+ * blanket rule.
+ *
+ * IMPORTANT — this lives at the CLASSIFICATION layer, NOT the normalizer. The
+ * normalizer is left untouched so preview family keys stay DISTINCT: a genuinely
+ * new preview family is still visible as its own key (never collapsed onto its GA
+ * sibling), which preserves the canary's ability to surface new families while
+ * making previews self-excluding.
+ */
+export const PREVIEW_FAMILY = /-preview(-\d+)?$/;
+
+/**
+ * A NORMALIZED family key is already classified if it is in `include ∪ exclude`,
+ * OR it matches the preview-exclude rule — with INCLUDE WINS: a family explicitly
+ * listed in `includeFamilies` is included even if it ends in `-preview`, so aimock
+ * can opt a preview surface back in (e.g. if it ever mocks a gemini-3 chat
+ * preview) without fighting the rule. Both the live drift check
+ * (`unclassifiedFamilies`) and the builder/fixture cross-check use this single
+ * predicate so their classification surfaces cannot drift apart.
+ */
+export function isClassifiedFamily(family: string, provider: Provider): boolean {
+  if (includeFamilies[provider].has(family)) return true; // include wins
+  if (excludeFamilies[provider].has(family)) return true;
+  if (PREVIEW_FAMILY.test(family)) return true; // exclude-by-rule
+  return false;
+}

--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -130,6 +130,8 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     "claude-sonnet-4-6",
     // Claude 5 families (text chat)
     "claude-sonnet-5",
+    // claude-fable-5 is included ahead of a recorded fixture (intended — mirrors
+    // the forward-looking rationale for the exclude-by-rule patterns above).
     "claude-fable-5",
   ]),
   gemini: familySet("gemini", [
@@ -233,10 +235,11 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     "imagen-4.0-ultra-generate",
     // Audio / native-audio (realtime canary domain)
     "gemini-2.5-flash-native-audio-latest",
-    // Open-weight Gemma line — aimock does NOT mock Gemma (no code/fixtures);
-    // it only rides the shared Gemini /models listing. Exclude, not include.
-    "gemma-4-26b-a4b-it",
-    "gemma-4-31b-it",
+    // NOTE: the open-weight Gemma line (`gemma-4-26b-a4b-it`, `gemma-4-31b-it`,
+    // and any future variant) is auto-excluded by the GEMMA_FAMILY rule (see
+    // isClassifiedFamily below) — no enumeration. Gemma is open-weight, not
+    // mocked on the Gemini surface, so it is out of scope; reversible by future
+    // explicit handling if a Gemma fixture is ever added.
     // Moving aliases (not families aimock commits to as stable text surfaces)
     "gemini-flash-latest",
     "gemini-flash-lite-latest",
@@ -282,12 +285,23 @@ export const NON_MODEL_TOKENS: Set<string> = new Set(["gemini-interactions"]);
  *
  * The pattern intentionally matches ONLY a trailing `-preview` token, optionally
  * followed by a short numeric build tag the normalizer does not strip
- * (`-preview-04`, `-preview-05`, `-preview-10`, `-preview-12` — 2-digit, below
- * `BUILD_TAG_SUFFIX`'s 3-4 digit floor). It deliberately does NOT match interior
+ * (`-preview-04`, `-preview-05`, `-preview-10`, `-preview-12`). The `-\d+` tail
+ * is unbounded on purpose — a 1-2 digit build tag survives the normalizer
+ * (`BUILD_TAG_SUFFIX` only strips 3-4 digit tails), and a longer numeric tail on
+ * a `-preview` token is still unambiguously a preview surface, so there is no
+ * upper bound to enforce. It deliberately does NOT match interior
  * `-preview-<word>` suffixes like `-preview-tts` / `-preview-customtools`; those
  * are non-text specialty surfaces enumerated explicitly in `excludeFamilies` so
  * their category (tts / custom-tools) stays documented rather than swept under a
  * blanket rule.
+ *
+ * TRADEOFF — previews are BLANKET-excluded until GA, per policy. This
+ * intentionally SILENCES the canary on new text previews (e.g. `o1-preview`,
+ * `gpt-4.5-preview`, a `gemini-3` chat preview) until they drop the `-preview`
+ * suffix and go GA. There is no include-side escape hatch: aimock does not mock
+ * preview surfaces, so re-alerting on each new preview tier is precisely the
+ * whack-a-mole this rule removes. If aimock ever needs to mock a specific
+ * preview surface, add explicit handling then.
  *
  * IMPORTANT — this lives at the CLASSIFICATION layer, NOT the normalizer. The
  * normalizer is left untouched so preview family keys stay DISTINCT: a genuinely
@@ -298,17 +312,32 @@ export const NON_MODEL_TOKENS: Set<string> = new Set(["gemini-interactions"]);
 export const PREVIEW_FAMILY = /-preview(-\d+)?$/;
 
 /**
+ * Durable EXCLUDE-BY-RULE predicate for the open-weight Gemma line.
+ *
+ * Gemma is open-weight and NOT mocked on aimock's Gemini surface (no code /
+ * fixtures); it only rides the shared Gemini `/models` listing. Every current
+ * AND future Gemma variant (`gemma-4-26b-a4b-it`, `gemma-4-31b-it`, …) is
+ * out of scope, so a pattern rule auto-excludes them with zero registry churn —
+ * mirroring the PREVIEW_FAMILY rationale. Reversible by future explicit handling
+ * if a Gemma fixture is ever added.
+ */
+export const GEMMA_FAMILY = /^gemma(-|$)/;
+
+/**
  * A NORMALIZED family key is already classified if it is in `include ∪ exclude`,
- * OR it matches the preview-exclude rule — with INCLUDE WINS: a family explicitly
- * listed in `includeFamilies` is included even if it ends in `-preview`, so aimock
- * can opt a preview surface back in (e.g. if it ever mocks a gemini-3 chat
- * preview) without fighting the rule. Both the live drift check
- * (`unclassifiedFamilies`) and the builder/fixture cross-check use this single
- * predicate so their classification surfaces cannot drift apart.
+ * OR it matches an exclude-by-rule pattern (preview, gemma). Both the live drift
+ * check (`unclassifiedFamilies`) and the builder/fixture cross-check use this
+ * single predicate so their classification surfaces cannot drift apart.
+ *
+ * There is deliberately NO include-side escape hatch: previews and Gemma are
+ * blanket-excluded (aimock does not mock either surface), so an include entry
+ * could never legitimately collide with an exclude rule. The intersection
+ * `include ∩ (preview ∪ gemma)` is empty by construction.
  */
 export function isClassifiedFamily(family: string, provider: Provider): boolean {
-  if (includeFamilies[provider].has(family)) return true; // include wins
+  if (includeFamilies[provider].has(family)) return true;
   if (excludeFamilies[provider].has(family)) return true;
   if (PREVIEW_FAMILY.test(family)) return true; // exclude-by-rule
+  if (GEMMA_FAMILY.test(family)) return true; // exclude-by-rule
   return false;
 }

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -29,26 +29,27 @@
 import { describe, it, expect } from "vitest";
 import { listOpenAIModels, listAnthropicModels, listGeminiModels } from "./providers.js";
 import { normalizeModelFamily } from "./model-family.js";
-import { includeFamilies, excludeFamilies, NON_MODEL_TOKENS } from "./model-registry.js";
+import { includeFamilies, NON_MODEL_TOKENS, isClassifiedFamily } from "./model-registry.js";
 import { formatDriftReport } from "./schema.js";
 
 type Provider = "openai" | "anthropic" | "gemini";
 
 /**
  * Reduce a live `/models` list to the UNCLASSIFIED families: normalize each id,
- * then drop everything already in `include ∪ exclude` or on the non-model
- * allowlist. The returned list (sorted, de-duplicated) is the drift signal.
+ * then drop everything already classified (`include ∪ exclude`, the
+ * preview-exclude rule — see `isClassifiedFamily` in model-registry.ts) or on
+ * the non-model allowlist. The returned list (sorted, de-duplicated) is the
+ * drift signal.
  *
  * Exported so the co-located regression suite can exercise the EXACT
  * enumerate→normalize→subtract pipeline the live check relies on, with an
  * injected payload — no reimplementation.
  */
 export function unclassifiedFamilies(modelIds: string[], provider: Provider): string[] {
-  const known = new Set<string>([...includeFamilies[provider], ...excludeFamilies[provider]]);
   const unclassified = new Set<string>();
   for (const id of modelIds) {
     const family = normalizeModelFamily(id, provider);
-    if (known.has(family)) continue;
+    if (isClassifiedFamily(family, provider)) continue;
     if (NON_MODEL_TOKENS.has(family) || NON_MODEL_TOKENS.has(id)) continue;
     unclassified.add(family);
   }
@@ -141,6 +142,219 @@ describe("model-family pipeline (injected /models)", () => {
     expect(unclassifiedFamilies(["gpt-live"], "openai")).toEqual(["gpt-live"]);
     // Single-digit trailing suffix is NOT a build tag, so it stays unknown.
     expect(unclassifiedFamilies(["gpt-live-1"], "openai")).toEqual(["gpt-live-1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PREVIEW_FAMILY exclude-by-rule predicate (the durable hardening).
+// ---------------------------------------------------------------------------
+
+describe("preview families are excluded by rule", () => {
+  it("a brand-new -preview family auto-excludes with zero registry edits", () => {
+    // Not in include or exclude — classified purely by the trailing-preview rule.
+    expect(unclassifiedFamilies(["gemini-9-pro-preview"], "gemini")).toEqual([]);
+    expect(unclassifiedFamilies(["gpt-9-search-preview"], "openai")).toEqual([]);
+  });
+
+  it("matches a trailing short numeric preview build tag (-preview-NN)", () => {
+    // The normalizer leaves 2-digit tails intact, so the rule must cover them.
+    expect(unclassifiedFamilies(["antigravity-preview-05"], "gemini")).toEqual([]);
+    expect(unclassifiedFamilies(["deep-research-pro-preview-12"], "gemini")).toEqual([]);
+  });
+
+  it("INCLUDE WINS: a family explicitly on includeFamilies is included even if it ends in -preview", () => {
+    // Guard the opt-in escape hatch. `includeFamilies` membership short-circuits
+    // the preview rule, so this appears as classified (not drift) precisely
+    // because it is included — proving include-wins, not rule-exclude.
+    const provider = "gemini" as const;
+    const included = "gemini-x-chat-preview";
+    // Temporarily assert the semantics against a synthetic included family.
+    includeFamilies[provider].add(normalizeModelFamily(included, provider));
+    try {
+      expect(unclassifiedFamilies([included], provider)).toEqual([]);
+      expect(includeFamilies[provider].has(normalizeModelFamily(included, provider))).toBe(true);
+    } finally {
+      includeFamilies[provider].delete(normalizeModelFamily(included, provider));
+    }
+  });
+
+  it("does NOT match interior -preview-<word> suffixes (they stay enumerated)", () => {
+    // `-preview-tts` / `-preview-customtools` are non-text specialty surfaces
+    // enumerated explicitly; a hypothetical UNLISTED interior-suffix family must
+    // still fire as drift so its category is not silently swallowed.
+    expect(unclassifiedFamilies(["gemini-x-flash-preview-widgets"], "gemini")).toEqual([
+      "gemini-x-flash-preview-widgets",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: the FULL live /models family wave (run 29478043559, 2026-07-16).
+// These are the exact families the drift job flagged as UNCLASSIFIED (OpenAI 49
+// / Anthropic 10 / Gemini 44). This suite injects representative raw ids for
+// every one of them into the REAL enumerate→normalize→subtract pipeline and
+// asserts the registry now classifies all of them — zero drift. It exercises
+// the same `unclassifiedFamilies` surface the live canary uses, so it is a true
+// regression against the classification (not a fake against a private copy).
+// ---------------------------------------------------------------------------
+
+describe("full live /models wave is fully classified (2026-07-16 drift)", () => {
+  it("OpenAI: every live family is classified (zero unclassified)", () => {
+    const openaiLive = [
+      // Existing include families (dated snapshots collapse onto them)
+      "gpt-3.5-turbo",
+      "gpt-4",
+      "gpt-4-turbo",
+      "gpt-4o-2024-08-06",
+      "gpt-4o-mini",
+      "gpt-4.1",
+      "gpt-4.1-mini",
+      "gpt-4.1-nano",
+      "gpt-5",
+      "gpt-5-mini",
+      // Newly-classified INCLUDE: gpt-5.x tiers + chat surfaces
+      "gpt-5-chat-latest",
+      "gpt-5.1-chat-latest",
+      "gpt-5.2-chat-latest",
+      "gpt-5.3-chat-latest",
+      "gpt-5-nano",
+      "gpt-5-pro",
+      "gpt-5.1",
+      "gpt-5.2",
+      "gpt-5.2-pro",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.4-nano",
+      "gpt-5.4-pro",
+      "gpt-5.5",
+      "gpt-5.5-pro",
+      "gpt-5.6-luna",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      // o-series reasoning
+      "o1",
+      "o1-pro",
+      "o3",
+      "o3-mini",
+      "o3-pro",
+      "o4-mini",
+      // Codex line
+      "gpt-5-codex",
+      "gpt-5.1-codex",
+      "gpt-5.1-codex-max",
+      "gpt-5.1-codex-mini",
+      "gpt-5.2-codex",
+      "gpt-5.3-codex",
+      // Newly-classified EXCLUDE: retired base
+      "babbage-002",
+      "davinci-002",
+      "gpt-3.5-turbo-16k",
+      "gpt-3.5-turbo-instruct",
+      // deep-research / search / computer-use surfaces
+      "o3-deep-research",
+      "o4-mini-deep-research",
+      "gpt-5-search-api",
+      "gpt-4o-search-preview", // preview pattern
+      "gpt-4o-mini-search-preview", // preview pattern
+      "computer-use-preview", // preview pattern
+      // image / video / moderation
+      "chatgpt-image-latest",
+      "gpt-image-1-mini",
+      "gpt-image-1.5",
+      "gpt-image-2",
+      "sora-2",
+      "sora-2-pro",
+      "omni-moderation",
+      "omni-moderation-latest",
+    ];
+    expect(unclassifiedFamilies(openaiLive, "openai")).toEqual([]);
+  });
+
+  it("Anthropic: every live family is classified (zero unclassified)", () => {
+    const anthropicLive = [
+      // Existing include (dated snapshots collapse)
+      "claude-3-opus-20240229",
+      "claude-3-5-sonnet-20241022",
+      "claude-3-7-sonnet-20250219",
+      "claude-opus-4-20250514",
+      "claude-sonnet-4",
+      "claude-haiku-4",
+      // Newly-classified INCLUDE: 4.x/5 point releases + fable
+      "claude-haiku-4-5",
+      "claude-opus-4-1",
+      "claude-opus-4-5",
+      "claude-opus-4-6",
+      "claude-opus-4-7",
+      "claude-opus-4-8",
+      "claude-sonnet-4-5",
+      "claude-sonnet-4-6",
+      "claude-sonnet-5",
+      "claude-fable-5",
+    ];
+    expect(unclassifiedFamilies(anthropicLive, "anthropic")).toEqual([]);
+  });
+
+  it("Gemini: every live family is classified (zero unclassified)", () => {
+    const geminiLive = [
+      // Existing include
+      "gemini-1.5-pro",
+      "gemini-1.5-flash",
+      "gemini-2.0-flash",
+      "gemini-2.5-flash",
+      "gemini-2.5-pro",
+      // Newly-classified INCLUDE: stable flash/pro tiers
+      "gemini-2.0-flash-lite",
+      "gemini-2.5-flash-lite",
+      "gemini-3.1-flash-lite",
+      "gemini-3.5-flash",
+      // Preview text tiers — auto-excluded by the -preview pattern rule
+      "gemini-3-flash-preview",
+      "gemini-3-pro-preview",
+      "gemini-3.1-pro-preview",
+      "gemini-3.1-flash-lite-preview",
+      // Preview specialty surfaces (pattern OR explicit)
+      "gemini-3.1-pro-preview-customtools", // explicit exclude (not -preview$)
+      "antigravity-preview-05", // pattern
+      "aqa", // explicit exclude (retired specialty)
+      "deep-research-max-preview-04", // pattern
+      "deep-research-preview-04", // pattern
+      "deep-research-pro-preview-12", // pattern
+      "gemini-2.5-computer-use-preview-10", // pattern
+      "gemini-omni-flash-preview", // pattern
+      // image / audio / tts / video / music / robotics / embeddings
+      "gemini-2.5-flash-image",
+      "gemini-2.5-flash-native-audio-latest",
+      "gemini-2.5-flash-preview-tts", // explicit exclude (-preview-tts)
+      "gemini-2.5-pro-preview-tts", // explicit exclude (-preview-tts)
+      "gemini-3-pro-image",
+      "gemini-3-pro-image-preview", // pattern
+      "gemini-3.1-flash-image",
+      "gemini-3.1-flash-image-preview", // pattern
+      "gemini-3.1-flash-lite-image",
+      "gemini-3.1-flash-tts-preview", // pattern
+      "gemini-embedding",
+      "gemini-embedding-2",
+      "gemini-embedding-2-preview", // pattern
+      "gemini-robotics-er-1.5-preview", // pattern
+      "gemini-robotics-er-1.6-preview", // pattern
+      "imagen-4.0-fast-generate",
+      "imagen-4.0-generate",
+      "imagen-4.0-ultra-generate",
+      "lyria-3-clip-preview", // pattern
+      "lyria-3-pro-preview", // pattern
+      "nano-banana-pro-preview", // pattern
+      "veo-3.1-fast-generate-preview", // pattern
+      "veo-3.1-generate-preview", // pattern
+      "veo-3.1-lite-generate-preview", // pattern
+      // Gemma open-weight — aimock does NOT mock; explicit exclude
+      "gemma-4-26b-a4b-it",
+      "gemma-4-31b-it",
+      // Moving aliases
+      "gemini-flash-latest",
+      "gemini-flash-lite-latest",
+      "gemini-pro-latest",
+    ];
+    expect(unclassifiedFamilies(geminiLive, "gemini")).toEqual([]);
   });
 });
 

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -29,7 +29,7 @@
 import { describe, it, expect } from "vitest";
 import { listOpenAIModels, listAnthropicModels, listGeminiModels } from "./providers.js";
 import { normalizeModelFamily } from "./model-family.js";
-import { includeFamilies, NON_MODEL_TOKENS, isClassifiedFamily } from "./model-registry.js";
+import { NON_MODEL_TOKENS, isClassifiedFamily } from "./model-registry.js";
 import { formatDriftReport } from "./schema.js";
 
 type Provider = "openai" | "anthropic" | "gemini";
@@ -37,9 +37,9 @@ type Provider = "openai" | "anthropic" | "gemini";
 /**
  * Reduce a live `/models` list to the UNCLASSIFIED families: normalize each id,
  * then drop everything already classified (`include ∪ exclude`, the
- * preview-exclude rule — see `isClassifiedFamily` in model-registry.ts) or on
- * the non-model allowlist. The returned list (sorted, de-duplicated) is the
- * drift signal.
+ * preview/gemma exclude-by-rule patterns — see `isClassifiedFamily` in
+ * model-registry.ts) or on the non-model allowlist. The returned list (sorted,
+ * de-duplicated) is the drift signal.
  *
  * Exported so the co-located regression suite can exercise the EXACT
  * enumerate→normalize→subtract pipeline the live check relies on, with an
@@ -162,22 +162,6 @@ describe("preview families are excluded by rule", () => {
     expect(unclassifiedFamilies(["deep-research-pro-preview-12"], "gemini")).toEqual([]);
   });
 
-  it("INCLUDE WINS: a family explicitly on includeFamilies is included even if it ends in -preview", () => {
-    // Guard the opt-in escape hatch. `includeFamilies` membership short-circuits
-    // the preview rule, so this appears as classified (not drift) precisely
-    // because it is included — proving include-wins, not rule-exclude.
-    const provider = "gemini" as const;
-    const included = "gemini-x-chat-preview";
-    // Temporarily assert the semantics against a synthetic included family.
-    includeFamilies[provider].add(normalizeModelFamily(included, provider));
-    try {
-      expect(unclassifiedFamilies([included], provider)).toEqual([]);
-      expect(includeFamilies[provider].has(normalizeModelFamily(included, provider))).toBe(true);
-    } finally {
-      includeFamilies[provider].delete(normalizeModelFamily(included, provider));
-    }
-  });
-
   it("does NOT match interior -preview-<word> suffixes (they stay enumerated)", () => {
     // `-preview-tts` / `-preview-customtools` are non-text specialty surfaces
     // enumerated explicitly; a hypothetical UNLISTED interior-suffix family must
@@ -189,9 +173,25 @@ describe("preview families are excluded by rule", () => {
 });
 
 // ---------------------------------------------------------------------------
+// GEMMA_FAMILY exclude-by-rule predicate (open-weight, out of scope).
+// ---------------------------------------------------------------------------
+
+describe("gemma families are excluded by rule", () => {
+  it("a future Gemma variant auto-excludes with zero registry edits", () => {
+    // `gemma-9-foo` has no numeric-only build tag to strip, so it normalizes to
+    // itself and is on NEITHER include nor exclude — classified purely by the
+    // gemma rule. Red against the old literal-names-only exclude set; green with
+    // the pattern.
+    expect(unclassifiedFamilies(["gemma-9-foo"], "gemini")).toEqual([]);
+    // The two originally-enumerated literals still classify (now via the rule).
+    expect(unclassifiedFamilies(["gemma-4-26b-a4b-it", "gemma-4-31b-it"], "gemini")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Regression: the FULL live /models family wave (run 29478043559, 2026-07-16).
-// These are the exact families the drift job flagged as UNCLASSIFIED (OpenAI 49
-// / Anthropic 10 / Gemini 44). This suite injects representative raw ids for
+// These are the exact families the drift job flagged as UNCLASSIFIED (OpenAI 48
+// / Anthropic 10 / Gemini 45). This suite injects representative raw ids for
 // every one of them into the REAL enumerate→normalize→subtract pipeline and
 // asserts the registry now classifies all of them — zero drift. It exercises
 // the same `unclassifiedFamilies` surface the live canary uses, so it is a true
@@ -346,7 +346,7 @@ describe("full live /models wave is fully classified (2026-07-16 drift)", () => 
       "veo-3.1-fast-generate-preview", // pattern
       "veo-3.1-generate-preview", // pattern
       "veo-3.1-lite-generate-preview", // pattern
-      // Gemma open-weight — aimock does NOT mock; explicit exclude
+      // Gemma open-weight — aimock does NOT mock; auto-excluded by GEMMA_FAMILY rule
       "gemma-4-26b-a4b-it",
       "gemma-4-31b-it",
       // Moving aliases


### PR DESCRIPTION
## Problem

The daily model-family drift canary (`src/__tests__/drift/models.drift.ts`)
flagged the entire 2026-07-16 live `GET /models` wave as **UNCLASSIFIED** —
families present in neither `includeFamilies` nor `excludeFamilies`, which turns
the drift job red:

- **OpenAI: 48** unclassified families (gpt-5.x tiers, Codex line, o-series,
  retired base models, image/video/moderation/search/deep-research surfaces)
- **Anthropic: 10** (all Claude 4.x/5 point releases + `claude-fable-5`)
- **Gemini: 45** (stable flash/pro tiers, plus preview/image/audio/tts/video/
  music/robotics/embeddings/Gemma surfaces)

Root cause of the recurrence: `excludeFamilies` is a hand-maintained enumerated
list with **no rule for the churn-heavy families** (previews, Gemma variants),
so each new one re-fires the canary as brand-new drift and needs a manual
registry edit — forever.

## Fix

**Classification** (per resolved decisions):
- **INCLUDE** (text chat / reasoning aimock mocks): OpenAI gpt-5.x tiers + chat
  surfaces, the Codex line (`gpt-5-codex` … `gpt-5.3-codex`),
  `gpt-5.6-luna/-sol/-terra`, o-series; Anthropic all 4.x/5 point releases
  **including `claude-fable-5`** (included ahead of a recorded fixture — intended,
  mirrors the forward-looking rationale of the exclude-by-rule patterns); stable
  Gemini flash/pro tiers.
- **EXCLUDE**: retired base (babbage/davinci/gpt-3.5-*), embeddings, image
  (gpt-image*/Imagen/nano-banana/gemini-*-image), audio/TTS, moderation, video
  (Sora/Veo), music (Lyria), robotics, deep-research, search, computer-use,
  antigravity, aqa.
- **Moving aliases** (`chat-latest`, gemini `*-latest`): excluded as non-family
  aliases — no existing include convention for them.

**Durable hardening — two exclude-by-rule predicates:**

- **`PREVIEW_FAMILY`** (`/-preview(-\d+)?$/`) — any family whose normalized key
  ends in `-preview` (optionally `-preview-NN`) is **excluded by RULE**.
  Previews are **blanket-excluded until GA per policy**: this intentionally
  silences the canary on new text previews (e.g. `o1-preview`, `gpt-4.5-preview`)
  until they drop the `-preview` suffix and go GA. There is **no include-side
  escape hatch** — aimock does not mock preview surfaces.
- **`GEMMA_FAMILY`** (`/^gemma(-|$)/`) — the open-weight Gemma line is out of
  scope (aimock does not mock it; it only rides the shared Gemini `/models`
  list). Replaces the two enumerated literals (`gemma-4-26b-a4b-it`,
  `gemma-4-31b-it`) so **future Gemma variants auto-exclude with zero registry
  churn**. Reversible by explicit handling if a Gemma fixture is ever added.

**Removed the dead include-wins escape hatch:** the prior `isClassifiedFamily`
had an "include wins" branch so an included family ending in `-preview` would
still be treated as included. No consumer distinguished include from exclude for
preview families, so the branch was **dead code**, and the two tests guarding it
were **false-green** (they used `gemini-x-chat-preview`, which matches
`PREVIEW_FAMILY`, so they passed even with the branch deleted). Both the dead
branch and the false-green tests are removed. Verified
**`include ∩ (preview ∪ gemma) = ∅`**, so removal is a functional no-op.

A family is now classified **iff** it is in `include ∪ exclude`, or matches an
exclude-by-rule pattern (preview, gemma). Implemented at the **classification
layer, not the normalizer**, so preview/gemma family keys stay distinct and the
canary keeps surfacing genuinely-new *non-preview, non-gemma* families. The
builder/fixture cross-check uses the same `isClassifiedFamily` predicate so the
two classification surfaces cannot drift apart.

**No version bump** — `package.json` untouched (versioned separately).

## Red → Green proof

**`include ∩ (preview ∪ gemma) = ∅`** — verified empirically before removing the
include-wins branch: no family in any `includeFamilies` set matches
`PREVIEW_FAMILY` or `GEMMA_FAMILY`, so the removal cannot mis-classify any
included family.

**GEMMA_FAMILY rule (new genuine red-green test):**

RED — against the pre-fix registry (literal names only, no `GEMMA_FAMILY`):
```
 × isClassifiedFamily / PREVIEW_FAMILY > classifies a future Gemma variant by rule
   → Cannot read properties of undefined (reading 'test')   # GEMMA_FAMILY did not exist
```
A synthetic `gemma-9-foo` (normalizes to itself — no numeric-only build tag to
strip) was on neither include nor exclude and was **unclassified** under the old
literal-names-only set.

GREEN — with the pattern:
```
 ✓ isClassifiedFamily / PREVIEW_FAMILY > classifies a future Gemma variant by rule
 ✓ gemma families are excluded by rule > a future Gemma variant auto-excludes with zero registry edits
```

**Full drift + unit suite (after the fix):**
```
 Test Files  16 passed | 8 skipped (24)     # pnpm test:drift — 0/0/0 unclassified
      Tests  98 passed | 55 skipped (153)
 Test Files  158 passed (158)               # pnpm test — full unit
      Tests  4670 passed (4670)
```
The full-wave regression suites (OpenAI/Anthropic/Gemini) still assert **zero
unclassified** against the real `unclassifiedFamilies` pipeline. The two
false-green INCLUDE-WINS tests are gone; no tautological test replaces them.

`format:check` / `lint` / `tsdown build` / `commitlint` (header ≤100) all pass on
the changed files.
