### PR TITLE
chore: release v1.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.37.2",
+  "version": "1.38.0",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Minor version bump 1.37.2 → 1.38.0. Merge to main triggers the Release workflow: npm publish, git tag, GitHub release, Docker image, Slack notify.