### PR TITLE
fix: classify gemini-3.5-flash-lite and gemini-3.6-flash families

### DIFF
--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -146,6 +146,8 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     "gemini-2.5-flash-lite",
     "gemini-3.1-flash-lite",
     "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.6-flash",
   ]),
 };
 

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -310,6 +310,8 @@ describe("full live /models wave is fully classified (2026-07-16 drift)", () => 
       "gemini-2.5-flash-lite",
       "gemini-3.1-flash-lite",
       "gemini-3.5-flash",
+      "gemini-3.5-flash-lite",
+      "gemini-3.6-flash",
       // Preview text tiers — auto-excluded by the -preview pattern rule
       "gemini-3-flash-preview",
       "gemini-3-pro-preview",


### PR DESCRIPTION
## What

Google Gemini's live `GET /models` now returns two new text-generation families that aimock's drift canary classified as **neither** included nor excluded, producing 2 critical drift diffs on every daily run:

- `gemini-3.5-flash-lite`
- `gemini-3.6-flash`

aimock mocks Gemini text models, so both belong in `includeFamilies.gemini` (not `excludeFamilies` — they are not preview / retired / non-text). This adds them to `includeFamilies` **and** to the static `/models` test wave in `models.drift.ts`, so the offline `test:drift` suite catches this class of drift going forward — closing the fixture-vs-live gap (per #315).

This touches only `src/__tests__/drift/*`. It does **not** ship in the published npm package, so there is no version bump and no CHANGELOG entry.

## Local red-green proof

The real failure surface is the drift classifier (`unclassifiedFamilies`) exercised by the static `/models` test wave. Both legs use the same command: `pnpm run test:drift`.

**RED** — add the two families to the static `/models` wave snapshot only (what live now returns), WITHOUT classifying them:

```
❯ src/__tests__/drift/models.drift.ts (13 tests | 1 failed | 3 skipped)
   × full live /models wave is fully classified (2026-07-16 drift) > Gemini: every live family is classified (zero unclassified)
     → expected [ 'gemini-3.5-flash-lite', …(1) ] to deeply equal []

 FAIL  src/__tests__/drift/models.drift.ts > ... > Gemini: every live family is classified (zero unclassified)
 AssertionError: expected [ 'gemini-3.5-flash-lite', …(1) ] to deeply equal []
 +   "gemini-3.5-flash-lite",
 +   "gemini-3.6-flash",

 Test Files  1 failed | 14 passed | 9 skipped (24)
      Tests  1 failed | 89 passed | 63 skipped (153)
```

**GREEN** — add both families to `includeFamilies.gemini` in `model-registry.ts`, re-run the same command:

```
 ✓ src/__tests__/drift/models.drift.ts (13 tests | 3 skipped) 3ms

 Test Files  15 passed | 9 skipped (24)
      Tests  90 passed | 63 skipped (153)
```

Full suite (`pnpm test`) and `pnpm run build` both green afterward.

## Live corroboration

This drift was also live-red/green-verified in CI run [29898337754](https://github.com/CopilotKit/aimock/actions/runs/29898337754): the pre-fix collector exited 2 with these exact 2 diffs; a post-fix re-collect exited 0. The local red-green above is the required proof; the CI run is corroborating live evidence.

## Scope

This is the **tactical half** of a two-part fix. The other half reconciles the drift-success-predicate so the bot can auto-classify canary drift going forward.
