### PR TITLE
fix(drift): classify bare chat-latest alias in openai excludeFamilies

### DIFF
--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -176,6 +176,9 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     "gpt-image-1.5",
     "gpt-image-2",
     "chatgpt-image-latest",
+    // Bare chat alias — a moving alias (not a stable mocked family); matches the
+    // *-latest exclude policy (chatgpt-image-latest, omni-moderation-latest, etc.)
+    "chat-latest",
     // Video generation (non-text)
     "sora-2",
     "sora-2-pro",

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -266,6 +266,9 @@ describe("full live /models wave is fully classified (2026-07-16 drift)", () => 
       "sora-2-pro",
       "omni-moderation",
       "omni-moderation-latest",
+      // bare chat alias (fixture-vs-live gap: present in live /models, was absent
+      // from the static wave — this is the 2026-07-18 canary residual)
+      "chat-latest",
     ];
     expect(unclassifiedFamilies(openaiLive, "openai")).toEqual([]);
   });


### PR DESCRIPTION
## Summary

Fixes the live drift job residual from run 29654128652 (2026-07-18, main): bare `chat-latest` was returned by OpenAI's `/models` but not present in either `includeFamilies` or `excludeFamilies` in `model-registry.ts`, causing a critical unclassified-family signal.

**Root cause:** `chat-latest` is a bare moving alias with no per-tier prefix (unlike `gpt-5-chat-latest`, `gpt-5.1/5.2/5.3-chat-latest`). The normalizer leaves it unchanged (no date/build-tag suffix to strip), so it fell through as an unclassified family.

**Fix:** Added `chat-latest` to `excludeFamilies.openai` — consistent with PR #313's stated policy that moving aliases belong in excludeFamilies (same rationale as `chatgpt-image-latest`, `omni-moderation-latest`, `gemini-flash-latest`, etc.).

**Fixture-vs-live gap closed:** The static OpenAI wave in `models.drift.ts` previously omitted bare `chat-latest`, so the test suite ran 0/0/0 for this family while the live `/models` endpoint returned it. Added `chat-latest` to the wave so the static suite will exercise this family class going forward.

**Sibling scan:** Audited all `*-latest` entries across openai/gemini/anthropic. Every other bare alias is already classified (include or exclude). `chat-latest` was the only unclassified one.

## Red-green proof

**RED** (wave has `chat-latest`, registry does not):
```
× src/__tests__/drift/models.drift.ts > full live /models wave is fully classified
  → expected [ 'chat-latest' ] to deeply equal []
```
Unclassified count: 1

**GREEN** (after adding to excludeFamilies):
```
✓ src/__tests__/drift/models.drift.ts > full live /models wave is fully classified
✓ ...OpenAI: every live family is classified (zero unclassified)
Test Files: 158 passed (158) — Tests: 4673 passed (4673)
```
Unclassified count: 0

## No version bump

`git diff origin/main -- package.json` → empty (zero diff).

## Changes

- `src/__tests__/drift/model-registry.ts` — added `chat-latest` to `excludeFamilies.openai` with comment
- `src/__tests__/drift/models.drift.ts` — added `chat-latest` to the static OpenAI wave (fixture-vs-live gap fix)