### PR TITLE
test(drift): drift guard and collector hardening (split out of #343)

### DIFF
--- a/scripts/drift-delta.ts
+++ b/scripts/drift-delta.ts
@@ -26,9 +26,9 @@ import type { DriftClass, DriftReport } from "./drift-types.js";
  * A single failure identified by the delta layer.
  *
  * A failure is keyed by `provider` + per-item `id` (NOT `path`, which is a
- * generic bucket like `"knownModels"` that would collapse N distinct model
- * drifts into one key). `class` is carried through purely for annotation and
- * never participates in routing.
+ * generic bucket like `"knownVoiceModelFamilies"` that would collapse N
+ * distinct model drifts into one key). `class` is carried through purely for
+ * annotation and never participates in routing.
  */
 export interface DeltaKey {
   /** Provider the failing entry belongs to (e.g. "anthropic"). */

--- a/scripts/drift-delta.ts
+++ b/scripts/drift-delta.ts
@@ -69,6 +69,8 @@ function indexReport(report: DriftReport): Map<string, DeltaKey> {
   for (const entry of report.entries) {
     for (const diff of entry.diffs) {
       // `id` is the stable per-item key; `path` is the legacy fallback bucket.
+      // Changing how a diff keys re-keys it against the origin/main base while the
+      // change is unmerged — see the transition note on isBaseReportReusable.
       const id = diff.id ?? diff.path;
       const key = keyOf(entry.provider, id);
       index.set(key, { provider: entry.provider, id, class: diff.class });
@@ -130,6 +132,15 @@ const REUSABLE_CONCLUSIONS: ReadonlySet<string> = new Set(["clean", "success"]);
  *      would misattribute a day's worth of environmental drift to the PR.
  *
  * Anything else → not reusable → caller should run a fresh live base.
+ *
+ * There is deliberately NO check that the base report was produced by the SAME
+ * collector code as the head report — the base comes from `origin/main`. So while
+ * a PR that changes how a diff is keyed is unmerged, base and head key the same
+ * drift differently: the base key shows up as `fixed` and the head key as `block`,
+ * and a non-empty `block` exits 1 (a hard required-check failure). That is
+ * EXPECTED during such a transition, it only fires if real drift appears while the
+ * PR is open, and it clears the moment the change reaches main and the next base is
+ * collected by the new code.
  */
 export function isBaseReportReusable(
   report: DriftReport | null | undefined,

--- a/scripts/drift-report-collector.ts
+++ b/scripts/drift-report-collector.ts
@@ -685,6 +685,29 @@ export interface CollectResult {
   quarantine: QuarantineEntry[];
 }
 
+/**
+ * Stable delta keys for the two realtime-canary diffs that have no per-model id.
+ *
+ * drift-delta keys a failure by `provider + (diff.id ?? diff.path)`. Both diffs
+ * below used to carry no `id`, so their delta key WAS their `path` — which is
+ * also the human-facing "Path:" line of the alert. That coupling means renaming
+ * the alert prose silently MOVES the key: drift already recorded in the cached
+ * same-UTC-day BASE report is re-classified as new-in-head (BLOCK) and the base
+ * key is reported as spuriously "fixed". It bit us once already, when these two
+ * `path` values were corrected to name the symbols that actually exist
+ * (`gaRealtimeModels` / `knownVoiceModelFamilies`) instead of the retired ones.
+ *
+ * Freezing the display string is the wrong fix — a `Path:` naming a nonexistent
+ * symbol is exactly what drift-remediation-strings.test.ts exists to prevent. So
+ * the key is instead an explicit SEMANTIC id that never appears in prose: the
+ * display text is now free to change without moving any key.
+ *
+ * These values are the wire contract of the delta layer. Renaming one shifts the
+ * key exactly as the old path rename did — don't, unless that is the intent.
+ */
+export const NO_GA_DELTA_ID = "openai-realtime:no-ga-family";
+export const TRUNCATED_DELTA_ID = "openai-realtime:unknown-models-truncated";
+
 export function collectDriftEntries(results: VitestJsonResult): CollectResult {
   const entries: DriftEntry[] = [];
   const quarantine: QuarantineEntry[] = [];
@@ -730,6 +753,11 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
                       ? `observed realtime models: ${canary.ids.join(", ")}`
                       : "no realtime models observed",
                   mock: NO_MOCK_LEG,
+                  // There is no per-model id for this diff (it reports the
+                  // ABSENCE of a family), so without an explicit id the delta
+                  // layer would key it by `path` — coupling the key to the alert
+                  // prose. See NO_GA_DELTA_ID.
+                  id: NO_GA_DELTA_ID,
                 },
                 // The hasGA assertion short-circuits the later unknown-models
                 // assertion, so surface any unknown models observed in the SAME
@@ -785,6 +813,10 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
                         expected: "<unavailable>",
                         real: "<unavailable>",
                         mock: NO_MOCK_LEG,
+                        // No per-model id exists here either (the ids are the
+                        // thing that was truncated away), so the key must be
+                        // explicit. See TRUNCATED_DELTA_ID.
+                        id: TRUNCATED_DELTA_ID,
                       },
                     ]
                   : []),

--- a/scripts/drift-report-collector.ts
+++ b/scripts/drift-report-collector.ts
@@ -722,8 +722,8 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
                   issue:
                     "GA realtime family unavailable — no known GA model in the OpenAI realtime list. " +
                     "OpenAI may have renamed/removed the GA family, or the realtime credential cannot see it. " +
-                    "Update the gaModels list in ws-realtime.drift.ts.",
-                  path: "gaModels",
+                    "Update gaRealtimeModels in src/__tests__/drift/voice-models.ts.",
+                  path: "gaRealtimeModels",
                   expected: "(at least one GA realtime model present)",
                   real:
                     canary.ids.length > 0
@@ -742,13 +742,13 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
                   issue:
                     "Unknown realtime model detected (observed in the same run as the missing GA " +
                     "family) — add to knownVoiceModelFamilies in src/__tests__/drift/voice-models.ts",
-                  path: "knownModels",
-                  expected: "(not in knownModels set)",
+                  path: "knownVoiceModelFamilies",
+                  expected: "(not in knownVoiceModelFamilies)",
                   real: id,
                   mock: NO_MOCK_LEG,
                   // D6.2: set `id` to the model id so the delta layer (D6.1)
                   // can key by provider+id, yielding one distinct key per model
-                  // rather than collapsing all entries under path:"knownModels".
+                  // rather than collapsing all entries under one path bucket.
                   id,
                 })),
               ]
@@ -761,13 +761,13 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
                   issue:
                     "Unknown realtime model detected — add to knownVoiceModelFamilies in " +
                     "src/__tests__/drift/voice-models.ts",
-                  path: "knownModels",
-                  expected: "(not in knownModels set)",
+                  path: "knownVoiceModelFamilies",
+                  expected: "(not in knownVoiceModelFamilies)",
                   real: id,
                   mock: NO_MOCK_LEG,
                   // D6.2: set `id` to the model id so the delta layer (D6.1)
                   // can key by provider+id, yielding one distinct key per model
-                  // rather than collapsing all entries under path:"knownModels".
+                  // rather than collapsing all entries under one path bucket.
                   id,
                 })),
                 ...(canary.truncated
@@ -778,7 +778,7 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
                           "Additional unknown realtime models were truncated in CI output — " +
                           "the full list is unrecoverable without the UNKNOWN_REALTIME_MODELS= marker. " +
                           "Re-run with the marker to enumerate them.",
-                        path: "knownModels[truncated]",
+                        path: "knownVoiceModelFamilies[truncated]",
                         // CLASS 3: `real`/`expected` NEVER carry a prose sentinel.
                         // The truncation fact lives entirely in `issue`/`path`;
                         // there is no observed model value to report here.

--- a/scripts/drift-report-collector.ts
+++ b/scripts/drift-report-collector.ts
@@ -741,7 +741,7 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
                   severity: "critical" as const,
                   issue:
                     "Unknown realtime model detected (observed in the same run as the missing GA " +
-                    "family) — add to knownModels in ws-realtime.drift.ts",
+                    "family) — add to knownVoiceModelFamilies in src/__tests__/drift/voice-models.ts",
                   path: "knownModels",
                   expected: "(not in knownModels set)",
                   real: id,
@@ -759,7 +759,8 @@ export function collectDriftEntries(results: VitestJsonResult): CollectResult {
                 ...canary.ids.map((id) => ({
                   severity: "critical" as const,
                   issue:
-                    "Unknown realtime model detected — add to knownModels in ws-realtime.drift.ts",
+                    "Unknown realtime model detected — add to knownVoiceModelFamilies in " +
+                    "src/__tests__/drift/voice-models.ts",
                   path: "knownModels",
                   expected: "(not in knownModels set)",
                   real: id,

--- a/scripts/drift-report-collector.ts
+++ b/scripts/drift-report-collector.ts
@@ -185,19 +185,37 @@ export function extractSurfaceKey(text: string): string | null {
 
 /**
  * LEGACY provider-name fallback for a drift block that carries NO `Surface:`
- * marker (predates the slug marker, or a path not yet migrated). Matches the
- * text against the registry's human `provider` labels (longest first to avoid
- * partial matches). Newer blocks resolve structurally via `extractSurfaceKey`;
- * this exists only as a defensive back-compat net.
+ * marker (predates the slug marker, or a path not yet migrated). Newer blocks
+ * resolve structurally via `extractSurfaceKey`; this exists only as a defensive
+ * back-compat net.
+ *
+ * ANCHORED AT THE START, longest label first. It used to accept a label found
+ * ANYWHERE in the text and rank candidates by length alone, so a qualifier later
+ * in the title could outrank the surface the title is about: "Gemini Live
+ * Transcription session" resolved to `Transcription` (13 chars) over `Gemini
+ * Live` (11) and routed a Gemini Live drift at `src/transcription.ts`. That
+ * failed OPEN — a confident wrong owner, no error, and the entry then drives
+ * remediation. Both inputs this is called with lead with the provider label:
+ * `parsed.context` is `formatDriftReport`'s "<Provider> (<scenario>)", and a drift
+ * describe title reads "<Provider> <rest>". So an unanchored occurrence is not
+ * evidence of ownership, and a text that does not START with a known label is
+ * unattributable → null → the caller quarantines it for human review (exit 5)
+ * rather than inventing an owner.
+ *
+ * Longest-first still resolves genuinely nested labels at the same anchor
+ * ("Google Gemini" over "Gemini", "Bedrock ConverseStream" over "Bedrock
+ * Converse", "OpenAI Responses WS" over "OpenAI Responses").
  *
  * Examples:
- *   "OpenAI Chat Completions drift" → "OpenAI Chat"
- *   "Anthropic Claude drift" → "Anthropic Claude"
+ *   "OpenAI Chat Completions drift"      → "OpenAI Chat"
+ *   "Anthropic Claude drift"             → "Anthropic Claude"
+ *   "Gemini Live Transcription session"  → "Gemini Live"  (not "Transcription")
+ *   "drift detected in OpenAI Chat"      → null           (not anchored)
  */
 export function extractProviderName(text: string): string | null {
   const sorted = Object.keys(PROVIDER_LABEL_MAP).sort((a, b) => b.length - a.length);
   for (const key of sorted) {
-    if (text.includes(key)) return key;
+    if (text.startsWith(key)) return key;
   }
   return null;
 }

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -9,7 +9,8 @@
  *
  * The canary fixtures below are REAL vitest failure-message shapes captured by
  * running the canary / drift / infra assertions under
- * `vitest run … --reporter=json` (see PR #291 RED/GREEN logs under tmp/). They
+ * `vitest run … --reporter=json` (the capture artifacts were throwaway and are
+ * not in the repo; the RED/GREEN logs are on PR #291). They
  * are NOT hand-authored: the single-glyph Unicode ellipsis `…(N)`, the
  * `AssertionError:` prefix, the leading blank line before a formatted drift
  * report, and the stack-frame layout are exactly what vitest emits.
@@ -113,18 +114,19 @@ const SAMPLE_DIFF_WARNING: ShapeDiff = {
 
 // ---------------------------------------------------------------------------
 // REAL captured vitest --reporter=json failure-message fixtures.
-// Captured via throwaway `*.drift.ts` capture tests run under the drift config;
-// see tmp/canary-fixtures.json + the PR #291 RED/GREEN logs.
+// Captured via throwaway `*.drift.ts` capture tests run under the drift config.
+// The capture files were throwaway and are not in the repo; the RED/GREEN logs
+// that show these exact shapes are on PR #291.
 // ---------------------------------------------------------------------------
 
 // Canary tripped with FOUR unknown models. The printed array is truncated by
 // vitest to `…(3)` (single-glyph Unicode ellipsis), but the custom assertion
 // message `UNKNOWN_REALTIME_MODELS=…` carries the full list verbatim.
-// NOTE (A4): the ids below are HYPOTHETICAL future models that are NOT in the
-// knownModels set in ws-realtime.drift.ts — so the real canary really could
-// emit them as unknown. (gpt-realtime-2.1 / -2.1-mini ARE in knownModels and
-// therefore can never appear here — the earlier fixture that used them was
-// impossible.)
+// NOTE (A4): the ids below are HYPOTHETICAL future models that are NOT in
+// knownVoiceModelFamilies in src/__tests__/drift/voice-models.ts — so the real
+// canary really could emit them as unknown. (gpt-realtime-2.1 / -2.1-mini ARE in
+// that set and therefore can never appear here — the earlier fixture that used
+// them was impossible.)
 const CANARY_MARKER_MULTI =
   "AssertionError: UNKNOWN_REALTIME_MODELS=gpt-realtime-3,gpt-realtime-3-mini,gpt-realtime-3-preview,gpt-realtime-ultra: expected [ 'gpt-realtime-3', …(3) ] to deeply equal []\n" +
   "    at /repo/src/__tests__/drift/ws-realtime.drift.ts:108:69\n" +
@@ -159,7 +161,7 @@ const INFRA_TOKEN_IN_STACKFRAME_ONLY =
 const REAL_INFRA_BODY = "fetch failed\n    at handler (file:///repo/src/x.drift.ts:5:1)";
 
 // CLASS 2 — the canary `hasGA`-false mode. Captured REAL from a throwaway
-// `*.drift.ts` capture run under the drift config (see tmp/captured-vitest-shapes.json).
+// `*.drift.ts` capture run under the drift config (capture file was throwaway).
 // When OpenAI renames/removes the GA realtime family, the canary emits the
 // NO_GA_REALTIME_MODELS= marker (symmetric to UNKNOWN_REALTIME_MODELS=) and the
 // assertion fails with "expected false to be true". The collector must map this
@@ -1382,7 +1384,8 @@ describe("classifyUnparseableAsInfra", () => {
 // The delta layer (D6.1) keys findings by `provider+id`. For N distinct unknown
 // model ids, the collector must produce N DISTINCT per-item `id` values so that
 // a downstream `provider+id` keying yields N distinct keys — not 1 collapsed
-// key under `path:"knownModels"` (pre-fix behaviour when `id` was absent/undefined).
+// key under the shared `path` bucket (pre-fix behaviour when `id` was
+// absent/undefined).
 //
 // RED (pre-fix): `id` is unset on every ParsedDiff produced by the canary path,
 //   so all 3 diffs have `id === undefined` → only 1 distinct key.
@@ -1391,8 +1394,8 @@ describe("classifyUnparseableAsInfra", () => {
 // ---------------------------------------------------------------------------
 
 describe("D6.2 — per-item id on ParsedDiff", () => {
-  // Three distinct hypothetical unknown model ids (not in the knownModels set
-  // in ws-realtime.drift.ts — A4 note: use future/hypothetical ids only).
+  // Three distinct hypothetical unknown model ids (not in knownVoiceModelFamilies
+  // in src/__tests__/drift/voice-models.ts — A4 note: hypothetical ids only).
   const THREE_UNKNOWN_IDS_CANARY =
     "AssertionError: UNKNOWN_REALTIME_MODELS=gpt-realtime-x1,gpt-realtime-x2,gpt-realtime-x3: " +
     "expected [ 'gpt-realtime-x1', …(2) ] to deeply equal []\n" +

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -724,11 +724,14 @@ describe("collectDriftEntries", () => {
     const entry = entries[0];
     expect(entry.provider).toBe("OpenAI Realtime");
     expect(entry.diffs.every((d) => d.severity === "critical")).toBe(true);
-    // The unknown model ids survive as `real` values on knownModels diffs.
-    const knownModelReals = entry.diffs.filter((d) => d.path === "knownModels").map((d) => d.real);
+    // The unknown model ids survive as `real` values on the
+    // knownVoiceModelFamilies diffs.
+    const knownModelReals = entry.diffs
+      .filter((d) => d.path === "knownVoiceModelFamilies")
+      .map((d) => d.real);
     expect(knownModelReals).toEqual(["gpt-realtime-99", "gpt-realtime-99-mini"]);
     // The GA-family diff is still present.
-    expect(entry.diffs.some((d) => d.path === "gaModels")).toBe(true);
+    expect(entry.diffs.some((d) => d.path === "gaRealtimeModels")).toBe(true);
   });
 
   it("maps an EMPTY NO_GA marker (no realtime models observed) to a CRITICAL entry too", () => {

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -30,12 +30,14 @@ import {
   classifyUnparseableAsInfra,
   INFRA_INDICATOR_SOURCES,
   infraIndicatorSample,
+  NO_GA_DELTA_ID,
+  TRUNCATED_DELTA_ID,
 } from "../../scripts/drift-report-collector.js";
-import type { DriftEntry, QuarantineEntry } from "../../scripts/drift-types.js";
+import type { DriftEntry, QuarantineEntry, ParsedDiff } from "../../scripts/drift-types.js";
 import { SURFACE_REGISTRY, KNOWN_SURFACE_SLUGS, isKnownSurface } from "./drift/surface-registry.js";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
-import { isBaseReportReusable } from "../../scripts/drift-delta.js";
+import { isBaseReportReusable, computeDelta } from "../../scripts/drift-delta.js";
 import type { DriftReport } from "../../scripts/drift-types.js";
 
 // ---------------------------------------------------------------------------
@@ -1452,6 +1454,131 @@ describe("D6.2 — per-item id on ParsedDiff", () => {
     // Each id must be derived from (or equal to) the path.
     for (const diff of parsed!.diffs) {
       expect(diff.id).toBe(diff.path);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The delta key must not be coupled to a DISPLAY string.
+//
+// drift-delta keys a failure by `provider + (diff.id ?? diff.path)`. Two canary
+// diffs shipped with NO `id` — the no-GA diff and the truncation diff — so their
+// delta key WAS their `path`, which is also the human-facing "Path:" line of the
+// alert. That coupling means renaming the prose (as 6614bb2 did, `gaModels` →
+// `gaRealtimeModels`) silently MOVES the key: a drift already recorded in the
+// cached same-UTC-day BASE report is re-classified as new-in-head and BLOCKS the
+// PR, while the base key is reported as spuriously "fixed".
+//
+// The fix is not to freeze the display string — a `path` naming a symbol that no
+// longer exists is the exact bug this file's sibling guard exists to kill. It is
+// to give those two diffs an explicit, stable, SEMANTIC id so the display string
+// is free to change and the key never moves again.
+// ---------------------------------------------------------------------------
+
+describe("canary delta keys are decoupled from the human-facing path string", () => {
+  function reportOf(diffs: ParsedDiff[], timestamp = "2026-08-03T00:00:00.000Z"): DriftReport {
+    return {
+      timestamp,
+      entries: [
+        {
+          provider: "OpenAI Realtime",
+          scenario: "known-models canary",
+          builderFile: "b.ts",
+          builderFunctions: ["f"],
+          typesFile: null,
+          sdkShapesFile: "shapes.ts",
+          diffs,
+        },
+      ],
+    };
+  }
+
+  function canaryDiffs(message: string): ParsedDiff[] {
+    const entries = entriesOf(
+      makeResult([
+        makeAssertion({
+          status: "failed",
+          ancestorTitles: ["OpenAI Realtime API drift"],
+          title: "canary: GA realtime models available",
+          failureMessages: [message],
+        }),
+      ]),
+    );
+    expect(entries).toHaveLength(1);
+    return entries[0].diffs;
+  }
+
+  // Characterization of the MECHANISM, so the coupling can never be re-created
+  // silently: with no `id`, a path-only rename moves the key. (Watched to fail by
+  // stubbing indexReport's `diff.id ?? diff.path` to a constant.)
+  it("MECHANISM: with no per-item id, renaming `path` alone moves the delta key", () => {
+    const idLess = (path: string): ParsedDiff => ({
+      path,
+      severity: "critical",
+      issue: "GA realtime family unavailable",
+      expected: "(at least one GA realtime model present)",
+      real: "no realtime models observed",
+      mock: "<no mock leg>",
+    });
+    const { block, advisory, fixed } = computeDelta(
+      reportOf([idLess("gaModels")]),
+      reportOf([idLess("gaRealtimeModels")]),
+    );
+    expect(advisory).toEqual([]);
+    expect(block.map((k) => k.id)).toEqual(["gaRealtimeModels"]);
+    expect(fixed.map((k) => k.id)).toEqual(["gaModels"]);
+  });
+
+  it("a stable per-item id makes the SAME path rename key-neutral (stays advisory)", () => {
+    const keyed = (path: string): ParsedDiff => ({
+      path,
+      id: NO_GA_DELTA_ID,
+      severity: "critical",
+      issue: "GA realtime family unavailable",
+      expected: "(at least one GA realtime model present)",
+      real: "no realtime models observed",
+      mock: "<no mock leg>",
+    });
+    const { block, advisory, fixed } = computeDelta(
+      reportOf([keyed("gaModels")]),
+      reportOf([keyed("gaRealtimeModels")]),
+    );
+    expect(block).toEqual([]);
+    expect(fixed).toEqual([]);
+    expect(advisory.map((k) => k.id)).toEqual([NO_GA_DELTA_ID]);
+  });
+
+  it("the collector sets the stable id on the no-GA diff", () => {
+    const diffs = canaryDiffs(CANARY_NO_GA_MARKER);
+    const noGA = diffs.filter((d) => d.path === "gaRealtimeModels");
+    expect(noGA).toHaveLength(1);
+    expect(noGA[0].id).toBe(NO_GA_DELTA_ID);
+  });
+
+  it("the collector sets the stable id on the truncation diff", () => {
+    const diffs = canaryDiffs(CANARY_FALLBACK_TRUNCATED);
+    const truncation = diffs.filter((d) => d.path === "knownVoiceModelFamilies[truncated]");
+    expect(truncation).toHaveLength(1);
+    expect(truncation[0].id).toBe(TRUNCATED_DELTA_ID);
+  });
+
+  // Vacuity guard: EVERY canary diff the collector can emit must now carry an
+  // `id`, so no future canary diff can silently re-acquire a path-derived key.
+  it("no canary diff is left keyed by its display path", () => {
+    for (const message of [
+      CANARY_NO_GA_MARKER,
+      CANARY_NO_GA_WITH_UNKNOWN,
+      CANARY_NO_GA_EMPTY,
+      CANARY_MARKER_MULTI,
+      CANARY_FALLBACK_TRUNCATED,
+    ]) {
+      for (const d of canaryDiffs(message)) {
+        expect(
+          d.id,
+          `canary diff path=${d.path} has no stable id — it would key on its ` +
+            `display path, so renaming the alert prose would move its delta key`,
+        ).toBeTruthy();
+      }
     }
   });
 });

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -1610,8 +1610,11 @@ describe("canary delta keys are decoupled from the human-facing path string", ()
  *              a key and is never mistaken for a symbol to go look up.
  *   observed — the id IS the value the live API returned (it equals the diff's
  *              `real`), i.e. wire data rather than repo prose.
- *   declared — the id is an identifier this repo actually DECLARES, so a reader
- *              who greps it lands on something real.
+ *   declared — the id is a symbol EXPORTED by a drift classification module
+ *              (`src/__tests__/drift/*.ts`), so a reader who greps it lands on the
+ *              actual seed set / rule the annotation is pointing at. Deliberately
+ *              NOT "declared anywhere in the repo" — see
+ *              `driftModuleExportsIdentifier`.
  *
  * Anything else fails: a bare display string, a prose bucket, a retired symbol
  * name, or a missing `id` whose `path` falls through to the key.
@@ -1654,37 +1657,49 @@ function deltaIdNamespace(id: string): string | null {
 }
 
 /**
- * Contents of every `.ts` file whose declarations a delta key may name. Read once
- * — the per-key check below runs over the cached text, not the filesystem.
+ * The drift CLASSIFICATION package — `src/__tests__/drift/*.ts`: the voice/model
+ * seed sets, the registry, the normalizers, the surface registry. These are the
+ * modules a human sent a delta key would actually open, because they hold the data
+ * the key names and the rule that has to change.
+ *
+ * SCOPED DELIBERATELY. An earlier revision of this guard scanned every `.ts` under
+ * `src/` and `scripts/` for ANY `const|function|class|…` declaration of the name,
+ * which made the `declared` provenance a near-wildcard: `path`, `models`,
+ * `entries`, `key`, `id`, `usage`, `body`, `type` — 20 of 20 generic one-word
+ * strings tried — are each some local `const` somewhere in the tree, so a bare
+ * display path satisfied it and the guard stopped binding on the thing it exists
+ * to prevent. Read once; the per-key check runs over the cached text.
  */
-let repoSourcesCache: string[] | null = null;
-function repoSources(): string[] {
-  if (repoSourcesCache !== null) return repoSourcesCache;
-  const repoRoot = resolve(__dirname, "..", "..");
-  const sources: string[] = [];
-  const walk = (dir: string): void => {
-    for (const name of readdirSync(dir, { withFileTypes: true })) {
-      const abs = resolve(dir, name.name);
-      if (name.isDirectory()) {
-        if (name.name === "node_modules" || name.name === "dist") continue;
-        walk(abs);
-      } else if (name.name.endsWith(".ts")) {
-        sources.push(readFileSync(abs, "utf8"));
-      }
-    }
-  };
-  for (const root of ["src", "scripts"]) walk(resolve(repoRoot, root));
-  repoSourcesCache = sources;
-  return sources;
+let driftModuleSourcesCache: string[] | null = null;
+function driftModuleSources(): string[] {
+  if (driftModuleSourcesCache !== null) return driftModuleSourcesCache;
+  const dir = resolve(__dirname, "drift");
+  driftModuleSourcesCache = readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith(".ts"))
+    .map((e) => readFileSync(resolve(dir, e.name), "utf8"));
+  return driftModuleSourcesCache;
 }
 
-/** Does any repo source DECLARE `id` (not merely mention it in prose)? */
-function repoDeclaresIdentifier(id: string): boolean {
+/**
+ * Does a drift classification module EXPORT `id` under exactly that name?
+ *
+ * Two structural requirements, both load-bearing:
+ *   - EXPORTED (`^export`, `m`-anchored so it is a top-level export and not an
+ *     indented interior binding) — an unexported local is not something a reader
+ *     can look up, and it is what let bare display words through.
+ *   - declared IN the drift package — a symbol from an unrelated corner of the
+ *     repo is not the data set the annotation is pointing at.
+ *
+ * `\b` after the name keeps the match exact (`gaModels` must not be satisfied by
+ * `gaModelsRetired`).
+ */
+function driftModuleExportsIdentifier(id: string): boolean {
   if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(id)) return false;
   const decl = new RegExp(
-    `(?:export\\s+)?(?:declare\\s+)?(?:const|let|var|function|class|interface|type|enum)\\s+${id}\\b`,
+    `^export\\s+(?:declare\\s+)?(?:const|let|var|function|class|interface|type|enum)\\s+${id}\\b`,
+    "m",
   );
-  return repoSources().some((src) => decl.test(src));
+  return driftModuleSources().some((src) => decl.test(src));
 }
 
 type DeltaKeyProvenance = "semantic" | "observed" | "declared";
@@ -1700,7 +1715,7 @@ function deltaKeyProvenanceOf(diff: ParsedDiff): DeltaKeyProvenance | null {
   const namespace = deltaIdNamespace(key);
   if (namespace !== null && SEMANTIC_DELTA_ID_NAMESPACES.includes(namespace)) return "semantic";
   if (key.length > 0 && key === diff.real) return "observed";
-  if (repoDeclaresIdentifier(key)) return "declared";
+  if (driftModuleExportsIdentifier(key)) return "declared";
   return null;
 }
 
@@ -1796,6 +1811,43 @@ describe("every delta key the collector constructs has a provenance", () => {
       }),
       "display path copied into the id",
     ).toBeNull();
+  });
+
+  // The `declared` provenance is the loosest of the three, so it is the one that
+  // can quietly stop binding. It must mean "names a symbol the drift
+  // classification modules EXPORT" — a reader greps it and lands on the data set
+  // to edit. It must NOT mean "this string appears as any identifier anywhere in
+  // src/ or scripts/": every one of these bare words is some local `const`
+  // somewhere in the repo, so under that reading a one-word display path would
+  // satisfy the guard and the gate could print `<provider> path` at a human.
+  it("rejects a bare generic one-word display path (`declared` is not a near-wildcard)", () => {
+    for (const word of [
+      "path",
+      "models",
+      "entries",
+      "key",
+      "id",
+      "report",
+      "usage",
+      "choices",
+      "message",
+      "content",
+      "delta",
+      "error",
+      "data",
+      "result",
+      "response",
+      "request",
+      "body",
+      "status",
+      "type",
+      "value",
+    ]) {
+      expect(
+        deltaKeyProvenanceOf(idLess(word)),
+        `"${word}" is a bare display path, not a symbol a reader can look up`,
+      ).toBeNull();
+    }
   });
 
   for (const { lane, diff } of constructed) {

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -334,6 +334,29 @@ describe("extractProviderName", () => {
     expect(extractProviderName("OpenAI Chat (non-streaming text)")).toBe("OpenAI Chat");
     expect(extractProviderName("Anthropic (streaming text)")).toBe("Anthropic");
   });
+
+  // A label appearing ANYWHERE in the text used to win on length alone, so a
+  // qualifier later in the title could outrank the surface the title is actually
+  // about: "Gemini Live Transcription session" resolved to `Transcription`
+  // (13 chars) over `Gemini Live` (11), silently routing a Gemini Live drift at
+  // src/transcription.ts. It failed OPEN — a confident wrong attribution, no
+  // error. Both `parsed.context` (`formatDriftReport`'s "<Provider> (<scenario>)")
+  // and a drift describe title LEAD with the provider label, so the match is now
+  // anchored at the start.
+  it("does not let a later qualifier outrank the leading provider label", () => {
+    expect(extractProviderName("Gemini Live Transcription session")).toBe("Gemini Live");
+    expect(extractProviderName("Gemini Live Transcription drift")).toBe("Gemini Live");
+    expect(extractProviderName("OpenAI Video Transcription drift")).toBe("OpenAI Video");
+    // …and the label that legitimately leads still resolves to itself.
+    expect(extractProviderName("Transcription (whisper-1 verbose_json)")).toBe("Transcription");
+  });
+
+  it("fails closed when the provider label is not the leading token", () => {
+    // Not anchored → unattributable → null, which routes the block to the
+    // quarantine lane (exit 5, human review) rather than to a fabricated owner.
+    expect(extractProviderName("drift detected in OpenAI Chat")).toBeNull();
+    expect(extractProviderName("session for Gemini Live")).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -2082,6 +2082,31 @@ describe("WS-5 — unknown surface slug fails LOUD (throws), never silent quaran
 });
 
 describe("WS-5 — base-report reuse contract (generatedAt + conclusion)", () => {
+  /**
+   * A DriftEntry shaped as main() really writes them: entries exist only for
+   * FAILED assertions, and always carry at least one diff (a block that parses to
+   * zero diffs is routed to the unparseable/quarantine lane instead). Fixtures
+   * below use this rather than an entry with `diffs: []`, which main() never emits.
+   */
+  const driftingEntry = (): DriftReport["entries"][number] => ({
+    provider: "OpenAI Chat",
+    scenario: "non-streaming text",
+    builderFile: "src/helpers.ts",
+    builderFunctions: ["buildTextCompletion"],
+    typesFile: "src/types.ts",
+    sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
+    diffs: [
+      {
+        path: "usage.prompt_tokens",
+        severity: "critical",
+        issue: "type mismatch",
+        expected: "number",
+        real: "string",
+        mock: "number",
+      },
+    ],
+  });
+
   it("conclusionForExitCode maps exit codes to coarse conclusions", () => {
     expect(conclusionForExitCode(0)).toBe("clean");
     expect(conclusionForExitCode(2)).toBe("critical");
@@ -2089,26 +2114,55 @@ describe("WS-5 — base-report reuse contract (generatedAt + conclusion)", () =>
     expect(conclusionForExitCode(1)).toBe("skipped");
   });
 
-  it("isBaseReportReusable accepts a written clean report (reuse works)", () => {
-    // A report shaped like what main() now writes for a clean run.
+  // KNOWN DEFECT, PINNED AS-IS — do not "fix" this test by inventing entries.
+  //
+  // An earlier version of this test claimed to use "a report shaped like what
+  // main() writes for a clean run" but gave it a non-empty `entries[]` holding an
+  // entry with `diffs: []`. main() writes neither: entries come only from FAILED
+  // assertions, and an assertion whose block parses to zero diffs is routed to the
+  // unparseable/quarantine lane, so no entry is ever written with empty `diffs`.
+  // A clean run (exit 0) writes `entries: []` — verified by running
+  // collectDriftEntries over an all-passing result.
+  //
+  // With the accurate fixture the guard REJECTS it, and that is the finding the
+  // invented fixture was concealing: `isBaseReportReusable` requires non-empty
+  // `entries[]`, but the only conclusions it accepts are "clean"/"success", and
+  // "clean" is exactly the run that has no entries. So a healthy main can never
+  // supply a reusable base — every PR pays for a fresh live base run. The guard
+  // conflates "empty" (main is clean: the MOST useful base, since it makes every
+  // head finding new-in-head) with "malformed" (truncated/garbage cached JSON),
+  // when the signal that separates them is the `conclusion`/`generatedAt` pair.
+  //
+  // Pinned rather than papered over: when the guard is corrected to accept a
+  // conclusion-attested empty base, this test goes RED and must be updated
+  // deliberately, which is the point.
+  it("a clean report as main() ACTUALLY writes it is NOT reusable (known defect: reuse is dead for a healthy main)", () => {
     const timestamp = new Date().toISOString();
     const report: DriftReport = {
       timestamp,
       generatedAt: timestamp,
       conclusion: conclusionForExitCode(0),
-      entries: [
-        {
-          provider: "OpenAI Chat",
-          scenario: "non-streaming text",
-          builderFile: "src/helpers.ts",
-          builderFunctions: ["buildTextCompletion"],
-          typesFile: "src/types.ts",
-          sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
-          diffs: [],
-        },
-      ],
+      // What main() really writes for a clean run — no failed assertions, no entries.
+      entries: [],
     };
-    // Same-UTC-day + known-good conclusion + non-empty entries → reusable.
+    expect(report.conclusion, "a clean run's conclusion is known-good").toBe("clean");
+    expect(
+      isBaseReportReusable(report, report.conclusion, true),
+      "same UTC day and a known-good conclusion, yet rejected purely for having no entries",
+    ).toBe(false);
+  });
+
+  // The reuse path is reachable ONLY for a base that carries drift — i.e. when
+  // main is already broken. This is the complement of the case above and is what
+  // keeps the guard's non-empty branch from being untested in both directions.
+  it("a base report that DOES carry drift is reusable", () => {
+    const timestamp = new Date().toISOString();
+    const report: DriftReport = {
+      timestamp,
+      generatedAt: timestamp,
+      conclusion: "success",
+      entries: [driftingEntry()],
+    };
     expect(isBaseReportReusable(report, report.conclusion, true)).toBe(true);
   });
 
@@ -2116,17 +2170,7 @@ describe("WS-5 — base-report reuse contract (generatedAt + conclusion)", () =>
     const timestamp = new Date().toISOString();
     const legacy: DriftReport = {
       timestamp,
-      entries: [
-        {
-          provider: "OpenAI Chat",
-          scenario: "non-streaming text",
-          builderFile: "src/helpers.ts",
-          builderFunctions: ["buildTextCompletion"],
-          typesFile: "src/types.ts",
-          sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
-          diffs: [],
-        },
-      ],
+      entries: [driftingEntry()],
     };
     // No conclusion field → falls back to undefined → not reusable.
     expect(isBaseReportReusable(legacy, legacy.conclusion, true)).toBe(false);
@@ -2148,25 +2192,19 @@ describe("WS-5 — base-report reuse contract (generatedAt + conclusion)", () =>
     };
 
     const now = new Date("2026-07-15T12:00:00.000Z");
-    const cleanReport = (generatedAt: string): DriftReport => ({
+    // A base that is otherwise reusable, so the ONLY variable is its UTC day.
+    // Note it has to be a report that CARRIES drift — see the known-defect test
+    // above: a clean (empty-entries) base is rejected outright, so it could not
+    // isolate the staleness behaviour being pinned here.
+    const reusableBase = (generatedAt: string): DriftReport => ({
       timestamp: generatedAt,
       generatedAt,
-      conclusion: conclusionForExitCode(0),
-      entries: [
-        {
-          provider: "OpenAI Chat",
-          scenario: "non-streaming text",
-          builderFile: "src/helpers.ts",
-          builderFunctions: ["buildTextCompletion"],
-          typesFile: "src/types.ts",
-          sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
-          diffs: [],
-        },
-      ],
+      conclusion: "success",
+      entries: [driftingEntry()],
     });
 
     // Same UTC day (later hour, same date) → derivation true → reusable.
-    const today = cleanReport("2026-07-15T03:00:00.000Z");
+    const today = reusableBase("2026-07-15T03:00:00.000Z");
     expect(sameUtcDay(today.generatedAt!, now)).toBe(true);
     expect(isBaseReportReusable(today, today.conclusion, sameUtcDay(today.generatedAt!, now))).toBe(
       true,
@@ -2174,7 +2212,7 @@ describe("WS-5 — base-report reuse contract (generatedAt + conclusion)", () =>
 
     // Prior UTC day → derivation false → NOT reusable, despite an otherwise
     // identical clean report. generatedAt is what makes the difference.
-    const yesterday = cleanReport("2026-07-14T23:59:59.000Z");
+    const yesterday = reusableBase("2026-07-14T23:59:59.000Z");
     expect(sameUtcDay(yesterday.generatedAt!, now)).toBe(false);
     expect(
       isBaseReportReusable(

--- a/src/__tests__/drift-collector.test.ts
+++ b/src/__tests__/drift-collector.test.ts
@@ -1587,6 +1587,234 @@ describe("canary delta keys are decoupled from the human-facing path string", ()
 });
 
 // ===========================================================================
+// Delta-key PROVENANCE — the gate's annotation cannot print a symbol that
+// does not exist
+// ===========================================================================
+
+/**
+ * The delta gate annotates a blocking key as `${k.provider} ${k.id}` (the
+ * "Delta gate" step of .github/workflows/test-drift.yml), so `DeltaKey.id` is the
+ * entire identifier a human gets when the required check hard-fails. `indexReport`
+ * builds it as `diff.id ?? diff.path` — so a diff with no `id` promotes a
+ * HUMAN-FACING DISPLAY STRING to the key. That is how `gaModels` and
+ * `knownModels[truncated]`, symbols retired from this repo, became printable delta
+ * keys: the annotation named a symbol the reader could not find anywhere.
+ *
+ * `98b9cf1` gave those two diffs explicit semantic ids, which fixes the current
+ * tree; this makes the property STRUCTURAL. Every key a collector-CONSTRUCTED diff
+ * can contribute must have one of three provenances, none of which can be an
+ * arbitrary display string:
+ *
+ *   semantic — `<namespace>:<slug>` with the namespace in the explicit
+ *              SEMANTIC_DELTA_ID_NAMESPACES allowlist. Namespaced, so it reads as
+ *              a key and is never mistaken for a symbol to go look up.
+ *   observed — the id IS the value the live API returned (it equals the diff's
+ *              `real`), i.e. wire data rather than repo prose.
+ *   declared — the id is an identifier this repo actually DECLARES, so a reader
+ *              who greps it lands on something real.
+ *
+ * Anything else fails: a bare display string, a prose bucket, a retired symbol
+ * name, or a missing `id` whose `path` falls through to the key.
+ *
+ * SCOPE: the diffs the collector writes ITSELF — the realtime-canary and WS
+ * handshake lanes — whose `path`/`id` are hand-authored. A diff parsed out of a
+ * formatted drift block carries the probe's observed wire path
+ * (`choices[0].message.refusal`), which is data from the run rather than a symbol
+ * citation, and is out of scope.
+ *
+ * Composes with drift-remediation-strings.test.ts, which separately forbids any
+ * RETIRED symbol name anywhere in the collector source: a `declared` id cannot be
+ * a retired symbol here, and a `semantic` id cannot smuggle one into its slug
+ * there.
+ */
+const SEMANTIC_DELTA_ID_NAMESPACES: readonly string[] = [
+  // The two id-less realtime-canary diffs: NO_GA_DELTA_ID / TRUNCATED_DELTA_ID.
+  "openai-realtime",
+  // The WS handshake lane: `ws-handshake:<provider error code>`.
+  "ws-handshake",
+];
+
+/**
+ * The WS handshake lane's fixture. Shaped to parseWSHandshakeFailure's three
+ * documented gates — a `waitUntil timeout`, the ws-realtime.drift.ts stack frame,
+ * and a surfaced provider `error` body. Unlike the canary fixtures above, this one
+ * is hand-authored to those gates rather than captured.
+ */
+const WS_HANDSHAKE_ERROR_FAILURE =
+  "AssertionError: waitUntil timeout after 10000ms; last message: " +
+  '{"type":"error","error":{"type":"invalid_request_error","code":"invalid_api_key",' +
+  '"message":"Incorrect API key provided."}}\n' +
+  "    at /repo/src/__tests__/drift/ws-realtime.drift.ts:64:11";
+
+/** The namespace of a `<namespace>:<slug>` id, or null when it is not namespaced. */
+function deltaIdNamespace(id: string): string | null {
+  const colon = id.indexOf(":");
+  if (colon <= 0 || colon >= id.length - 1) return null;
+  return id.slice(0, colon);
+}
+
+/**
+ * Contents of every `.ts` file whose declarations a delta key may name. Read once
+ * — the per-key check below runs over the cached text, not the filesystem.
+ */
+let repoSourcesCache: string[] | null = null;
+function repoSources(): string[] {
+  if (repoSourcesCache !== null) return repoSourcesCache;
+  const repoRoot = resolve(__dirname, "..", "..");
+  const sources: string[] = [];
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir, { withFileTypes: true })) {
+      const abs = resolve(dir, name.name);
+      if (name.isDirectory()) {
+        if (name.name === "node_modules" || name.name === "dist") continue;
+        walk(abs);
+      } else if (name.name.endsWith(".ts")) {
+        sources.push(readFileSync(abs, "utf8"));
+      }
+    }
+  };
+  for (const root of ["src", "scripts"]) walk(resolve(repoRoot, root));
+  repoSourcesCache = sources;
+  return sources;
+}
+
+/** Does any repo source DECLARE `id` (not merely mention it in prose)? */
+function repoDeclaresIdentifier(id: string): boolean {
+  if (!/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(id)) return false;
+  const decl = new RegExp(
+    `(?:export\\s+)?(?:declare\\s+)?(?:const|let|var|function|class|interface|type|enum)\\s+${id}\\b`,
+  );
+  return repoSources().some((src) => decl.test(src));
+}
+
+type DeltaKeyProvenance = "semantic" | "observed" | "declared";
+
+/**
+ * Classify the provenance of the delta key a diff will contribute, keying it
+ * EXACTLY as `indexReport` does (`diff.id ?? diff.path`). null = no provenance:
+ * the key is an arbitrary display string and the gate could annotate it at a
+ * human as if it were something to look up.
+ */
+function deltaKeyProvenanceOf(diff: ParsedDiff): DeltaKeyProvenance | null {
+  const key = diff.id ?? diff.path;
+  const namespace = deltaIdNamespace(key);
+  if (namespace !== null && SEMANTIC_DELTA_ID_NAMESPACES.includes(namespace)) return "semantic";
+  if (key.length > 0 && key === diff.real) return "observed";
+  if (repoDeclaresIdentifier(key)) return "declared";
+  return null;
+}
+
+/** Every diff the collector CONSTRUCTS itself, labelled by the lane it came from. */
+function constructedDiffs(): { lane: string; diff: ParsedDiff }[] {
+  const lanes: Record<string, string> = {
+    "canary no-GA (marker)": CANARY_NO_GA_MARKER,
+    "canary no-GA + unknown": CANARY_NO_GA_WITH_UNKNOWN,
+    "canary no-GA (empty list)": CANARY_NO_GA_EMPTY,
+    "canary unknown models": CANARY_MARKER_MULTI,
+    "canary truncated": CANARY_FALLBACK_TRUNCATED,
+    "WS handshake error": WS_HANDSHAKE_ERROR_FAILURE,
+  };
+  const out: { lane: string; diff: ParsedDiff }[] = [];
+  for (const [lane, message] of Object.entries(lanes)) {
+    const entries = entriesOf(
+      makeResult([
+        makeAssertion({
+          status: "failed",
+          ancestorTitles: ["OpenAI Realtime API drift"],
+          title: "canary: GA realtime models available",
+          failureMessages: [message],
+        }),
+      ]),
+    );
+    for (const entry of entries) {
+      for (const diff of entry.diffs) out.push({ lane, diff });
+    }
+  }
+  return out;
+}
+
+describe("every delta key the collector constructs has a provenance", () => {
+  const constructed = constructedDiffs();
+
+  const idLess = (path: string): ParsedDiff => ({
+    path,
+    severity: "critical",
+    issue: "GA realtime family unavailable",
+    expected: "(at least one GA realtime model present)",
+    real: "no realtime models observed",
+    mock: "<no mock leg>",
+  });
+
+  // Vacuity guard: the per-key cases below are GENERATED from the enumeration, so
+  // an enumeration that quietly found nothing would report a green suite with no
+  // cases in it. Both id-less canary diffs, the per-model diffs and the WS lane
+  // must be present.
+  it("enumerates the collector's constructed diffs", () => {
+    expect(constructed.length, "constructed diffs found").toBeGreaterThanOrEqual(8);
+    expect(new Set(constructed.map((c) => c.lane)).size, "lanes covered").toBe(6);
+    const keys = constructed.map((c) => c.diff.id ?? c.diff.path);
+    expect(keys).toContain(NO_GA_DELTA_ID);
+    expect(keys).toContain(TRUNCATED_DELTA_ID);
+    expect(keys).toContain("ws-handshake:invalid_api_key");
+  });
+
+  // Known-positive controls: the classifier must ACCEPT each provenance, not just
+  // reject bad input. Without these a classifier that returned "semantic" for
+  // everything, or a repo scan that matched everything, would look green.
+  it("accepts each of the three provenances", () => {
+    expect(deltaKeyProvenanceOf(idLess("x")), "unclassifiable control").toBeNull();
+    expect(deltaKeyProvenanceOf({ ...idLess("gaRealtimeModels"), id: NO_GA_DELTA_ID })).toBe(
+      "semantic",
+    );
+    expect(
+      deltaKeyProvenanceOf({
+        ...idLess("knownVoiceModelFamilies"),
+        id: "gpt-realtime-99",
+        real: "gpt-realtime-99",
+      }),
+    ).toBe("observed");
+    // `gaRealtimeModels` really is declared in src/__tests__/drift/voice-models.ts.
+    expect(deltaKeyProvenanceOf(idLess("gaRealtimeModels"))).toBe("declared");
+  });
+
+  // Known-negative controls: the two keys that actually shipped, and the shape of
+  // the regression this guard exists to catch.
+  it("rejects a retired symbol name and a prose bucket", () => {
+    expect(deltaKeyProvenanceOf(idLess("gaModels")), "retired symbol as path").toBeNull();
+    expect(
+      deltaKeyProvenanceOf(idLess("knownModels[truncated]")),
+      "retired symbol + bucket suffix as path",
+    ).toBeNull();
+    expect(
+      deltaKeyProvenanceOf({ ...idLess("gaRealtimeModels"), id: "gaModels" }),
+      "retired symbol as an explicit id",
+    ).toBeNull();
+    expect(
+      deltaKeyProvenanceOf({
+        ...idLess("knownVoiceModelFamilies[truncated]"),
+        id: "knownVoiceModelFamilies[truncated]",
+      }),
+      "display path copied into the id",
+    ).toBeNull();
+  });
+
+  for (const { lane, diff } of constructed) {
+    it(`${lane}: "${diff.id ?? diff.path}" has a provenance`, () => {
+      expect(
+        deltaKeyProvenanceOf(diff),
+        `The delta key for this ${lane} diff is "${diff.id ?? diff.path}", which is ` +
+          `neither a namespaced semantic id (${SEMANTIC_DELTA_ID_NAMESPACES.join(", ")}), ` +
+          `nor the value the API returned, nor an identifier this repo declares. The ` +
+          `drift gate prints that key verbatim at a human — as "<provider> ` +
+          `${diff.id ?? diff.path}" — when it hard-fails the required check, so it must ` +
+          `not be an arbitrary display string. Give the diff an explicit semantic id ` +
+          `(see NO_GA_DELTA_ID) instead of letting its display path become the key.`,
+      ).not.toBeNull();
+    });
+  }
+});
+
+// ===========================================================================
 // WS-5 — structural surface keying via SURFACE_REGISTRY
 // ===========================================================================
 

--- a/src/__tests__/drift-delta.test.ts
+++ b/src/__tests__/drift-delta.test.ts
@@ -16,7 +16,7 @@ import type { DriftReport, ParsedDiff } from "../../scripts/drift-types.js";
 
 function diff(overrides: Partial<ParsedDiff> = {}): ParsedDiff {
   return {
-    path: "knownModels",
+    path: "knownVoiceModelFamilies",
     severity: "critical",
     issue: "model drift",
     expected: "x",
@@ -132,9 +132,9 @@ describe("computeDelta routing by key presence", () => {
   it("keys by provider+id (path bucket must NOT collapse N distinct ids into one)", () => {
     const base = report("anthropic", []);
     const head = report("anthropic", [
-      diff({ path: "knownModels", id: "a" }),
-      diff({ path: "knownModels", id: "b" }),
-      diff({ path: "knownModels", id: "c" }),
+      diff({ path: "knownVoiceModelFamilies", id: "a" }),
+      diff({ path: "knownVoiceModelFamilies", id: "b" }),
+      diff({ path: "knownVoiceModelFamilies", id: "c" }),
     ]);
     const { block } = computeDelta(base, head);
     expect(keys(block)).toEqual(["anthropic:a", "anthropic:b", "anthropic:c"]);

--- a/src/__tests__/drift-remediation-strings.test.ts
+++ b/src/__tests__/drift-remediation-strings.test.ts
@@ -9,38 +9,99 @@
  *   - `knownModels` was renamed `knownVoiceModelFamilies` and moved out of
  *     `ws-realtime.drift.ts` into `src/__tests__/drift/voice-models.ts`;
  *   - `gaModels` was renamed `gaRealtimeModels` and moved to the same place.
- * Both renames left the collector's prose pointing at the old name/location, and
- * the hand-written EXCLUDE notes under `drift-proposals/` cite test paths in the
- * same shape.
+ * Both renames left the collector's prose pointing at the old name/location.
  *
  * So this test makes the audit trail STRUCTURAL rather than a matter of
- * remembering to grep: every "<symbol> in <file>" pair that appears in the
- * scanned surfaces must resolve to a real file that really declares that symbol.
- * Rename a frozen surface without updating its remediation prose and this goes
- * red.
+ * remembering to grep. Rename a frozen surface without updating its remediation
+ * prose and this goes red.
+ *
+ * WHAT IS AND IS NOT REQUIRED TO CARRY A CITATION
+ * -----------------------------------------------
+ * `scripts/drift-report-collector.ts` is HAND-WRITTEN and stable: its alert
+ * strings are the pipeline's permanent remediation prose, so it MUST keep
+ * yielding "<symbol> in <file>" pairs, and a citation that stops being
+ * extractable is itself a failure (see the vacuity guards).
+ *
+ * `drift-proposals/*.md` are the OPPOSITE: drift-sync WRITES them mechanically,
+ * a human may hand-annotate them, and `fb9d9c5`-style cleanups legitimately
+ * DELETE them once resolved — the directory is routinely empty and is not even
+ * tracked when it holds no notes. A freshly generated note cites no symbol at
+ * all (see `renderProposalNote`), so requiring one to yield a pair turns the very
+ * next needs-human PR red with a false "prose was removed" message, and pinning
+ * the pair-count floor to note-borne pairs makes deleting a resolved note fail.
+ * They are therefore scanned OPPORTUNISTICALLY: whatever citation a note does
+ * carry must resolve, and no note may name a retired symbol, but a note is never
+ * required to carry a citation and an absent/empty directory is not an error.
+ *
+ * The "accepts valid input" describe block at the bottom is the standing proof of
+ * that: it runs this guard's own predicates against a REAL drift-sync-generated
+ * note, an empty notes directory, and an absent one, and requires all three to
+ * be accepted.
  *
  * Scope note: only camelCase / dotted / SCREAMING identifiers are treated as
  * symbol references. A lowercase English word before "in <file>" ("single source
  * of truth in surface-registry.ts") is prose, not a symbol reference.
  */
 import { describe, it, expect } from "vitest";
-import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { renderProposalNote, DRIFT_PROPOSALS_DIR } from "../../scripts/drift-sync.js";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 
+/** A file whose prose is scanned. `label` is what failure messages name. */
+interface Surface {
+  label: string;
+  abs: string;
+}
+
 /**
- * Surfaces whose prose instructs a human to edit a named symbol in a named file.
- * Add a surface here when it starts carrying that kind of instruction.
+ * Hand-written surfaces that instruct a human to edit a named symbol in a named
+ * file. These MUST yield at least one pair — add a surface here when it starts
+ * carrying that kind of instruction. Auto-generated or deletable files do NOT
+ * belong here; see the module docstring.
  */
-const SCANNED_SURFACES: string[] = [
-  "scripts/drift-report-collector.ts",
-  ...readdirSync(join(repoRoot, "drift-proposals"))
+const COLLECTOR_SURFACE = "scripts/drift-report-collector.ts";
+
+const REQUIRED_SURFACES: Surface[] = [
+  { label: COLLECTOR_SURFACE, abs: join(repoRoot, COLLECTOR_SURFACE) },
+];
+
+/**
+ * List the needs-human note directory, tolerating both an EMPTY directory and an
+ * ABSENT one. Git tracks no empty directories, so once the last resolved note is
+ * deleted the directory itself disappears — a bare `readdirSync` there throws
+ * ENOENT at module scope and takes every test in this file down with it as a
+ * collection error, which is a false red AND a total loss of coverage.
+ */
+function listNoteSurfaces(dirAbs: string, label: string): Surface[] {
+  let names: string[];
+  try {
+    names = readdirSync(dirAbs);
+  } catch {
+    return [];
+  }
+  return names
     .filter((f) => f.endsWith(".md"))
     .sort()
-    .map((f) => join("drift-proposals", f)),
-];
+    .map((f) => ({ label: `${label}/${f}`, abs: join(dirAbs, f) }));
+}
+
+/** Opportunistically-scanned surfaces: never required to carry a citation. */
+const OPTIONAL_SURFACES: Surface[] = listNoteSurfaces(
+  join(repoRoot, DRIFT_PROPOSALS_DIR),
+  DRIFT_PROPOSALS_DIR,
+);
+
+const ALL_SURFACES: Surface[] = [...REQUIRED_SURFACES, ...OPTIONAL_SURFACES];
+
+/** Must this surface yield at least one "<symbol> in <file>" pair? */
+function requiresPair(surface: Surface): boolean {
+  return REQUIRED_SURFACES.some((r) => r.label === surface.label);
+}
 
 /**
  * Directories a bare filename (`ws-realtime.drift.ts`, with no directory part)
@@ -72,13 +133,13 @@ interface Pair {
   file: string;
 }
 
-function collectPairs(): Pair[] {
+function collectPairs(surfaces: Surface[]): Pair[] {
   const pairs: Pair[] = [];
-  for (const surface of SCANNED_SURFACES) {
-    const src = flatten(readFileSync(join(repoRoot, surface), "utf8"));
+  for (const surface of surfaces) {
+    const src = flatten(readFileSync(surface.abs, "utf8"));
     for (const m of src.matchAll(SYMBOL_IN_FILE)) {
       if (!isSymbolShaped(m[1])) continue;
-      pairs.push({ surface, symbol: m[1], file: m[2] });
+      pairs.push({ surface: surface.label, symbol: m[1], file: m[2] });
     }
   }
   return pairs;
@@ -107,23 +168,55 @@ function declaresSymbol(file: string, symbol: string): boolean {
   return decl.test(src);
 }
 
-const pairs = collectPairs();
+/** `<line-number>: <text>` for every line of `surface` naming `symbol`. */
+function symbolHits(surface: Surface, symbol: string): string[] {
+  const re = new RegExp(`\\b${symbol}\\b`);
+  return readFileSync(surface.abs, "utf8")
+    .split("\n")
+    .map((line, i) => ({ line, n: i + 1 }))
+    .filter(({ line }) => re.test(line))
+    .map(({ n, line }) => `${n}: ${line.trim()}`);
+}
+
+/** `<line-number>: <text>` for every line carrying a Prettier-bolded `__tests__`. */
+function mangledTestPathLines(surface: Surface): string[] {
+  return readFileSync(surface.abs, "utf8")
+    .split("\n")
+    .map((line, i) => ({ line, n: i + 1 }))
+    .filter(({ line }) => /\*\*tests\*\*/.test(line))
+    .map(({ n, line }) => `${n}: ${line.trim()}`);
+}
+
+const pairs = collectPairs(ALL_SURFACES);
+const requiredPairs = pairs.filter((p) => REQUIRED_SURFACES.some((r) => r.label === p.surface));
 
 describe("drift remediation strings point at symbols that exist", () => {
-  // Vacuity guards. Every case below is generated FROM the extraction, so an
-  // extraction that quietly matches nothing would report a green suite with no
-  // cases at all. These two assertions are what make the generated cases mean
-  // something.
-  it("finds the symbol-and-file pairs it is meant to guard", () => {
-    expect(pairs.length).toBeGreaterThanOrEqual(5);
+  // Vacuity guards. Every per-pair case below is generated FROM the extraction,
+  // so an extraction that quietly matched nothing would report a green suite with
+  // no cases at all. These assertions are what make the generated cases mean
+  // something — and they are pinned to the REQUIRED surfaces only, so deleting a
+  // resolved needs-human note can never trip them.
+  it("has at least one required surface to scan", () => {
+    expect(REQUIRED_SURFACES.map((s) => s.label)).not.toHaveLength(0);
   });
 
-  for (const surface of SCANNED_SURFACES) {
-    it(`${surface} still contributes at least one pair`, () => {
+  it("finds the symbol-and-file pairs it is meant to guard", () => {
+    expect(
+      requiredPairs.map((p) => `${p.surface}: ${p.symbol} in ${p.file}`),
+      `The hand-written remediation surfaces yielded fewer than 3 "<symbol> in ` +
+        `<file>" pairs. Either the prose was removed, or a citation was reshaped ` +
+        `into something the extraction no longer recognises — which silently ` +
+        `drops it from this guard instead of failing it.`,
+    ).toHaveLength(requiredPairs.length);
+    expect(requiredPairs.length).toBeGreaterThanOrEqual(3);
+  });
+
+  for (const surface of REQUIRED_SURFACES) {
+    it(`${surface.label} still contributes at least one pair`, () => {
       expect(
-        pairs.filter((p) => p.surface === surface).map((p) => `${p.symbol} in ${p.file}`),
-        `No "<symbol> in <file>" pair was extracted from ${surface}. Either its ` +
-          `remediation prose was removed, or the citation was reshaped into ` +
+        pairs.filter((p) => p.surface === surface.label).map((p) => `${p.symbol} in ${p.file}`),
+        `No "<symbol> in <file>" pair was extracted from ${surface.label}. Either ` +
+          `its remediation prose was removed, or the citation was reshaped into ` +
           `something the extraction no longer recognises — which silently drops ` +
           `it from this guard.`,
       ).not.toHaveLength(0);
@@ -140,17 +233,13 @@ describe("drift remediation strings point at symbols that exist", () => {
  * `.prettierignore` to stop the rewrite at source; this asserts the outcome.
  */
 describe("no scanned surface carries a Prettier-mangled test path", () => {
-  for (const surface of SCANNED_SURFACES) {
-    it(`${surface} spells __tests__ literally`, () => {
-      const lines = readFileSync(join(repoRoot, surface), "utf8")
-        .split("\n")
-        .map((line, i) => ({ line, n: i + 1 }))
-        .filter(({ line }) => /\*\*tests\*\*/.test(line));
+  for (const surface of ALL_SURFACES) {
+    it(`${surface.label} spells __tests__ literally`, () => {
       expect(
-        lines.map(({ n, line }) => `${n}: ${line.trim()}`),
-        `${surface} contains \`**tests**\` — a Prettier-bolded \`__tests__\`. The ` +
-          `cited path does not exist. Restore the underscores (backtick the path) ` +
-          `and keep the file out of Prettier's reach.`,
+        mangledTestPathLines(surface),
+        `${surface.label} contains \`**tests**\` — a Prettier-bolded \`__tests__\`. ` +
+          `The cited path does not exist. Restore the underscores (backtick the ` +
+          `path) and keep the file out of Prettier's reach.`,
       ).toEqual([]);
     });
   }
@@ -181,7 +270,12 @@ describe("every cited symbol-and-file pair resolves on disk", () => {
  * Symbols that USED to name a drift-classification surface and no longer exist.
  * The pair check above only sees a symbol when the prose also names a file, so a
  * bare mention (`expected: "(not in knownModels set)"`, `path: "knownModels"`)
- * would still rot silently. Listing the retired names closes that gap.
+ * would still rot silently. Listing the retired names closes that gap for every
+ * surface scanned by this file — hand-written AND opportunistic.
+ *
+ * Scanning the notes for retired names cannot produce a false positive: a
+ * drift-sync-generated note never contains one (proved below), so a hit is always
+ * a human who hand-wrote a symbol that no longer exists.
  *
  * When you rename one of these surfaces again: add the OLD name here and update
  * every string that used it. The list is the record of what must no longer be
@@ -194,18 +288,100 @@ const RETIRED_SYMBOLS: Record<string, string> = {
 
 describe("drift remediation strings never name a retired symbol", () => {
   for (const [retired, replacement] of Object.entries(RETIRED_SYMBOLS)) {
-    it(`scripts/drift-report-collector.ts no longer references ${retired}`, () => {
-      const src = readFileSync(join(repoRoot, "scripts/drift-report-collector.ts"), "utf8");
-      const hits = src
-        .split("\n")
-        .map((line, i) => ({ line, n: i + 1 }))
-        .filter(({ line }) => new RegExp(`\\b${retired}\\b`).test(line));
-      expect(
-        hits.map(({ n, line }) => `${n}: ${line.trim()}`),
-        `"${retired}" no longer exists — it is now ${replacement}. Any drift ` +
-          `report field or alert string still using the old name sends the reader ` +
-          `after a symbol that is not in the codebase.`,
-      ).toEqual([]);
-    });
+    for (const surface of ALL_SURFACES) {
+      it(`${surface.label} no longer references ${retired}`, () => {
+        expect(
+          symbolHits(surface, retired),
+          `"${retired}" no longer exists — it is now ${replacement}. Any drift ` +
+            `report field or alert string still using the old name sends the ` +
+            `reader after a symbol that is not in the codebase.`,
+        ).toEqual([]);
+      });
+    }
   }
+});
+
+/**
+ * KNOWN-NEGATIVE CONTROLS — the guard must ACCEPT the input it is supposed to
+ * accept, not merely reject bad input.
+ *
+ * The version of this guard that shipped in `6614bb2` was only ever run against
+ * a tree whose two notes happened to be hand-annotated with citations. It was
+ * never shown to accept a note as drift-sync actually writes them, nor an empty
+ * notes directory, nor an absent one — and it in fact rejected all three. These
+ * cases are standing assertions so that regression cannot recur.
+ */
+describe("the guard accepts the input it is supposed to accept", () => {
+  /** A note exactly as drift-sync writes it — the REAL renderer, not a mock. */
+  function freshGeneratedNote(dirAbs: string): Surface {
+    const abs = join(dirAbs, "openai-gpt-nova-new-family.md");
+    writeFileSync(
+      abs,
+      renderProposalNote(
+        "openai",
+        "gpt-nova",
+        "new-family",
+        "This model family appeared in a live /models listing but matches no " +
+          "classification rule (include, exclude, -preview, gemma). drift-sync never " +
+          "silently classifies a new family.",
+        "2026-08-03",
+      ),
+      "utf-8",
+    );
+    return { label: `${DRIFT_PROPOSALS_DIR}/openai-gpt-nova-new-family.md`, abs };
+  }
+
+  it("accepts a note exactly as drift-sync generates it", () => {
+    const dir = mkdtempSync(join(tmpdir(), "drift-remediation-note-"));
+    try {
+      const note = freshGeneratedNote(dir);
+
+      // A generated note cites no symbol — that is CORRECT, not a removed
+      // citation, so it must not be required to yield a pair.
+      expect(
+        collectPairs([note]),
+        `drift-sync's generated note template now yields a "<symbol> in <file>" ` +
+          `pair. That is fine, but it means the template changed — re-read the ` +
+          `module docstring before assuming notes are still citation-free.`,
+      ).toEqual([]);
+      expect(
+        requiresPair(note),
+        `A drift-proposals note is being REQUIRED to carry a citation. Generated ` +
+          `notes carry none, so the next needs-human PR would go red with a false ` +
+          `"prose was removed" message.`,
+      ).toBe(false);
+
+      // And it must clear every check that IS applied to it.
+      expect(mangledTestPathLines(note)).toEqual([]);
+      for (const retired of Object.keys(RETIRED_SYMBOLS)) {
+        expect(symbolHits(note, retired)).toEqual([]);
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts an EMPTY notes directory (every note was resolved and deleted)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "drift-remediation-empty-"));
+    try {
+      expect(listNoteSurfaces(dir, DRIFT_PROPOSALS_DIR)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts an ABSENT notes directory (git tracks no empty directory)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "drift-remediation-absent-"));
+    rmSync(dir, { recursive: true, force: true });
+    expect(existsSync(dir)).toBe(false);
+    // Must not throw: at module scope a throw here is a COLLECTION error that
+    // takes every test in this file with it.
+    expect(listNoteSurfaces(dir, DRIFT_PROPOSALS_DIR)).toEqual([]);
+  });
+
+  it("still has required coverage when there are no notes at all", () => {
+    // The floor and the per-surface pair requirement must be satisfiable with the
+    // notes directory contributing nothing.
+    expect(collectPairs(REQUIRED_SURFACES).length).toBeGreaterThanOrEqual(3);
+  });
 });

--- a/src/__tests__/drift-remediation-strings.test.ts
+++ b/src/__tests__/drift-remediation-strings.test.ts
@@ -200,15 +200,31 @@ describe("drift remediation strings point at symbols that exist", () => {
     expect(REQUIRED_SURFACES.map((s) => s.label)).not.toHaveLength(0);
   });
 
+  // This asserted `requiredPairs.map(…)` had length `requiredPairs.length`, which
+  // is true of any array and could not fail, leaving a raw-count floor of 3 as the
+  // only real check — and the required surface cites the SAME
+  // `knownVoiceModelFamilies in …voice-models.ts` pair twice, so 3 raw pairs are
+  // only 2 DISTINCT citations. A raw count cannot tell "a citation was reshaped
+  // away" from "a citation is mentioned once more", which is the exact silent-drop
+  // this guard exists to catch. Assert the citations BY IDENTITY instead.
   it("finds the symbol-and-file pairs it is meant to guard", () => {
-    expect(
-      requiredPairs.map((p) => `${p.surface}: ${p.symbol} in ${p.file}`),
-      `The hand-written remediation surfaces yielded fewer than 3 "<symbol> in ` +
-        `<file>" pairs. Either the prose was removed, or a citation was reshaped ` +
-        `into something the extraction no longer recognises — which silently ` +
-        `drops it from this guard instead of failing it.`,
-    ).toHaveLength(requiredPairs.length);
-    expect(requiredPairs.length).toBeGreaterThanOrEqual(3);
+    const distinct = [...new Set(requiredPairs.map((p) => `${p.symbol} in ${p.file}`))].sort();
+    const why =
+      `A citation the required remediation prose is supposed to make was not ` +
+      `extracted. Either the prose was removed, or the citation was reshaped into ` +
+      `something the extraction no longer recognises — which silently drops it ` +
+      `from this guard instead of failing it. Extracted: ${JSON.stringify(distinct)}`;
+
+    // Every symbol the exit-2 realtime lane tells a human to go edit. Named
+    // individually: a count cannot distinguish losing one of these from repeating
+    // another, and it is the identity that has to survive a reshape.
+    expect(distinct, why).toContain("gaRealtimeModels in src/__tests__/drift/voice-models.ts");
+    expect(distinct, why).toContain(
+      "knownVoiceModelFamilies in src/__tests__/drift/voice-models.ts",
+    );
+    // Vacuity floor, in DISTINCT citations — scales if a surface starts citing
+    // more, and unlike the raw count it cannot be satisfied by duplication.
+    expect(distinct.length, why).toBeGreaterThanOrEqual(2);
   });
 
   for (const surface of REQUIRED_SURFACES) {

--- a/src/__tests__/drift-remediation-strings.test.ts
+++ b/src/__tests__/drift-remediation-strings.test.ts
@@ -1,0 +1,211 @@
+/**
+ * The remediation strings in the drift pipeline are the ONLY instruction a human
+ * gets when the daily drift job goes red: they arrive in a Slack alert (or the
+ * auto-fix prompt) saying "add X to <symbol> in <file>". If the symbol was
+ * renamed or the file moved, the reader chases a ghost — and nothing in CI
+ * notices, because a string literal is never type-checked.
+ *
+ * That has now happened twice on the same string:
+ *   - `knownModels` was renamed `knownVoiceModelFamilies` and moved out of
+ *     `ws-realtime.drift.ts` into `src/__tests__/drift/voice-models.ts`;
+ *   - `gaModels` was renamed `gaRealtimeModels` and moved to the same place.
+ * Both renames left the collector's prose pointing at the old name/location, and
+ * the hand-written EXCLUDE notes under `drift-proposals/` cite test paths in the
+ * same shape.
+ *
+ * So this test makes the audit trail STRUCTURAL rather than a matter of
+ * remembering to grep: every "<symbol> in <file>" pair that appears in the
+ * scanned surfaces must resolve to a real file that really declares that symbol.
+ * Rename a frozen surface without updating its remediation prose and this goes
+ * red.
+ *
+ * Scope note: only camelCase / dotted / SCREAMING identifiers are treated as
+ * symbol references. A lowercase English word before "in <file>" ("single source
+ * of truth in surface-registry.ts") is prose, not a symbol reference.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+/**
+ * Surfaces whose prose instructs a human to edit a named symbol in a named file.
+ * Add a surface here when it starts carrying that kind of instruction.
+ */
+const SCANNED_SURFACES: string[] = [
+  "scripts/drift-report-collector.ts",
+  ...readdirSync(join(repoRoot, "drift-proposals"))
+    .filter((f) => f.endsWith(".md"))
+    .sort()
+    .map((f) => join("drift-proposals", f)),
+];
+
+/**
+ * Directories a bare filename (`ws-realtime.drift.ts`, with no directory part)
+ * is resolved against, in order.
+ */
+const BARE_FILENAME_ROOTS = ["src/__tests__/drift", "src/__tests__", "scripts", "src"];
+
+/** `<symbol> in <file>.ts`, allowing an optional "list"/"set" noun and backticks. */
+const SYMBOL_IN_FILE =
+  /([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z0-9_$]+)*)\s+(?:list\s+|set\s+)?in\s+`?((?:[A-Za-z0-9_./-]*\/)?[A-Za-z0-9_.-]+\.ts)`?/g;
+
+/**
+ * Flatten a source file for prose scanning: join adjacent concatenated string
+ * literals (`"… in " + "src/…"`) and unwrap hard-wrapped lines, so a pair split
+ * across a line break is still seen as one pair.
+ */
+function flatten(src: string): string {
+  return src.replace(/"\s*\+\s*\n?\s*"/g, "").replace(/\n\s*/g, " ");
+}
+
+/** A symbol reference is code-shaped if it is camelCase, dotted, or SCREAMING. */
+function isSymbolShaped(token: string): boolean {
+  return /[A-Z]/.test(token) || token.includes(".");
+}
+
+interface Pair {
+  surface: string;
+  symbol: string;
+  file: string;
+}
+
+function collectPairs(): Pair[] {
+  const pairs: Pair[] = [];
+  for (const surface of SCANNED_SURFACES) {
+    const src = flatten(readFileSync(join(repoRoot, surface), "utf8"));
+    for (const m of src.matchAll(SYMBOL_IN_FILE)) {
+      if (!isSymbolShaped(m[1])) continue;
+      pairs.push({ surface, symbol: m[1], file: m[2] });
+    }
+  }
+  return pairs;
+}
+
+/** Resolve a cited path to an on-disk file, or null when it resolves nowhere. */
+function resolveCitedFile(cited: string): string | null {
+  if (cited.includes("/")) {
+    return existsSync(join(repoRoot, cited)) ? join(repoRoot, cited) : null;
+  }
+  for (const root of BARE_FILENAME_ROOTS) {
+    const candidate = join(repoRoot, root, cited);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** Does `file` DECLARE `symbol` (not merely mention it in a comment)? */
+function declaresSymbol(file: string, symbol: string): boolean {
+  // A dotted reference (`excludeFamilies.openai`) is satisfied by its head.
+  const head = symbol.split(".")[0];
+  const src = readFileSync(file, "utf8");
+  const decl = new RegExp(
+    `(?:export\\s+)?(?:declare\\s+)?(?:const|let|var|function|class|interface|type|enum)\\s+${head}\\b`,
+  );
+  return decl.test(src);
+}
+
+const pairs = collectPairs();
+
+describe("drift remediation strings point at symbols that exist", () => {
+  // Vacuity guards. Every case below is generated FROM the extraction, so an
+  // extraction that quietly matches nothing would report a green suite with no
+  // cases at all. These two assertions are what make the generated cases mean
+  // something.
+  it("finds the symbol-and-file pairs it is meant to guard", () => {
+    expect(pairs.length).toBeGreaterThanOrEqual(5);
+  });
+
+  for (const surface of SCANNED_SURFACES) {
+    it(`${surface} still contributes at least one pair`, () => {
+      expect(
+        pairs.filter((p) => p.surface === surface).map((p) => `${p.symbol} in ${p.file}`),
+        `No "<symbol> in <file>" pair was extracted from ${surface}. Either its ` +
+          `remediation prose was removed, or the citation was reshaped into ` +
+          `something the extraction no longer recognises — which silently drops ` +
+          `it from this guard.`,
+      ).not.toHaveLength(0);
+    });
+  }
+});
+
+/**
+ * The specific reshaping that already bit us: Prettier's markdown formatter
+ * reads `__tests__` in prose as bold emphasis and rewrites it to a bolded
+ * `tests`, so `src/__tests__/drift/voice-models.ts` turns into a path that does
+ * not exist AND no longer matches the extraction above — so it would vanish from
+ * the guard instead of failing it. `drift-proposals/` is in
+ * `.prettierignore` to stop the rewrite at source; this asserts the outcome.
+ */
+describe("no scanned surface carries a Prettier-mangled test path", () => {
+  for (const surface of SCANNED_SURFACES) {
+    it(`${surface} spells __tests__ literally`, () => {
+      const lines = readFileSync(join(repoRoot, surface), "utf8")
+        .split("\n")
+        .map((line, i) => ({ line, n: i + 1 }))
+        .filter(({ line }) => /\*\*tests\*\*/.test(line));
+      expect(
+        lines.map(({ n, line }) => `${n}: ${line.trim()}`),
+        `${surface} contains \`**tests**\` — a Prettier-bolded \`__tests__\`. The ` +
+          `cited path does not exist. Restore the underscores (backtick the path) ` +
+          `and keep the file out of Prettier's reach.`,
+      ).toEqual([]);
+    });
+  }
+});
+
+describe("every cited symbol-and-file pair resolves on disk", () => {
+  for (const { surface, symbol, file } of pairs) {
+    it(`${surface}: "${symbol} in ${file}" resolves`, () => {
+      const resolved = resolveCitedFile(file);
+      expect(
+        resolved,
+        `${surface} tells a human to edit "${symbol}" in "${file}", but that file ` +
+          `does not exist. Remediation prose is the only instruction the drift ` +
+          `alert carries — fix the path.`,
+      ).not.toBeNull();
+
+      expect(
+        declaresSymbol(resolved as string, symbol),
+        `${surface} tells a human to edit "${symbol}" in "${file}", but that file ` +
+          `declares no such symbol — it was renamed or moved. Point the prose at ` +
+          `the real symbol.`,
+      ).toBe(true);
+    });
+  }
+});
+
+/**
+ * Symbols that USED to name a drift-classification surface and no longer exist.
+ * The pair check above only sees a symbol when the prose also names a file, so a
+ * bare mention (`expected: "(not in knownModels set)"`, `path: "knownModels"`)
+ * would still rot silently. Listing the retired names closes that gap.
+ *
+ * When you rename one of these surfaces again: add the OLD name here and update
+ * every string that used it. The list is the record of what must no longer be
+ * referenced.
+ */
+const RETIRED_SYMBOLS: Record<string, string> = {
+  knownModels: "knownVoiceModelFamilies (src/__tests__/drift/voice-models.ts)",
+  gaModels: "gaRealtimeModels (src/__tests__/drift/voice-models.ts)",
+};
+
+describe("drift remediation strings never name a retired symbol", () => {
+  for (const [retired, replacement] of Object.entries(RETIRED_SYMBOLS)) {
+    it(`scripts/drift-report-collector.ts no longer references ${retired}`, () => {
+      const src = readFileSync(join(repoRoot, "scripts/drift-report-collector.ts"), "utf8");
+      const hits = src
+        .split("\n")
+        .map((line, i) => ({ line, n: i + 1 }))
+        .filter(({ line }) => new RegExp(`\\b${retired}\\b`).test(line));
+      expect(
+        hits.map(({ n, line }) => `${n}: ${line.trim()}`),
+        `"${retired}" no longer exists — it is now ${replacement}. Any drift ` +
+          `report field or alert string still using the old name sends the reader ` +
+          `after a symbol that is not in the codebase.`,
+      ).toEqual([]);
+    });
+  }
+});

--- a/src/__tests__/drift-scripts.test.ts
+++ b/src/__tests__/drift-scripts.test.ts
@@ -482,7 +482,7 @@ describe("summarizeDriftReport — headline class", () => {
             {
               severity: "critical",
               issue: "model removed from mock",
-              path: "knownModels",
+              path: "knownVoiceModelFamilies",
               id: "gpt-4o-mini",
               expected: "present",
               real: "present",


### PR DESCRIPTION
Split out of #343. Pre-strip sha of that branch: `146cb9d2b81017097480b0616d36b576411aa11c`.

#343 had accumulated 19 commits mixing two unrelated concerns. It has been stripped in place to the 8 commits that carry the actual model-family classification decision; this PR carries the other 11 — drift guard and collector/tooling hardening. Both branches are cut from the same merge-base (`9ce3107`), so this is **not** stacked on #343.

## What is here

Guard/tooling hardening only. This branch touches **no** classification data and **no** pin table:

| file | +/- |
|---|---|
| `scripts/drift-delta.ts` | 14 / 3 |
| `scripts/drift-report-collector.ts` | 69 / 18 |
| `src/__tests__/drift-collector.test.ts` | 531 / 57 |
| `src/__tests__/drift-delta.test.ts` | 4 / 4 |
| `src/__tests__/drift-remediation-strings.test.ts` | 403 / 0 |
| `src/__tests__/drift-scripts.test.ts` | 1 / 1 |

Highlights:

- **`declared` delta-key provenance actually binds.** It previously scanned every `.ts` under `src/` and `scripts/` for any declaration of the name, which made it a near-wildcard — all 20 generic one-word strings tried (`path`, `models`, `key`, `id`, …) are some local `const` somewhere, so a bare display path satisfied it. Now the key must name a symbol *exported* by a drift classification module.
- **Legacy provider-label fallback is anchored.** It accepted a label found anywhere and ranked by length, so `"Gemini Live Transcription session"` resolved to `Transcription` (13 chars) over `Gemini Live` (11) and routed a Gemini Live drift at `src/transcription.ts` — a confident wrong owner that failed open. Now anchored at the start, longest-first, and unattributable text fails closed to human review.
- **Remediation citations asserted by identity, not by count.** The old floor was a raw count of 3, but the required surface cites the same pair twice — so 3 raw pairs are only 2 distinct citations, and a count cannot distinguish "a citation was reshaped away" from "a citation is mentioned once more".
- Unknown-realtime-model alert points at a real symbol; canary delta keys decoupled from the display path; the clean-run base fixture made accurate, pinning a reuse defect it had hidden.

## Expected to be RED until #343 lands

Two live-API canaries fail on this branch, and **both already fail on `main`** — they are inherited, not introduced here:

- `src/__tests__/drift/models.drift.ts` › `live /models contains no unclassified family` — `['gpt-live-transcribe', 'gpt-transcribe']`
- `src/__tests__/drift/ws-realtime.drift.ts` › `canary: GA realtime models available` — `UNKNOWN_REALTIME_MODELS=gpt-transcribe,gpt-live-transcribe`

OpenAI shipped those two transcription families on 2026-07-28 and `main` does not classify them yet. **#343 is the PR that classifies them**, so these go green once it merges. Nothing in this branch can fix them — the classification data deliberately lives entirely in #343 so the decision exists in exactly one place.

Local gate on this branch: `pnpm build`, `pnpm lint`, `prettier --check .` all pass. `pnpm test` — 4810 passed, 2 failed (one is the canary above, one is the known `timing-replay` wall-clock flake, which passes isolated). `pnpm test:drift` — 134 passed, 2 failed (the two canaries above). No pin failures.

## Verification

Each of the three guards added here was mutation-tested on this branch — the guard was reverted to its pre-fix behaviour, the target test was confirmed RED, then the mutation was reverted:

- old wide-scan `declared` logic → `"path"` accepted, `expected 'declared' to be null` (RED)
- un-anchored provider label → `expected 'Transcription' to be 'Gemini Live'` (RED), plus the fail-closed case
- duplicated remediation citation → distinct citations dropped to 1 while the raw count stayed 3, so the old count-floor guard would have stayed green (RED)

DRAFT — do not merge. Ordering with #343 is intentional.
