### PR TITLE
feat: Ollama live drift leg via CI-provisioned daemon

### DIFF
--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -62,6 +62,24 @@ jobs:
           git config user.email "drift-bot@copilotkit.ai"
           git checkout -B "fix/drift-$(date +%Y-%m-%d)-${RUN_ID}"
 
+      # Provision a local Ollama daemon so the OLLAMA_HOST-gated live drift leg
+      # (src/__tests__/drift/ollama.drift.ts) is detected here too. Ollama needs
+      # NO API key — the "credential" is just a running daemon. Pull the smallest
+      # chat+generate-capable model (qwen2:0.5b, ~350MB); OLLAMA_MODEL points the
+      # leg at it. COST: install + model pull adds ~2-4 min to the fix run.
+      - name: Provision Ollama daemon (live drift leg)
+        run: |
+          set -euo pipefail
+          curl -fsSL https://ollama.com/install.sh | sh
+          ollama serve > /tmp/ollama-serve.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:11434/api/version >/dev/null 2>&1; then
+              echo "ollama daemon ready"; break
+            fi
+            sleep 1
+          done
+          ollama pull qwen2:0.5b
+
       # Step 1: Detect drift and produce report.
       #
       # FIX #F3 (round-4) — write the report OUTSIDE the repo checkout, to
@@ -78,6 +96,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Un-gates the Ollama live drift leg against the daemon provisioned above.
+          OLLAMA_HOST: 127.0.0.1:11434
+          OLLAMA_MODEL: qwen2:0.5b
           PRE_FIX_REPORT: ${{ runner.temp }}/drift-report.json
         run: |
           set +e
@@ -210,6 +231,10 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Keep the Ollama live leg un-gated so post-fix verification exercises it
+          # (the daemon provisioned earlier in this job is still running).
+          OLLAMA_HOST: 127.0.0.1:11434
+          OLLAMA_MODEL: qwen2:0.5b
         run: pnpm test:drift
 
       # Step 4c: Re-collect drift AUTHORITATIVELY against the LIVE SDK, writing
@@ -234,6 +259,10 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Keep the Ollama live leg un-gated so the authoritative re-collect
+          # exercises it (the daemon provisioned earlier in this job is running).
+          OLLAMA_HOST: 127.0.0.1:11434
+          OLLAMA_MODEL: qwen2:0.5b
           POST_FIX_REPORT: ${{ runner.temp }}/drift-report.post-fix.json
         run: |
           set +e

--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -70,7 +70,10 @@ jobs:
       - name: Provision Ollama daemon (live drift leg)
         run: |
           set -euo pipefail
-          curl -fsSL https://ollama.com/install.sh | sh
+          # Download the installer to disk first, then execute it — avoids piping
+          # a remote, mutable script straight into a shell (no `curl | sh`).
+          curl -fsSL https://ollama.com/install.sh -o "${RUNNER_TEMP}/ollama-install.sh"
+          sh "${RUNNER_TEMP}/ollama-install.sh"
           ollama serve > /tmp/ollama-serve.log 2>&1 &
           for _ in $(seq 1 30); do
             if curl -sf http://127.0.0.1:11434/api/version >/dev/null 2>&1; then

--- a/.github/workflows/test-drift.yml
+++ b/.github/workflows/test-drift.yml
@@ -148,6 +148,25 @@ jobs:
           PREFLIGHT
           npx tsx "$PREFLIGHT_FILE"
 
+      # Provision a local Ollama daemon so the OLLAMA_HOST-gated live drift leg
+      # (src/__tests__/drift/ollama.drift.ts) actually runs. Ollama needs NO API
+      # key — the "credential" is just a running daemon. We pull the smallest
+      # chat+generate-capable model (qwen2:0.5b, ~350MB) and point the leg at it
+      # via OLLAMA_MODEL to keep the added cost minimal. COST: the install + model
+      # pull adds ~2-4 min to every drift run.
+      - name: Provision Ollama daemon (live drift leg)
+        run: |
+          set -euo pipefail
+          curl -fsSL https://ollama.com/install.sh | sh
+          ollama serve > /tmp/ollama-serve.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:11434/api/version >/dev/null 2>&1; then
+              echo "ollama daemon ready"; break
+            fi
+            sleep 1
+          done
+          ollama pull qwen2:0.5b
+
       # Run the collector behind a "retry before alert" wrapper. A single
       # critical run can be a transient real-API hiccup (a streaming call
       # failing mid-flight), NOT a format change — so the wrapper re-runs the
@@ -163,6 +182,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Un-gates the Ollama live drift leg against the daemon provisioned above.
+          OLLAMA_HOST: 127.0.0.1:11434
+          OLLAMA_MODEL: qwen2:0.5b
         run: |
           set +e
           npx tsx scripts/drift-retry.ts

--- a/.github/workflows/test-drift.yml
+++ b/.github/workflows/test-drift.yml
@@ -157,7 +157,10 @@ jobs:
       - name: Provision Ollama daemon (live drift leg)
         run: |
           set -euo pipefail
-          curl -fsSL https://ollama.com/install.sh | sh
+          # Download the installer to disk first, then execute it — avoids piping
+          # a remote, mutable script straight into a shell (no `curl | sh`).
+          curl -fsSL https://ollama.com/install.sh -o "${RUNNER_TEMP}/ollama-install.sh"
+          sh "${RUNNER_TEMP}/ollama-install.sh"
           ollama serve > /tmp/ollama-serve.log 2>&1 &
           for _ in $(seq 1 30); do
             if curl -sf http://127.0.0.1:11434/api/version >/dev/null 2>&1; then

--- a/src/__tests__/drift/ollama.drift.ts
+++ b/src/__tests__/drift/ollama.drift.ts
@@ -16,7 +16,20 @@ import { httpPost, startDriftServer, stopDriftServer } from "./helpers.js";
 // Environment-based opt-in (consistent with other drift files)
 // ---------------------------------------------------------------------------
 
-const OLLAMA_HOST = process.env.OLLAMA_HOST ?? "http://localhost:11434";
+// Accept both a full base URL ("http://127.0.0.1:11434") and Ollama's native
+// host:port form ("127.0.0.1:11434" — the value the daemon itself uses). The
+// test issues real HTTP requests, so a scheme is required; prefix http:// when
+// one is absent.
+const RAW_OLLAMA_HOST = process.env.OLLAMA_HOST ?? "http://localhost:11434";
+const OLLAMA_HOST = /^https?:\/\//.test(RAW_OLLAMA_HOST)
+  ? RAW_OLLAMA_HOST
+  : `http://${RAW_OLLAMA_HOST}`;
+
+// The model to exercise against the live daemon. Defaults to "llama3.2" for a
+// local developer run, but CI provisions a much smaller model (to keep the
+// daemon pull cheap) and points the leg at it via OLLAMA_MODEL. Both /api/chat
+// and /api/generate use the same model.
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL ?? "llama3.2";
 
 // ---------------------------------------------------------------------------
 // Server lifecycle
@@ -112,7 +125,7 @@ describe.skipIf(!process.env.OLLAMA_HOST)("Ollama drift", () => {
     const sdkShape = ollamaChatResponseShape();
 
     const body = {
-      model: "llama3.2",
+      model: OLLAMA_MODEL,
       messages: [{ role: "user", content: "Say hello" }],
       stream: false,
     };
@@ -143,7 +156,7 @@ describe.skipIf(!process.env.OLLAMA_HOST)("Ollama drift", () => {
     const sdkChunkShape = ollamaChatStreamChunkShape();
 
     const body = {
-      model: "llama3.2",
+      model: OLLAMA_MODEL,
       messages: [{ role: "user", content: "Say hello" }],
       stream: true,
     };
@@ -181,7 +194,7 @@ describe.skipIf(!process.env.OLLAMA_HOST)("Ollama drift", () => {
     const sdkShape = ollamaGenerateResponseShape();
 
     const body = {
-      model: "llama3.2",
+      model: OLLAMA_MODEL,
       prompt: "Say hello",
       stream: false,
     };


### PR DESCRIPTION
## What

Brings the **Ollama drift surface into live CI coverage**. Today `src/__tests__/drift/ollama.drift.ts` has a live leg gated on `OLLAMA_HOST`, but no Ollama daemon exists in CI and there is no static fallback, so the leg is **silently skipped — zero CI signal**. Ollama needs **no API key**; the only "credential" is a running local daemon, so we can provision one in CI for free.

### Changes
- **`test-drift.yml`** (scheduled/dispatch `drift` job) and **`fix-drift.yml`** (`fix` job): added an additive `Provision Ollama daemon` step that installs Ollama, starts `ollama serve` in the background, waits for readiness, and pulls the tiny **`qwen2:0.5b`** (~350 MB, smallest model supporting both `/api/chat` and `/api/generate`). Exported `OLLAMA_HOST=127.0.0.1:11434` + `OLLAMA_MODEL=qwen2:0.5b` into the collector/verify steps so the leg runs against the real daemon. `fix-drift.yml`'s post-fix verify + authoritative re-collect steps are also un-gated so the auto-fix path can actually verify an Ollama fix (daemon is already running in that job).
- **`ollama.drift.ts`**: model is now `OLLAMA_MODEL ?? "llama3.2"` (lets CI use the tiny model while a local dev run defaults unchanged); `OLLAMA_HOST` is normalized to accept both a full base URL and Ollama's native bare `host:port` form. No assertion logic changed.

## ⚠️ CI-time cost (for merge consideration)

The daemon install + model pull adds **~2-4 min to every drift run** (daily scheduled `test-drift` + every `fix-drift` invocation). This is the tradeoff for real Ollama coverage. Weigh at merge — if too costly, options are caching the model or gating the leg to a less frequent cadence.

## Red-green proof (LIVE, real Ollama daemon)

Ran locally against a real `ollama serve` + `qwen2:0.5b` (no key needed).

**GREEN (baseline, unmodified mock):**
```
OLLAMA_HOST=127.0.0.1:11434 OLLAMA_MODEL=qwen2:0.5b npx vitest run src/__tests__/drift/ollama.drift.ts --config vitest.config.drift.ts
 ✓ src/__tests__/drift/ollama.drift.ts (3 tests) 1256ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**RED (temporarily dropped `done_reason` from the mock's non-streaming `/api/chat` builder — a genuine mock/real divergence):**
```
 × Ollama drift > /api/chat response shape matches
API DRIFT DETECTED: Ollama /api/chat
  Surface: ollama

  1. [critical] LLMOCK DRIFT — field in SDK + real API but missing from mock
     Path:    done_reason
     SDK:     string
     Real:    string
     Mock:    <absent>
```
The `Surface: ollama` marker is emitted → the collector maps it to exit 2 (auto-fixable), confirming the leg has teeth against the real API.

**GREEN again (reverted):** 3/3 pass; working tree clean (only the test + workflows changed).

**Skip-safe:** with no `OLLAMA_HOST` (local dev / non-CI), the leg still cleanly skips (3 skipped) — no regression.

## Other checks
- Tests-inclusive ES2022 typecheck on the touched test file: **0 new errors** (pre-existing errors in other test files unchanged).
- prettier ✓, eslint ✓ (exit 0), `pnpm build` ✓, full unit suite ✓ (4684 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KamK73Wu5heLxJEogM6hHC
