### PR TITLE
chore: release v1.37.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.37.3",
+  "version": "1.37.4",
   "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Release v1.37.4. Bumps `package.json` to publish the fix from #319 to npm + ghcr.

## What ships
- **#319** — `hasToolResult` record/replay symmetry via shared `currentTurnHasToolResult` helper (recorder previously stamped whole-conversation while the matcher read current-turn, so genuinely-recorded multi-turn fixtures could never match), plus Anthropic `tool_result`+text ordering fix. Completes the incomplete #316 / v1.37.3 fix.
- CHANGELOG entries for 1.37.4 and the retroactive 1.37.3 (which shipped undocumented) already landed in #319.

Consumer: unblocks CopilotKit showcase multi-turn recording once bumped to 1.37.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)