### PR TITLE
fix(drift): pass --report to Auto-fix step so it reads the pinned report

### DIFF
--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -159,6 +159,15 @@ jobs:
           echo "Pinned pre-fix drift report to $PINNED_REPORT (outside the LLM-writable repo checkout)"
 
       # Step 3: Invoke Claude Code to fix
+      #
+      # --report reads the PINNED pre-fix report (Step 2b), NOT the default
+      # in-repo `drift-report.json`. The collector writes its report to
+      # $RUNNER_TEMP (Step 1, FIX #F3), which is OUTSIDE the repo checkout, so
+      # the repo-root `drift-report.json` that fix-drift.ts defaults to does not
+      # exist — without this flag readDriftReport throws "Drift report not
+      # found" and the fixer never runs. Reading the pinned copy (same source
+      # the Assert and Create PR steps read) also keeps the fixer's view of the
+      # drift consistent with the downstream integrity gate.
       - name: Auto-fix drift
         id: autofix
         if: steps.check.outputs.skip != 'true'
@@ -167,7 +176,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-        run: npx tsx scripts/fix-drift.ts
+          PINNED_REPORT: ${{ runner.temp }}/drift-report.pinned.json
+        run: npx tsx scripts/fix-drift.ts --report "${PINNED_REPORT}"
 
       # Upload Claude Code output for debugging
       - name: Upload Claude Code logs

--- a/src/__tests__/fix-drift-workflow.test.ts
+++ b/src/__tests__/fix-drift-workflow.test.ts
@@ -98,6 +98,39 @@ describe("fix-drift.yml — F-A: PRE-fix report pinned outside the LLM-writable 
 });
 
 // ---------------------------------------------------------------------------
+// report-path — the Auto-fix step must pass --report from the PINNED copy.
+//
+// FIX #F3 moved the collector's report to $RUNNER_TEMP (outside the repo
+// checkout), so the repo-root drift-report.json that fix-drift.ts defaults to no
+// longer exists. The Assert and Create-PR steps were updated to read --report
+// from the pinned copy, but the Auto-fix step still ran `fix-drift.ts` with NO
+// --report, so it fell back to the missing repo-root path and died with "Drift
+// report not found" (readDriftReport) — the recurring drift-job failure. These
+// lock that the Auto-fix step reads --report from the pinned copy, matching the
+// downstream integrity gate.
+// ---------------------------------------------------------------------------
+describe("fix-drift.yml — report-path: Auto-fix step reads --report from the pinned copy", () => {
+  it("passes --report from the PINNED copy into the Auto-fix `fix-drift.ts` invocation", () => {
+    expect(wfFlat).toMatch(/scripts\/fix-drift\.ts --report "\$\{PINNED_REPORT\}"/);
+  });
+
+  it("does NOT run the Auto-fix step against the default (missing) repo-root drift-report.json", () => {
+    // The bare `npx tsx scripts/fix-drift.ts` (no --report) is the regression:
+    // it defaults to the repo-root drift-report.json which FIX #F3 no longer
+    // writes. Ensure the autofix invocation always carries a --report flag.
+    expect(wfFlat).not.toMatch(/npx tsx scripts\/fix-drift\.ts(?! --)/);
+  });
+
+  it("exposes PINNED_REPORT as an env in the Auto-fix step", () => {
+    const idx = wf.indexOf("name: Auto-fix drift");
+    expect(idx).toBeGreaterThan(-1);
+    const nextStep = wf.indexOf("\n      - name:", idx + 1);
+    const stepBlock = wf.slice(idx, nextStep === -1 ? undefined : nextStep);
+    expect(stepBlock).toContain("PINNED_REPORT: ${{ runner.temp }}/drift-report.pinned.json");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // FIX (round-4, user-approved) — HUMAN-APPROVAL BACKSTOP. The drift path opens a
 // PR but must NEVER auto-merge: the predicate is a strong AUTO-FILTER, not a
 // provable merge gate (the re-collect is not independent of the fix — WS-2b), so


### PR DESCRIPTION
## Root cause

The **Auto-fix drift** step in `.github/workflows/fix-drift.yml` ran `npx tsx scripts/fix-drift.ts` with **no `--report` flag**, so `fix-drift.ts` defaulted `reportPath` to the repo-root `drift-report.json`. But FIX #F3 moved the collector's report to `$RUNNER_TEMP` (outside the repo checkout) and pinned a copy to `$RUNNER_TEMP/drift-report.pinned.json`. Nothing writes the repo-root file anymore, so `readDriftReport` threw and the job died with exit 3 **before the fixer ran**.

This is the recurring drift-job failure — e.g. run [29634448013](https://github.com/CopilotKit/aimock/actions/runs/29634448013):
```
Fatal error: Error: Drift report not found at /home/runner/work/aimock/aimock/drift-report.json
    at readDriftReport (scripts/fix-drift.ts:199:11)
    at main (scripts/fix-drift.ts:1167:18)   → exit code 3
```
The earlier steps succeeded because none of them read the repo-root file: **Collect** wrote to `$RUNNER_TEMP`, **Check for critical diffs** read only `steps.detect.outputs.exit_code`, and **Pin** `cp`'d within `$RUNNER_TEMP`. The **Assert** and **Create PR** steps already read `--report "${PINNED_REPORT}"`; only the **Auto-fix** step was missed when FIX #F3 relocated the report.

The prompt's `mv`-vs-`cp` hypothesis was ruled out — the pin uses `cp`, and both its src/dest are in `$RUNNER_TEMP`. The real gap was the missing `--report` on the Auto-fix invocation.

## The fix

Pass `--report "${PINNED_REPORT}"` to the Auto-fix step (with `PINNED_REPORT` in its env), matching the Assert and Create-PR steps. The fixer now reads the same out-of-repo pinned report the integrity gate uses — lightest correct change, consistent with the existing design.

## Red-green proof (real failure surface)

Replicated the workflow's exact sequence locally: collector report written to a simulated `$RUNNER_TEMP`, pinned via `cp`, repo-root `drift-report.json` absent, then ran the real `scripts/fix-drift.ts`.

**RED** (pre-fix invocation, bare `fix-drift.ts`, no `--report`):
```
Fatal error: Error: Drift report not found at .../drift-report-path/drift-report.json
    at readDriftReport (scripts/fix-drift.ts:199:11)
    at main (scripts/fix-drift.ts:1167:18)
RED exit code = 3
```
Same error, same stack frames, same exit code as CI.

**GREEN** (fixed invocation, `fix-drift.ts --report "$PINNED_REPORT"`):
```
Loaded drift report: 1 entries from 2026-07-18T00:00:00Z
Invoking Claude Code CLI...
```
The report is read (past `readDriftReport:199` / `main:1167`) and the fixer proceeds to invoke Claude Code. No "not found", no fatal error.

**Unit-level red-green** (`src/__tests__/fix-drift-workflow.test.ts`): 3 new text-shape tests assert the Auto-fix step carries `--report "${PINNED_REPORT}"` and the `PINNED_REPORT` env, and that no bare `fix-drift.ts` invocation remains. All 3 FAIL against the pre-fix workflow (stashed) and PASS against the fix.

## Verification

- `pnpm run format:check` clean
- `pnpm run lint` clean
- `pnpm run test` — 4625 passed, 44 skipped, 0 failed
- `pnpm run build` (tsdown) clean
- `commitlint --from origin/main --to HEAD` exit 0
- **No version bump.** Only `.github/workflows/fix-drift.yml` and the test file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)