### PR TITLE
fix: correct 6 competitive-matrix drift-automation bugs (public-docs safety)

### DIFF
--- a/scripts/update-competitive-matrix.ts
+++ b/scripts/update-competitive-matrix.ts
@@ -15,6 +15,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -32,7 +33,7 @@ interface FeatureRule {
   keywords: string[];
 }
 
-interface DetectedChange {
+export interface DetectedChange {
   competitor: string;
   capability: string;
   from: string;
@@ -48,7 +49,7 @@ const COMPETITORS: Competitor[] = [
   { name: "mokksy/ai-mocks", repo: "mokksy/ai-mocks" },
 ];
 
-const FEATURE_RULES: FeatureRule[] = [
+export const FEATURE_RULES: FeatureRule[] = [
   {
     rowLabel: "Chat Completions SSE",
     keywords: ["chat/completions", "streaming", "SSE", "server-sent", "stream.*true"],
@@ -259,11 +260,12 @@ const FEATURE_RULES: FeatureRule[] = [
 ];
 
 /** Maps competitor display names to their migration page paths (relative to docs/) */
-const COMPETITOR_MIGRATION_PAGES: Record<string, string> = {
-  VidaiMock: "docs/migrate-from-vidaimock.html",
-  "mock-llm": "docs/migrate-from-mock-llm.html",
-  "piyook/llm-mock": "docs/migrate-from-piyook.html",
-  // MSW, Mokksy, Python don't have GitHub repos in COMPETITORS[] yet
+export const COMPETITOR_MIGRATION_PAGES: Record<string, string> = {
+  VidaiMock: "docs/migrate-from-vidaimock/index.html",
+  "mock-llm": "docs/migrate-from-mock-llm/index.html",
+  "piyook/llm-mock": "docs/migrate-from-piyook/index.html",
+  "mokksy/ai-mocks": "docs/migrate-from-mokksy/index.html",
+  // MSW and Python don't have GitHub repos in COMPETITORS[] yet
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -305,14 +307,24 @@ async function fetchPackageJson(repo: string): Promise<string> {
   return "";
 }
 
-function extractFeatures(text: string): Record<string, boolean> {
+/**
+ * Builds a case-insensitive regex for a keyword that will only match when the
+ * pattern is bounded by non-alphanumeric characters (or string edges). This
+ * prevents short tokens from matching as substrings of larger words — e.g.
+ * "cli" must not match "client"/"click", "sse" must not match "assess". The
+ * boundary lookarounds constrain the surrounding text only, so keywords that
+ * are themselves regexes (`stream.*true`, `output_text\.delta`) or that begin
+ * or end with non-word characters (`/v1/models`, `ws://`) keep working.
+ */
+function keywordRegex(kw: string): RegExp {
+  return new RegExp(`(?<![a-z0-9])(?:${kw.toLowerCase()})(?![a-z0-9])`, "i");
+}
+
+export function extractFeatures(text: string): Record<string, boolean> {
   const lower = text.toLowerCase();
   const result: Record<string, boolean> = {};
   for (const rule of FEATURE_RULES) {
-    const found = rule.keywords.some((kw) => {
-      const pattern = new RegExp(kw.toLowerCase(), "i");
-      return pattern.test(lower);
-    });
+    const found = rule.keywords.some((kw) => keywordRegex(kw).test(lower));
     result[rule.rowLabel] = found;
   }
   return result;
@@ -323,15 +335,16 @@ function extractFeatures(text: string): Record<string, boolean> {
  * README text. De-duplicates overlapping patterns (e.g. "anthropic" and "claude"
  * both map to the same provider).
  */
-function countProviders(text: string): number {
+export function countProviders(text: string): number {
   const lower = text.toLowerCase();
 
-  // Group patterns that refer to the same provider
+  // Group patterns that refer to the same provider. Each provider appears in
+  // exactly ONE group so it is counted at most once (e.g. "gemini interactions"
+  // is still just Gemini, not a separate provider).
   const providerGroups: string[][] = [
     ["openai"],
     ["claude", "anthropic"],
     ["gemini", "google.*ai"],
-    ["gemini.*interactions"],
     ["bedrock", "aws"],
     ["azure"],
     ["vertex"],
@@ -344,9 +357,11 @@ function countProviders(text: string): number {
     ["elevenlabs"],
   ];
 
+  // Word-boundary matching so "cohere" does not match "coherent", "aws" does
+  // not match "flaws", etc.
   let count = 0;
   for (const group of providerGroups) {
-    const found = group.some((kw) => new RegExp(kw, "i").test(lower));
+    const found = group.some((kw) => keywordRegex(kw).test(lower));
     if (found) count++;
   }
   return count;
@@ -365,7 +380,36 @@ function countProviders(text: string): number {
  * The function also updates numeric provider claims in both table cells and
  * prose text (e.g., "5 providers" -> "8 providers").
  */
-function updateMigrationPage(
+/**
+ * Finds the 0-based <td> index of a competitor's column in a migration-page
+ * table by matching the <th> header text to the competitor name. The <th> list
+ * includes the leading "Capability" header at index 0, which aligns with the
+ * leading label <td> in each body row, so the returned index can be used
+ * directly against a row's <td> list. Matching is case-insensitive and
+ * bidirectional-substring so header text ("Mokksy") resolves against the
+ * competitor key ("mokksy/ai-mocks", whose leading token "mokksy" matches the
+ * "Mokksy" header). Returns -1 when no column matches.
+ *
+ * Matching is intentionally token-aware rather than loose-substring: a plain
+ * bidirectional `includes` would wrongly match the "aimock" header against the
+ * "VidaiMock" competitor (the string "vidaimock" contains "aimock").
+ */
+function findMigrationCompetitorColumn(tableHtml: string, competitorName: string): number {
+  const thRegex = /<th[^>]*>([\s\S]*?)<\/th>/g;
+  const thTexts: string[] = [];
+  let thM: RegExpExecArray | null;
+  while ((thM = thRegex.exec(tableHtml)) !== null) {
+    thTexts.push(thM[1].trim());
+  }
+  const comp = competitorName.toLowerCase();
+  const compToken = comp.split("/")[0]; // "mokksy/ai-mocks" -> "mokksy"
+  return thTexts.findIndex((t) => {
+    const h = t.toLowerCase();
+    return h.length > 0 && (h === comp || h === compToken || h.includes(comp));
+  });
+}
+
+export function updateMigrationPage(
   html: string,
   competitorName: string,
   features: Record<string, boolean>,
@@ -382,22 +426,47 @@ function updateMigrationPage(
     return { html: result, changes };
   }
 
-  // Update feature cells: find rows where the competitor column shows &#10007;
-  // and the feature was detected
-  for (const rule of FEATURE_RULES) {
-    if (!features[rule.rowLabel]) continue;
+  // Locate the competitor's column by header name (NOT by assuming it is the
+  // first data column) so the correct cell flips even when an intervening
+  // column (e.g. aimock) precedes it.
+  const compColIdx = findMigrationCompetitorColumn(tableMatch[0], competitorName);
 
-    // Migration tables have different row labels than the index matrix.
-    // We look for rows that conceptually match the feature rule.
-    // The competitor column is always the first data column (index 1) after the label.
-    const rowPatterns = buildMigrationRowPatterns(rule.rowLabel);
-    for (const rowPat of rowPatterns) {
-      const rowRegex = new RegExp(
-        `(<tr>\\s*<td>${escapeRegex(rowPat)}</td>\\s*)<td style="color: var\\(--error\\)">&#10007;</td>`,
-      );
-      if (rowRegex.test(result)) {
-        result = result.replace(rowRegex, `$1<td style="color: var(--accent)">&#10003;</td>`);
-        changes.push(`${competitorName}: ${rowPat} ✗ -> ✓`);
+  // Update feature cells: find rows where the competitor column shows &#10007;
+  // and the feature was detected.
+  if (compColIdx >= 0) {
+    for (const rule of FEATURE_RULES) {
+      if (!features[rule.rowLabel]) continue;
+
+      // Migration tables have different row labels than the index matrix.
+      // We look for rows that conceptually match the feature rule.
+      const rowPatterns = buildMigrationRowPatterns(rule.rowLabel);
+      for (const rowPat of rowPatterns) {
+        const rowRegex = new RegExp(`<tr>\\s*<td>${escapeRegex(rowPat)}</td>[\\s\\S]*?</tr>`);
+        const rowMatch = result.match(rowRegex);
+        if (!rowMatch) continue;
+
+        const fullRow = rowMatch[0];
+        let tdIdx = 0;
+        let flipped = false;
+        const newRow = fullRow.replace(/<td[^>]*>[\s\S]*?<\/td>/g, (tdMatch) => {
+          const currentIdx = tdIdx++;
+          if (
+            currentIdx === compColIdx &&
+            /var\(--error\)/.test(tdMatch) &&
+            tdMatch.includes("&#10007;")
+          ) {
+            flipped = true;
+            return `<td style="color: var(--accent)">&#10003;</td>`;
+          }
+          return tdMatch;
+        });
+
+        if (flipped) {
+          // Function-form replacement keeps newRow literal (a $ / $& / $1 in the
+          // surrounding HTML must not be interpreted by String.replace).
+          result = result.replace(fullRow, () => newRow);
+          changes.push(`${competitorName}: ${rowPat} ✗ -> ✓`);
+        }
       }
     }
   }
@@ -415,7 +484,7 @@ function updateMigrationPage(
  * Builds possible row label strings that a migration page might use for a given
  * feature rule. Migration pages use more descriptive labels than the index matrix.
  */
-function buildMigrationRowPatterns(rowLabel: string): string[] {
+export function buildMigrationRowPatterns(rowLabel: string): string[] {
   const patterns = [rowLabel];
 
   // Add common migration-page variants
@@ -437,7 +506,11 @@ function buildMigrationRowPatterns(rowLabel: string): string[] {
     "AG-UI event mocking": ["AG-UI event mocking", "AG-UI mocking", "AG-UI"],
     "Realtime GA protocol": ["Realtime GA protocol", "GA Realtime"],
     "Realtime Beta compatibility": ["Realtime Beta compatibility", "Beta Realtime"],
-    "Realtime translate/whisper": ["Realtime translate/whisper", "Translate/Whisper"],
+    "Realtime transcription/translation": [
+      "Realtime transcription/translation",
+      "Realtime translate/whisper",
+      "Translate/Whisper",
+    ],
     "Realtime image input": ["Realtime image input"],
     "Realtime commentary phase": ["Realtime commentary phase", "Commentary phase"],
     "Image editing": ["Image editing", "Image edit"],
@@ -462,7 +535,7 @@ function buildMigrationRowPatterns(rowLabel: string): string[] {
  * competitor by name, or within the competitor's column in a table row whose
  * label matches "provider" (case-insensitive).
  */
-function updateProviderCounts(
+export function updateProviderCounts(
   html: string,
   competitorName: string,
   detectedCount: number,
@@ -480,14 +553,9 @@ function updateProviderCounts(
   if (tableMatch) {
     const fullTable = tableMatch[0];
 
-    // Find the competitor's column index from headers
-    const thRegex = /<th[^>]*>([\s\S]*?)<\/th>/g;
-    const thTexts: string[] = [];
-    let thM: RegExpExecArray | null;
-    while ((thM = thRegex.exec(fullTable)) !== null) {
-      thTexts.push(thM[1].trim());
-    }
-    const compColIdx = thTexts.findIndex((t) => t.includes(competitorName) || t === competitorName);
+    // Find the competitor's column index by header name (shared with the
+    // feature-cell updater so both locate the same column).
+    const compColIdx = findMigrationCompetitorColumn(fullTable, competitorName);
 
     if (compColIdx >= 0) {
       // Find provider-related rows and update only the competitor's cell
@@ -510,14 +578,17 @@ function updateProviderCounts(
               changes.push(
                 `${competitorName}: provider count ${oldCount} -> ${detectedCount} (table)`,
               );
-              return tdMatch.replace(tdContent, updated);
+              // Function-form replacement keeps `updated` literal.
+              return tdMatch.replace(tdContent, () => updated);
             }
             return tdMatch;
           });
         },
       );
 
-      result = result.replace(fullTable, updatedTable);
+      // Function-form replacement keeps `updatedTable` literal so any $-sequence
+      // in the HTML is not interpreted by String.replace.
+      result = result.replace(fullTable, () => updatedTable);
     }
   }
 
@@ -556,7 +627,7 @@ function replaceProviderCount(text: string, detectedCount: number): string {
  * Parses the comparison table from docs/index.html.
  * Returns a map: competitorName -> { rowLabel -> cellText }
  */
-function parseCurrentMatrix(html: string): {
+export function parseCurrentMatrix(html: string): {
   headers: string[];
   rows: Map<string, Map<string, string>>;
 } {
@@ -610,7 +681,7 @@ function parseCurrentMatrix(html: string): {
  *
  * Only upgrades "No" -> "Yes", never downgrades.
  */
-function computeChanges(
+export function computeChanges(
   html: string,
   matrix: { headers: string[]; rows: Map<string, Map<string, string>> },
   competitorFeatures: Map<string, Record<string, boolean>>,
@@ -652,7 +723,7 @@ function computeChanges(
  * Applies detected changes to the HTML string by finding the exact table cells
  * and replacing them.
  */
-function applyChanges(html: string, changes: DetectedChange[]): string {
+export function applyChanges(html: string, changes: DetectedChange[]): string {
   if (changes.length === 0) return html;
 
   // We need to find each specific cell. The approach: locate each <tr> by its
@@ -716,7 +787,9 @@ function applyChanges(html: string, changes: DetectedChange[]): string {
       return fullMatch;
     });
 
-    result = result.replace(rowPattern, prefix + tdReplace + suffix);
+    // Function-form replacement keeps the HTML-derived text literal so any
+    // $ / $& / $1 in the row is not interpreted by String.replace.
+    result = result.replace(rowPattern, () => prefix + tdReplace + suffix);
   }
 
   return result;
@@ -909,7 +982,11 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error("Fatal error:", err);
-  process.exit(1);
-});
+// Only run when executed directly as a script (not when imported by tests).
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : "";
+if (import.meta.url === invokedPath) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/src/__tests__/competitive-matrix.test.ts
+++ b/src/__tests__/competitive-matrix.test.ts
@@ -1,481 +1,25 @@
 import { describe, it, expect } from "vitest";
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-// ── Reimplement pure functions from scripts/update-competitive-matrix.ts ─────
-// These mirror the logic so we can unit-test without requiring network access
-// or dealing with import.meta.dirname in the test runner.
+// These tests exercise the REAL functions from the drift-automation script
+// (not a reimplemented mirror), so behavioral bugs surface here directly.
+import {
+  countProviders,
+  extractFeatures,
+  buildMigrationRowPatterns,
+  updateProviderCounts,
+  updateMigrationPage,
+  parseCurrentMatrix,
+  computeChanges,
+  applyChanges,
+  COMPETITOR_MIGRATION_PAGES,
+  type DetectedChange,
+} from "../../scripts/update-competitive-matrix.ts";
 
-// ── Provider count detection ────────────────────────────────────────────────
-
-const PROVIDER_GROUPS: string[][] = [
-  ["openai"],
-  ["claude", "anthropic"],
-  ["gemini", "google.*ai"],
-  ["gemini.*interactions"],
-  ["bedrock", "aws"],
-  ["azure"],
-  ["vertex"],
-  ["ollama"],
-  ["cohere"],
-  ["mistral"],
-  ["groq"],
-  ["together"],
-  ["llama"],
-  ["elevenlabs"],
-];
-
-function countProviders(text: string): number {
-  const lower = text.toLowerCase();
-  let count = 0;
-  for (const group of PROVIDER_GROUPS) {
-    const found = group.some((kw) => new RegExp(kw, "i").test(lower));
-    if (found) count++;
-  }
-  return count;
-}
-
-// ── Feature rules (subset needed for tests) ────────────────────────────────
-
-interface FeatureRule {
-  rowLabel: string;
-  keywords: string[];
-}
-
-const FEATURE_RULES: FeatureRule[] = [
-  {
-    rowLabel: "Chat Completions SSE",
-    keywords: ["chat/completions", "streaming", "SSE", "server-sent", "stream.*true"],
-  },
-  {
-    rowLabel: "WebSocket APIs",
-    keywords: ["websocket", "realtime", "ws://", "wss://"],
-  },
-  {
-    rowLabel: "Embeddings API",
-    keywords: ["/v1/embeddings", "embeddings api", "embedding endpoint", "embedding model"],
-  },
-  {
-    rowLabel: "Image generation",
-    keywords: ["dall-e", "dalle", "/v1/images", "image generation", "imagen", "generate.*image"],
-  },
-  {
-    rowLabel: "Image editing",
-    keywords: ["/v1/images/edits", "image edit", "image editing", "inpainting", "edit.*image"],
-  },
-  {
-    rowLabel: "Non-speech audio",
-    keywords: [
-      "sound-generation",
-      "sound effect",
-      "music generation",
-      "elevenlabs",
-      "fal.ai",
-      "audio generation",
-      "non-speech audio",
-    ],
-  },
-  {
-    rowLabel: "Video generation",
-    keywords: ["sora", "/v1/videos", "video generation", "generate.*video"],
-  },
-  {
-    rowLabel: "Docker image",
-    keywords: ["dockerfile", "docker image", "docker-compose", "docker compose", "docker run"],
-  },
-  {
-    rowLabel: "Structured output / JSON mode",
-    keywords: ["json_object", "json_schema", "structured output", "response_format"],
-  },
-  {
-    rowLabel: "Realtime GA protocol",
-    keywords: [
-      "gpt-realtime-2",
-      "realtime.*ga",
-      "ga.*protocol",
-      "output_text\\.delta",
-      "conversation\\.item\\.added",
-    ],
-  },
-  {
-    rowLabel: "Realtime Beta compatibility",
-    keywords: [
-      "openai-beta.*realtime",
-      "realtime=v1",
-      "beta.*shim",
-      "beta.*compat",
-      "response\\.text\\.delta",
-    ],
-  },
-  {
-    rowLabel: "Realtime transcription/translation",
-    keywords: [
-      "gpt-4o-transcribe",
-      "gpt-4o-mini-transcribe",
-      "whisper-1",
-      "realtime.*transcription",
-      "realtime.*translation",
-    ],
-  },
-  {
-    rowLabel: "Realtime image input",
-    keywords: ["input_image.*realtime", "realtime.*image", "realtime.*vision"],
-  },
-  {
-    rowLabel: "Realtime commentary phase",
-    keywords: ["commentary.*phase", "phase.*commentary", "final_answer.*commentary"],
-  },
-  {
-    rowLabel: "Audio translation",
-    keywords: [
-      "/v1/audio/translations",
-      "audio translation",
-      "translate.*audio",
-      "audio.*translate",
-    ],
-  },
-  {
-    rowLabel: "Streaming usage chunks",
-    keywords: [
-      "stream_options",
-      "include_usage",
-      "streaming.*usage",
-      "usage.*chunk",
-      "usage.*stream",
-    ],
-  },
-  {
-    rowLabel: "Rate limiting headers",
-    keywords: ["x-ratelimit", "rate.limit.*header", "retry-after", "429.*retry", "rate.limiting"],
-  },
-];
-
-function extractFeatures(text: string): Record<string, boolean> {
-  const lower = text.toLowerCase();
-  const result: Record<string, boolean> = {};
-  for (const rule of FEATURE_RULES) {
-    const found = rule.keywords.some((kw) => {
-      const pattern = new RegExp(kw.toLowerCase(), "i");
-      return pattern.test(lower);
-    });
-    result[rule.rowLabel] = found;
-  }
-  return result;
-}
-
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
-}
-
-// ── Migration page row pattern builder ──────────────────────────────────────
-
-function buildMigrationRowPatterns(rowLabel: string): string[] {
-  const patterns = [rowLabel];
-  const variants: Record<string, string[]> = {
-    "Chat Completions SSE": ["OpenAI Chat Completions", "Streaming SSE"],
-    "Responses API SSE": ["OpenAI Responses API"],
-    "Claude Messages API": ["Anthropic Claude"],
-    "Gemini streaming": ["Google Gemini"],
-    "WebSocket APIs": ["WebSocket protocols"],
-    "Structured output / JSON mode": ["Structured output / JSON mode", "Structured output"],
-    "Sequential / stateful responses": ["Sequential responses"],
-    "Docker image": ["Docker"],
-    "Fixture files (JSON)": ["Fixture files"],
-    "CLI server": ["CLI"],
-    "Error injection (one-shot)": ["Error injection"],
-    "Request journal": ["Request journal"],
-    "Drift detection": ["Drift detection"],
-    "Realtime GA protocol": ["Realtime GA protocol", "GA Realtime"],
-    "Realtime Beta compatibility": ["Realtime Beta compatibility", "Beta Realtime"],
-    "Realtime translate/whisper": ["Realtime translate/whisper", "Translate/Whisper"],
-    "Realtime image input": ["Realtime image input"],
-    "Realtime commentary phase": ["Realtime commentary phase", "Commentary phase"],
-    "Image editing": ["Image editing", "Image edit"],
-    "Audio translation": ["Audio translation", "Audio translations"],
-    "Streaming usage chunks": ["Streaming usage chunks", "Streaming usage"],
-    "Rate limiting headers": ["Rate limiting headers", "Rate limiting"],
-  };
-  if (variants[rowLabel]) {
-    patterns.push(...variants[rowLabel]);
-  }
-  return patterns;
-}
-
-// ── Provider count update logic (scoped version) ───────────────────────────
-
-/** Replaces "N providers" or "N+ providers" in a string if detected > current */
-function replaceProviderCount(text: string, detectedCount: number): string {
-  return text.replace(/(\d+)\+?\s*(?:LLM\s*)?providers?/gi, (match, numStr) => {
-    const currentCount = parseInt(numStr, 10);
-    if (detectedCount > currentCount) {
-      return `${detectedCount} providers`;
-    }
-    return match;
-  });
-}
-
-function updateProviderCounts(
-  html: string,
-  competitorName: string,
-  detectedCount: number,
-  changes: string[],
-): string {
-  let result = html;
-  const escapedName = escapeRegex(competitorName);
-
-  // Strategy 1: Replace provider counts in table rows about providers,
-  // scoped to the competitor's column.
-  const tableMatch = result.match(
-    /<table class="(?:comparison-table|endpoint-table)">([\s\S]*?)<\/table>/,
-  );
-  if (tableMatch) {
-    const fullTable = tableMatch[0];
-
-    // Find the competitor's column index from headers
-    const thRegex = /<th[^>]*>([\s\S]*?)<\/th>/g;
-    const thTexts: string[] = [];
-    let thM: RegExpExecArray | null;
-    while ((thM = thRegex.exec(fullTable)) !== null) {
-      thTexts.push(thM[1].trim());
-    }
-    const compColIdx = thTexts.findIndex((t) => t.includes(competitorName) || t === competitorName);
-
-    if (compColIdx >= 0) {
-      const updatedTable = fullTable.replace(
-        /<tr>([\s\S]*?)<\/tr>/g,
-        (trMatch, trContent: string) => {
-          const firstTd = trContent.match(/<td[^>]*>([\s\S]*?)<\/td>/);
-          if (!firstTd || !/provider/i.test(firstTd[1])) return trMatch;
-
-          let cellIdx = 0;
-          return trMatch.replace(/<td[^>]*>([\s\S]*?)<\/td>/g, (tdMatch, tdContent: string) => {
-            const currentIdx = cellIdx++;
-            if (currentIdx !== compColIdx) return tdMatch;
-
-            const updated = replaceProviderCount(tdContent, detectedCount);
-            if (updated !== tdContent) {
-              const oldCount = tdContent.match(/(\d+)/)?.[1] ?? "?";
-              changes.push(
-                `${competitorName}: provider count ${oldCount} -> ${detectedCount} (table)`,
-              );
-              return tdMatch.replace(tdContent, updated);
-            }
-            return tdMatch;
-          });
-        },
-      );
-
-      result = result.replace(fullTable, updatedTable);
-    }
-  }
-
-  // Strategy 2: Replace provider counts in prose paragraphs/sentences that
-  // explicitly mention the competitor by name.
-  const prosePattern = new RegExp(
-    `(<[^>]*>[^<]*${escapedName}[^<]*)(\\d+)\\+?\\s*(?:LLM\\s*)?providers?`,
-    "gi",
-  );
-  result = result.replace(prosePattern, (match, prefix, numStr) => {
-    const currentCount = parseInt(numStr, 10);
-    if (detectedCount > currentCount) {
-      changes.push(`${competitorName}: provider count ${currentCount} -> ${detectedCount} (prose)`);
-      return match.replace(/(\d+)\+?\s*(?:LLM\s*)?providers?/, `${detectedCount} providers`);
-    }
-    return match;
-  });
-
-  return result;
-}
-
-// ── Migration page update logic ─────────────────────────────────────────────
-
-function updateMigrationPage(
-  html: string,
-  competitorName: string,
-  features: Record<string, boolean>,
-  providerCount: number,
-): { html: string; changes: string[] } {
-  let result = html;
-  const changes: string[] = [];
-
-  const tableMatch = result.match(
-    /<table class="(?:comparison-table|endpoint-table)">([\s\S]*?)<\/table>/,
-  );
-  if (!tableMatch) {
-    return { html: result, changes };
-  }
-
-  for (const rule of FEATURE_RULES) {
-    if (!features[rule.rowLabel]) continue;
-
-    const rowPatterns = buildMigrationRowPatterns(rule.rowLabel);
-    for (const rowPat of rowPatterns) {
-      const rowRegex = new RegExp(
-        `(<tr>\\s*<td>${escapeRegex(rowPat)}</td>\\s*)<td style="color: var\\(--error\\)">&#10007;</td>`,
-      );
-      if (rowRegex.test(result)) {
-        result = result.replace(rowRegex, `$1<td style="color: var(--accent)">&#10003;</td>`);
-        changes.push(`${competitorName}: ${rowPat} ✗ -> ✓`);
-      }
-    }
-  }
-
-  if (providerCount > 0) {
-    result = updateProviderCounts(result, competitorName, providerCount, changes);
-  }
-
-  return { html: result, changes };
-}
-
-// ── parseCurrentMatrix reimplementation for testing ────────────────────────
-
-function parseCurrentMatrix(html: string): {
-  headers: string[];
-  rows: Map<string, Map<string, string>>;
-} {
-  const tableMatch = html.match(/<table class="comparison-table">([\s\S]*?)<\/table>/);
-  if (!tableMatch) {
-    throw new Error("Could not find comparison-table in HTML");
-  }
-  const tableHtml = tableMatch[1];
-
-  const thRegex = /<th[^>]*>[\s\S]*?<a[^>]*>(.*?)<\/a[\s\S]*?<\/th>/g;
-  const headers: string[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = thRegex.exec(tableHtml)) !== null) {
-    headers.push(m[1].trim());
-  }
-
-  const rows = new Map<string, Map<string, string>>();
-  const tbody = tableHtml.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] ?? "";
-  let tr: RegExpExecArray | null;
-  const trIter = new RegExp(/<tr>([\s\S]*?)<\/tr>/g);
-
-  while ((tr = trIter.exec(tbody)) !== null) {
-    const tds: string[] = [];
-    const tdRegex = /<td[^>]*>([\s\S]*?)<\/td>/g;
-    let td: RegExpExecArray | null;
-    while ((td = tdRegex.exec(tr[1])) !== null) {
-      tds.push(td[1].trim());
-    }
-    if (tds.length < 2) continue;
-
-    const rowLabel = tds[0];
-    const rowMap = new Map<string, string>();
-    for (let i = 1; i < tds.length && i - 1 < headers.length; i++) {
-      rowMap.set(headers[i - 1], tds[i]);
-    }
-    rows.set(rowLabel, rowMap);
-  }
-
-  return { headers, rows };
-}
-
-// ── computeChanges reimplementation (mirrors fixed version) ────────────────
-
-interface DetectedChange {
-  competitor: string;
-  capability: string;
-  from: string;
-  to: string;
-}
-
-function computeChanges(
-  _html: string,
-  matrix: { headers: string[]; rows: Map<string, Map<string, string>> },
-  competitorFeatures: Map<string, Record<string, boolean>>,
-): DetectedChange[] {
-  const changes: DetectedChange[] = [];
-
-  for (const [compName, features] of competitorFeatures) {
-    for (const [rowLabel, detected] of Object.entries(features)) {
-      if (!detected) continue;
-
-      const row = matrix.rows.get(rowLabel);
-      if (!row) continue;
-
-      const currentCell = row.get(compName);
-      if (!currentCell) continue;
-
-      // Only upgrade "No" cells — cells contain inner HTML like
-      // '<span class="no">&#10007;</span>', not bare "No" text.
-      if (
-        currentCell.includes('class="no"') ||
-        currentCell.includes("\u2717") ||
-        currentCell.includes("&#10007;")
-      ) {
-        changes.push({
-          competitor: compName,
-          capability: rowLabel,
-          from: "No",
-          to: "Yes",
-        });
-      }
-    }
-  }
-
-  return changes;
-}
-
-// ── applyChanges reimplementation (mirrors fixed version) ──────────────────
-
-function applyChanges(html: string, changes: DetectedChange[]): string {
-  if (changes.length === 0) return html;
-
-  const tableMatch = html.match(/<table class="comparison-table">([\s\S]*?)<\/table>/);
-  if (!tableMatch) return html;
-
-  const theadMatch = tableMatch[1].match(/<thead>([\s\S]*?)<\/thead>/);
-  if (!theadMatch) return html;
-
-  const thRegex = /<th[^>]*>[\s\S]*?<a[^>]*>(.*?)<\/a[\s\S]*?<\/th>/g;
-  const headers: string[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = thRegex.exec(theadMatch[1])) !== null) {
-    headers.push(m[1].trim());
-  }
-
-  const compColumnIndex = (name: string): number => {
-    const idx = headers.indexOf(name);
-    return idx === -1 ? -1 : idx + 1;
-  };
-
-  let result = html;
-
-  for (const change of changes) {
-    const colIdx = compColumnIndex(change.competitor);
-    if (colIdx === -1) continue;
-
-    const rowPattern = new RegExp(
-      `(<tr>\\s*<td>\\s*${escapeRegex(change.capability)}\\s*</td>)([\\s\\S]*?)(</tr>)`,
-    );
-    const rowMatch = result.match(rowPattern);
-    if (!rowMatch) continue;
-
-    const prefix = rowMatch[1];
-    const cellsHtml = rowMatch[2];
-    const suffix = rowMatch[3];
-
-    const targetTdIdx = colIdx - 1;
-    let tdCount = 0;
-    const tdReplace = cellsHtml.replace(/<td[^>]*>([\s\S]*?)<\/td>/g, (fullMatch, content) => {
-      const currentIdx = tdCount++;
-      if (
-        currentIdx === targetTdIdx &&
-        (content.includes('class="no"') ||
-          content.includes("\u2717") ||
-          content.includes("&#10007;"))
-      ) {
-        return `<td><span class="yes">&#10003;</span></td>`;
-      }
-      return fullMatch;
-    });
-
-    result = result.replace(rowPattern, prefix + tdReplace + suffix);
-  }
-
-  return result;
-}
-
-// ── Tests ───────────────────────────────────────────────────────────────────
+// Repo root: this file lives at <root>/src/__tests__/, so up two levels.
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
 describe("provider count extraction from README text", () => {
   it("counts distinct providers from a README mentioning several", () => {
@@ -500,12 +44,12 @@ describe("provider count extraction from README text", () => {
     expect(countProviders("This is a generic testing library.")).toBe(0);
   });
 
-  it("counts all 14 provider groups when all are mentioned", () => {
+  it("counts all 13 provider groups when all are mentioned (Gemini Interactions is not its own group)", () => {
     const readme = `
       OpenAI, Claude, Gemini, Gemini Interactions, Bedrock, Azure, Vertex AI,
       Ollama, Cohere, Mistral, Groq, Together AI, Llama, ElevenLabs
     `;
-    expect(countProviders(readme)).toBe(14);
+    expect(countProviders(readme)).toBe(13);
   });
 
   it("is case-insensitive", () => {
@@ -908,8 +452,6 @@ describe("parseCurrentMatrix header extraction", () => {
   });
 });
 
-// ── computeChanges tests with actual HTML structure ────────────────────────
-
 describe("computeChanges with actual HTML cell structure", () => {
   // This matrix uses the actual HTML structure from docs/index.html:
   // cells contain <span class="no">&#10007;</span> not bare "No"
@@ -1018,8 +560,6 @@ describe("computeChanges with actual HTML cell structure", () => {
   });
 });
 
-// ── applyChanges tests with actual HTML structure ──────────────────────────
-
 describe("applyChanges with actual HTML cell structure", () => {
   const ACTUAL_HTML_MATRIX = `
 <table class="comparison-table">
@@ -1103,8 +643,6 @@ describe("applyChanges with actual HTML cell structure", () => {
   });
 });
 
-// ── extractFeatures tests (tightened keyword patterns) ─────────────────────
-
 describe("extractFeatures keyword precision", () => {
   it("does not trigger Embeddings API on bare word 'embed'", () => {
     const text = "You can embed this widget in your page.";
@@ -1164,5 +702,205 @@ describe("extractFeatures keyword precision", () => {
     const text = "Run with: docker run -p 8080:8080 aimock";
     const features = extractFeatures(text);
     expect(features["Docker image"]).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Regression coverage for the 6 pre-existing drift-automation bugs. Each block
+// is a red→green repro: it fails against the pre-fix script and passes after.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── Bug 1: migration-page paths must resolve; missing competitor mapping ─────
+describe("Bug 1: COMPETITOR_MIGRATION_PAGES", () => {
+  it("maps every mapped competitor to a file that actually exists on disk", () => {
+    for (const [competitor, relPath] of Object.entries(COMPETITOR_MIGRATION_PAGES)) {
+      const abs = resolve(REPO_ROOT, relPath);
+      expect(existsSync(abs), `${competitor} -> ${relPath} should exist`).toBe(true);
+    }
+  });
+
+  it("includes a mapping for the mokksy/ai-mocks competitor", () => {
+    expect(COMPETITOR_MIGRATION_PAGES["mokksy/ai-mocks"]).toBeDefined();
+  });
+});
+
+// ── Bug 2: unanchored keyword regexes → false substring flips ────────────────
+describe("Bug 2: extractFeatures keyword anchoring", () => {
+  it('does not flip "CLI server" from the words "client"/"click"', () => {
+    const feats = extractFeatures("This mock has a Python client library and you click buttons.");
+    expect(feats["CLI server"]).toBe(false);
+  });
+
+  it('does not flip "Chat Completions SSE" from the word "assess"', () => {
+    const feats = extractFeatures("We assess the output quality carefully.");
+    expect(feats["Chat Completions SSE"]).toBe(false);
+  });
+
+  it("still detects a genuine standalone CLI mention", () => {
+    const feats = extractFeatures("Run it via npx or the cli command.");
+    expect(feats["CLI server"]).toBe(true);
+  });
+
+  it("still detects a genuine standalone SSE / streaming mention", () => {
+    const feats = extractFeatures("Supports SSE streaming responses.");
+    expect(feats["Chat Completions SSE"]).toBe(true);
+  });
+});
+
+// ── Bug 3: countProviders substring inflation + redundant group ──────────────
+describe("Bug 3: countProviders substring safety", () => {
+  it('does not count "cohere" inside "coherent" or "aws" inside "flaws"', () => {
+    expect(countProviders("The system is coherent and has flaws.")).toBe(0);
+  });
+
+  it("counts Gemini exactly once (no redundant gemini-interactions group)", () => {
+    expect(countProviders("gemini interactions with the model")).toBe(1);
+  });
+});
+
+// ── Bug 4: String.replace $-sequence corruption ──────────────────────────────
+describe("Bug 4: literal $-sequences in HTML replacements stay literal", () => {
+  const matrixWithDollar = `
+<table class="comparison-table">
+  <thead>
+    <tr>
+      <th>Capability</th>
+      <th class="col-aimock"><a href="#">aimock</a></th>
+      <th><a href="#">VidaiMock</a></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Docker image</td>
+      <td class="col-aimock"><span class="yes">&#10003; price $&amp;</span></td>
+      <td><span class="no">&#10007;</span></td>
+    </tr>
+  </tbody>
+</table>`;
+
+  it("applyChanges does not duplicate the row when replacement text contains $&", () => {
+    const result = applyChanges(matrixWithDollar, [
+      { competitor: "VidaiMock", capability: "Docker image", from: "No", to: "Yes" },
+    ]);
+    // The competitor cell flips to "yes".
+    expect(result).toContain('<td><span class="yes">&#10003;</span></td>');
+    // The row label must appear exactly once — a $&-expanding replace duplicates it.
+    expect((result.match(/Docker image/g) || []).length).toBe(1);
+  });
+
+  it("updateProviderCounts does not corrupt the table when a cell contains $&", () => {
+    const migration = `
+<table class="comparison-table">
+  <thead>
+    <tr><th>Capability</th><th>VidaiMock</th><th>aimock</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>LLM providers supported</td>
+      <td style="color: var(--text-dim)">3 providers $&amp;</td>
+      <td style="color: var(--accent)">13 providers</td>
+    </tr>
+  </tbody>
+</table>`;
+    const changes: string[] = [];
+    const result = updateProviderCounts(migration, "VidaiMock", 8, changes);
+    expect(result).toContain("8 providers");
+    // Table label must not be duplicated by $&-expansion.
+    expect((result.match(/LLM providers supported/g) || []).length).toBe(1);
+  });
+});
+
+// ── Bug 5: migration cell column located by header name, not adjacency ───────
+describe("Bug 5: migration cell column resolution by header name", () => {
+  it("flips the competitor cell even when aimock is the first data column", () => {
+    const migration = `
+<table class="comparison-table">
+  <thead>
+    <tr><th>Capability</th><th>aimock</th><th>VidaiMock</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Docker</td>
+      <td style="color: var(--accent)">&#10003;</td>
+      <td style="color: var(--error)">&#10007;</td>
+    </tr>
+  </tbody>
+</table>`;
+    const { html } = updateMigrationPage(migration, "VidaiMock", { "Docker image": true }, 0);
+    // The only error cell (VidaiMock) must be flipped to accent; none remain,
+    // and aimock's original accent cell is untouched (2 accent cells total).
+    expect(html).not.toContain("var(--error)");
+    expect((html.match(/var\(--accent\)/g) || []).length).toBe(2);
+  });
+
+  it("resolves the column when the header text differs from the competitor key (Mokksy)", () => {
+    const migration = `
+<table class="comparison-table">
+  <thead>
+    <tr><th>Capability</th><th>Mokksy</th><th>aimock</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>LLM providers supported</td>
+      <td style="color: var(--text-dim)">3 providers</td>
+      <td style="color: var(--accent)">13 providers</td>
+    </tr>
+  </tbody>
+</table>`;
+    const { html } = updateMigrationPage(migration, "mokksy/ai-mocks", {}, 8);
+    expect(html).toContain("8 providers");
+  });
+});
+
+// ── Bug 6: orphaned variant key renamed to the real FEATURE_RULE label ───────
+describe("Bug 6: buildMigrationRowPatterns realtime variant key", () => {
+  it("returns variants for the real rule label 'Realtime transcription/translation'", () => {
+    const patterns = buildMigrationRowPatterns("Realtime transcription/translation");
+    expect(patterns.length).toBeGreaterThan(1);
+    expect(patterns).toContain("Translate/Whisper");
+  });
+
+  it("flips a migration row that uses a variant label for the realtime rule", () => {
+    const migration = `
+<table class="comparison-table">
+  <thead>
+    <tr><th>Capability</th><th>VidaiMock</th><th>aimock</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Translate/Whisper</td>
+      <td style="color: var(--error)">&#10007;</td>
+      <td style="color: var(--accent)">&#10003;</td>
+    </tr>
+  </tbody>
+</table>`;
+    const { html, changes } = updateMigrationPage(
+      migration,
+      "VidaiMock",
+      { "Realtime transcription/translation": true },
+      0,
+    );
+    expect(changes.length).toBeGreaterThan(0);
+    expect(html).not.toContain("var(--error)");
+  });
+});
+
+// ── Regression guard: PR #328 OpenRouter entry must keep working ─────────────
+describe("Regression guard: OpenRouter router / fallback simulation (PR #328)", () => {
+  const ROW = "OpenRouter router / fallback simulation";
+
+  it("detects OpenRouter fallback signals", () => {
+    const feats = extractFeatures("Supports OpenRouter with allow_fallbacks and provider routing.");
+    expect(feats[ROW]).toBe(true);
+  });
+
+  it("does not false-trigger on an unrelated 'router' mention", () => {
+    const feats = extractFeatures("This is a router for plain HTTP requests.");
+    expect(feats[ROW]).toBe(false);
+  });
+
+  it("keeps its migration row variants", () => {
+    const patterns = buildMigrationRowPatterns(ROW);
+    expect(patterns).toContain("Model fallback/failover");
   });
 });


### PR DESCRIPTION
## Why

`scripts/update-competitive-matrix.ts` runs weekly (`.github/workflows/update-competitive-matrix.yml`) and **auto-commits to public, customer-facing docs** (`docs/index.html` and `docs/migrate-from-*/index.html`). Six pre-existing bugs (all predate #328) caused it to write wrong data or silently skip updates. This PR fixes all six and adds real red→green regression coverage.

`#328`'s single new FEATURE_RULES entry ("OpenRouter router / fallback simulation") and its migration-variant entry are **left untouched** and are covered by an explicit regression guard.

## The 6 bugs & fixes

| # | Bug | Fix |
|---|-----|-----|
| 1 | `COMPETITOR_MIGRATION_PAGES` mapped to `docs/migrate-from-*.html`, but the pages are **directories** (`.../index.html`), so `existsSync` always failed → every migration-page update silently skipped. `mokksy/ai-mocks` had no mapping at all. | Paths → `/index.html`; added the `mokksy/ai-mocks` mapping. (Note: `VidaiMock` was already mapped; the genuinely missing competitor was `mokksy/ai-mocks`.) |
| 2 | Unanchored keyword regexes: `cli`→"client"/"click", `sse`→"assess" → false ✗→✓ flips in public docs. | New `keywordRegex()` wraps each keyword in non-alphanumeric boundary lookarounds `(?<![a-z0-9])…(?![a-z0-9])`; works for literal tokens, path/regex keywords, and edge-punctuation keywords alike. |
| 3 | `countProviders` over-counted via substrings (`cohere`→"coherent", `aws`→"flaws") plus a redundant `gemini.*interactions` group double-counting Gemini. | Bounded matching (same helper) + removed the redundant group (13 groups, each provider counted once). |
| 4 | `String.replace(pattern, htmlString)` let literal `$`, `$&`, `$1` in HTML be interpreted → corrupted/duplicated output (3 sites). | Switched the HTML-derived replacements to **function form** `(…) => text` so replacement text stays literal. |
| 5 | Migration feature-cell updater assumed the competitor column was adjacent to the label; the provider-count updater located it by header **name** — they disagreed when an intervening column (e.g. aimock) existed. | Both now use one shared `findMigrationCompetitorColumn()` (token-aware header-name match — avoids the `"vidaimock"⊇"aimock"` substring trap). |
| 6 | Orphaned variant key `"Realtime translate/whisper"` never matched its rule label `"Realtime transcription/translation"` → that rule got no migration variants, cells never flipped. | Renamed the key to match the rule label exactly. |

## Tests

A 1168-line `competitive-matrix.test.ts` already existed but **reimplemented the script logic inline** (a mirror), so it tested copies that mirrored the bugs — it could never catch them. Converted it to **import the real script** (added `export`s + an `import.meta` main-guard so importing doesn't run `main()`), fixed the one assertion that encoded the buggy behavior (`countProviders` all-groups `14`→`13`), and added red→green repros for each bug plus a regression guard for the OpenRouter entry.

## Red → Green (fixture-based, no network)

**RED** — bug repros run against the pre-fix script (enabling refactor only, no behavioral change):

```
Tests  13 failed | 49 passed (62)
```
The 13 failures were exactly:
- Bug 1: `maps every mapped competitor to a file that actually exists on disk`; `includes a mapping for the mokksy/ai-mocks competitor`
- Bug 2: `does not flip "CLI server" from the words "client"/"click"`; `does not flip "Chat Completions SSE" from the word "assess"`
- Bug 3: `does not count "cohere" inside "coherent" or "aws" inside "flaws"`; `counts Gemini exactly once`; `counts all 13 provider groups …`
- Bug 4: `applyChanges does not duplicate the row when replacement text contains $&`; `updateProviderCounts does not corrupt the table when a cell contains $&`
- Bug 5: `flips the competitor cell even when aimock is the first data column`; `resolves the column when the header text differs from the competitor key (Mokksy)`
- Bug 6: `returns variants for the real rule label 'Realtime transcription/translation'`; `flips a migration row that uses a variant label for the realtime rule`

(The #328 OpenRouter guard tests and the positive-control tests passed in the RED run, as expected.)

**GREEN** — after the 6 fixes:

```
✓ src/__tests__/competitive-matrix.test.ts (62 tests)
Test Files  1 passed (1)
      Tests  62 passed (62)
```

**Full suite / build / lint** (no regressions):

```
Tests  4706 passed | 44 skipped (4750)     # vitest run
Build complete                              # pnpm build (tsdown)
All matched files use Prettier code style!  # pnpm format:check
eslint .  → 0 problems                      # pnpm lint
```

**Live end-to-end** — `npx tsx scripts/update-competitive-matrix.ts --dry-run` against real GitHub still fires `main()`, parses all 4 competitors + the 38-row / 6-column matrix, and reports "No changes detected" (no spurious flips).

## Scope / safety
- No package version bump (this is scripts/docs tooling, not the published package surface).
- `#328`'s FEATURE_RULES + variant entry unchanged; guarded by regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KamK73Wu5heLxJEogM6hHC
