### PR TITLE
test(drift): deliver the live-canary anti-silence coverage 4b26308 claimed had moved to #349

### DIFF
--- a/src/__tests__/drift/live-canary-silence.test.ts
+++ b/src/__tests__/drift/live-canary-silence.test.ts
@@ -1,0 +1,177 @@
+/**
+ * ANTI-SILENCE guard for the live TEXT-lane model-family canary — a
+ * fetch-stubbed, OFFLINE, end-to-end harness over the real chain.
+ *
+ * RECORD CORRECTION. Commit `4b26308` ("test(drift): move the live-canary
+ * anti-silence work to the guard PR (#349)") removed the previous anti-silence
+ * mechanism and said the work had moved to #349. It had not: #349 has since
+ * merged and neither `LIVE_CANARY_LEGS` nor the `freezes liveLeg.*` pins exist
+ * on it or on `main` — `git grep LIVE_CANARY_LEGS` returns nothing. The work was
+ * DELETED, not moved. The commit message on main cannot be rewritten, so this
+ * file is where the coverage actually landed. The original mechanism pinned
+ * SPANS OF TEXT and was defeated four times at four successive frames (detector,
+ * `describe.skipIf` gate, call site, fetcher); one of those pins even held
+ * regardless of production code, because the substring it matched is supplied by
+ * vitest's own `toEqual` diff output. Text-span pinning cannot close this class
+ * by extension, so this harness observes the chain's OUTPUT instead.
+ *
+ * WHAT IT DOES. `globalThis.fetch` is stubbed to serve a provider `/models`
+ * payload containing families that no classification rule covers, then the REAL
+ * chain is driven — `listOpenAIModels` (the fetcher) →
+ * `runUnclassifiedFamilyCanary` (the canary's call site) →
+ * `assertNoUnclassifiedFamilies` → `unclassifiedFamilies` (the detector) →
+ * `formatDriftReport` (the formatter) — and the assertion is BEHAVIOURAL: a
+ * failure must come out, and its text must parse through the collector's own
+ * `parseDriftBlock` into a `critical` entry per offending family, carrying the
+ * `API DRIFT DETECTED:` marker the collector routes on. Silencing at ANY of
+ * those four frames reddens this file.
+ *
+ * Parsing the failure with the REAL collector — rather than substring-matching
+ * the family name — is what keeps the assertion non-vacuous: vitest's diff does
+ * print the family names, but it cannot produce the numbered
+ * `[critical] … / Path: / SDK: / Real: / Mock:` block `parseDriftBlock` requires.
+ *
+ * OFFLINE BY CONSTRUCTION. The stub is installed per-test and throws on any URL
+ * other than the provider listing endpoint, so this file cannot reach the
+ * network even if the chain changes which host it calls; the recorded URL list is
+ * asserted too, which also proves the fetcher really ran rather than being
+ * bypassed. No API key is read from the environment — a literal placeholder is
+ * passed in.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { runUnclassifiedFamilyCanary } from "./text-drift.js";
+import { includeFamilies } from "./model-registry.js";
+import { parseDriftBlock, extractProviderName } from "../../../scripts/drift-report-collector.js";
+
+/** The only URL this suite's stub will serve. Anything else throws. */
+const OPENAI_MODELS_URL = "https://api.openai.com/v1/models";
+
+/** Verbatim the context string the OpenAI live leg in `models.drift.ts` passes. */
+const CANARY_CONTEXT = "OpenAI Chat (live /models family canary)";
+
+/**
+ * The literal the collector routes on — verified against the header regex in
+ * `scripts/drift-report-collector.ts`'s `parseDriftBlock`
+ * (`text.match(/API DRIFT DETECTED:\s*(.+)/)`), and emitted by
+ * `formatDriftReport` in `schema.ts`.
+ */
+const DRIFT_MARKER = "API DRIFT DETECTED:";
+
+/**
+ * Synthetic families that no rule classifies, deliberately TWO of them and
+ * deliberately named nothing else in the repo uses: a detector special-cased to
+ * keep one example family and drop the rest would still red this harness.
+ * Single-digit tails are not stripped by `normalizeModelFamily`, so each id
+ * normalizes to itself. Sorted, because `unclassifiedFamilies` sorts.
+ */
+const UNCLASSIFIED_FAMILIES = ["gpt-quasar-7", "gpt-zephyr"];
+
+/** A listing every classification rule already covers — the negative control. */
+function fullyClassifiedListing(): string[] {
+  return [...includeFamilies.openai];
+}
+
+let fetchedUrls: string[] = [];
+let realFetch: typeof globalThis.fetch;
+
+function stubModelsListing(modelIds: string[]): void {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    fetchedUrls.push(url);
+    if (url !== OPENAI_MODELS_URL) {
+      throw new Error(
+        `OFFLINE HARNESS: refusing to reach ${url} — this suite makes no network calls`,
+      );
+    }
+    return new Response(JSON.stringify({ data: modelIds.map((id) => ({ id })) }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+}
+
+/**
+ * Drive the real canary leg against a stubbed listing. Returns the failure
+ * message, or `null` if the chain produced no failure at all (i.e. it is
+ * silent).
+ */
+async function driveCanary(modelIds: string[]): Promise<string | null> {
+  stubModelsListing(modelIds);
+  try {
+    await runUnclassifiedFamilyCanary("openai", "sk-offline-stub-not-a-real-key", CANARY_CONTEXT);
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+beforeEach(() => {
+  realFetch = globalThis.fetch;
+  fetchedUrls = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("live TEXT-lane family canary: end-to-end anti-silence harness", () => {
+  it("emits a collector-routable drift report when the live listing carries an unclassified family", async () => {
+    const message = await driveCanary([...fullyClassifiedListing(), ...UNCLASSIFIED_FAMILIES]);
+
+    expect(
+      message,
+      "the canary chain produced NO failure for a listing containing unclassified families — " +
+        "it is SILENCED somewhere between the fetcher and the assertion",
+    ).not.toBeNull();
+
+    // The fetcher really ran, through the stub, and reached nothing else.
+    expect(fetchedUrls).toEqual([OPENAI_MODELS_URL]);
+
+    // The marker the collector routes on must be in the payload.
+    expect(message).toContain(DRIFT_MARKER);
+
+    // …and the payload must actually PARSE through the collector's own parser,
+    // which no amount of vitest diff noise can satisfy.
+    const block = parseDriftBlock(message!);
+    expect(
+      block,
+      "the failure text does not parse as a drift block — the collector would quarantine it",
+    ).not.toBeNull();
+    expect(block!.context).toBe(CANARY_CONTEXT);
+    expect(extractProviderName(block!.context)).toBe("OpenAI Chat");
+
+    // One critical entry per offending family, each naming the family.
+    expect(block!.diffs.map((d) => d.path).sort()).toEqual(
+      UNCLASSIFIED_FAMILIES.map((family) => `models/${family}`),
+    );
+    expect(block!.diffs.map((d) => d.severity)).toEqual(
+      UNCLASSIFIED_FAMILIES.map(() => "critical"),
+    );
+    for (const family of UNCLASSIFIED_FAMILIES) {
+      expect(block!.diffs.some((d) => d.issue.includes(family))).toBe(true);
+      expect(block!.diffs.some((d) => d.real === family)).toBe(true);
+    }
+  });
+
+  it("KNOWN-NEGATIVE control: stays green when every family in the listing is classified", async () => {
+    const message = await driveCanary(fullyClassifiedListing());
+
+    expect(
+      message,
+      "a fully-classified listing produced a drift failure — this guard fires on healthy input",
+    ).toBeNull();
+    expect(fetchedUrls).toEqual([OPENAI_MODELS_URL]);
+  });
+
+  it("is offline by construction: the stub refuses every URL but the listing endpoint", async () => {
+    stubModelsListing(fullyClassifiedListing());
+
+    await expect(globalThis.fetch("https://api.openai.com/v1/chat/completions")).rejects.toThrow(
+      /OFFLINE HARNESS: refusing to reach/,
+    );
+    expect(fetchedUrls).toEqual(["https://api.openai.com/v1/chat/completions"]);
+  });
+});

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -25,26 +25,22 @@
  * (e.g. `gemini-interactions`) can never enter the pipeline as a candidate id —
  * the only inputs are the provider's own `/models` payload.
  *
- * This file is the SPEC. The pipeline itself (`unclassifiedFamilies`), its live
- * assertion wrapper (`assertNoUnclassifiedFamilies`) and the C4 deprecation
- * detector live in `text-drift.ts`, which registers no suites — so another spec
- * can import them without also adopting the LIVE canaries below (see that
- * module's header).
+ * This file is the SPEC — the env gate and the `it()`, nothing more. The
+ * pipeline itself (`unclassifiedFamilies`), its live assertion wrapper
+ * (`assertNoUnclassifiedFamilies`), the leg body the canaries below call
+ * (`runUnclassifiedFamilyCanary`) and the C4 deprecation detector all live in
+ * `text-drift.ts`, which registers no suites — so another spec, or the offline
+ * fetch-stubbed guard in `live-canary-silence.test.ts`, can import and drive
+ * them without also adopting the LIVE canaries below (see that module's header).
  */
 
 import { describe, it, expect } from "vitest";
-import {
-  listOpenAIModels,
-  listAnthropicModels,
-  listGeminiModels,
-  InfraError,
-  isInfraSkip,
-} from "./providers.js";
+import { InfraError, isInfraSkip } from "./providers.js";
 import { includeFamilies } from "./model-registry.js";
 import { isFamilyStillReferenced } from "./deprecation-detector.js";
 import {
   unclassifiedFamilies,
-  assertNoUnclassifiedFamilies,
+  runUnclassifiedFamilyCanary,
   detectDeprecatedFamilies,
   checkDeprecatedFamiliesLive,
 } from "./text-drift.js";
@@ -443,8 +439,11 @@ describe("full live /models wave is fully classified (2026-07-16 drift)", () => 
 
 describe.skipIf(!process.env.OPENAI_API_KEY)("OpenAI Chat model-family availability", () => {
   it("live /models contains no unclassified family", async () => {
-    const models = await listOpenAIModels(process.env.OPENAI_API_KEY!);
-    assertNoUnclassifiedFamilies(models, "openai", "OpenAI Chat (live /models family canary)");
+    await runUnclassifiedFamilyCanary(
+      "openai",
+      process.env.OPENAI_API_KEY!,
+      "OpenAI Chat (live /models family canary)",
+    );
   });
 });
 
@@ -456,10 +455,9 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY)(
   "Anthropic Claude model-family availability",
   () => {
     it("live /models contains no unclassified family", async () => {
-      const models = await listAnthropicModels(process.env.ANTHROPIC_API_KEY!);
-      assertNoUnclassifiedFamilies(
-        models,
+      await runUnclassifiedFamilyCanary(
         "anthropic",
+        process.env.ANTHROPIC_API_KEY!,
         "Anthropic Claude (live /models family canary)",
       );
     });
@@ -472,7 +470,10 @@ describe.skipIf(!process.env.ANTHROPIC_API_KEY)(
 
 describe.skipIf(!process.env.GOOGLE_API_KEY)("Google Gemini model-family availability", () => {
   it("live /models contains no unclassified family", async () => {
-    const models = await listGeminiModels(process.env.GOOGLE_API_KEY!);
-    assertNoUnclassifiedFamilies(models, "gemini", "Google Gemini (live /models family canary)");
+    await runUnclassifiedFamilyCanary(
+      "gemini",
+      process.env.GOOGLE_API_KEY!,
+      "Google Gemini (live /models family canary)",
+    );
   });
 });

--- a/src/__tests__/drift/text-drift.ts
+++ b/src/__tests__/drift/text-drift.ts
@@ -27,7 +27,13 @@
 
 import { expect } from "vitest";
 
-import { InfraError, isInfraSkip } from "./providers.js";
+import {
+  InfraError,
+  isInfraSkip,
+  listOpenAIModels,
+  listAnthropicModels,
+  listGeminiModels,
+} from "./providers.js";
 import { normalizeModelFamily } from "./model-family.js";
 import { NON_MODEL_TOKENS, isClassifiedFamily, includeFamilies } from "./model-registry.js";
 import { formatDriftReport } from "./schema.js";
@@ -63,23 +69,17 @@ export function unclassifiedFamilies(modelIds: string[], provider: Provider): st
  * `formatDriftReport` block so the collector routes it to the exit-2 auto-fix
  * lane (provider names match `PROVIDER_MAP` keys in the collector).
  *
- * COVERAGE STATUS — this wrapper is currently UNGUARDED, on purpose, pending
- * PR #349. `unclassifiedFamilies` (above) is behaviourally covered: neutering it
- * to `return []` reddens `text-drift.test.ts`, the drift-sync mirror-equivalence
- * guard, and its co-located regressions under `test:drift`. THIS wrapper is not:
- * replacing its computed `unclassified` with a literal `[]`, or its `report` with
- * an unformatted string, silences the live text-lane canary with every suite
- * still green.
+ * COVERAGE STATUS — GUARDED, behaviourally, by
+ * `src/__tests__/drift/live-canary-silence.test.ts`. That harness stubs the HTTP
+ * layer and drives the whole chain (fetcher → `runUnclassifiedFamilyCanary` →
+ * this wrapper → `formatDriftReport` → the collector's real `parseDriftBlock`),
+ * so neutering this function's computed `unclassified` to `[]`, or replacing its
+ * `report` with an unformatted string, reddens that harness. Text pins on this
+ * function do NOT close that class (see the harness header); observing the
+ * chain's OUTPUT does.
  *
- * That gap is NOT closable by pinning this function's text or asserting that it
- * throws. The canary is a chain — fetcher → gate → call site → formatter →
- * collector — and each text-level pin only moves the silencing edit one frame
- * out (see the TEXT-lane note in `logic-pin.test.ts` for the four surfaces that
- * were tried). #349 replaces the approach with a fetch-stubbed end-to-end
- * harness that drives the real chain and asserts a collector-routable
- * `API DRIFT DETECTED:` report comes out, which catches silencing at any link.
- *
- * Exported because the three live legs of `models.drift.ts` call it.
+ * Exported because the three live legs of `models.drift.ts` reach it through
+ * {@link runUnclassifiedFamilyCanary}.
  */
 export function assertNoUnclassifiedFamilies(
   modelIds: string[],
@@ -105,6 +105,32 @@ export function assertNoUnclassifiedFamilies(
         )
       : `No drift detected: ${context}`;
   expect(unclassified, report).toEqual([]);
+}
+
+/**
+ * The live TEXT-lane canary LEG itself: fetch one provider's live `/models`
+ * listing and assert it carries no unclassified family.
+ *
+ * WHY THIS IS A FUNCTION and not inlined in each `models.drift.ts` leg — the
+ * CALL SITE (which list the fetcher's result is handed to) is one of the frames
+ * a silencing edit can hit, and `models.drift.ts` is a spec file whose top-level
+ * `describe`s are the LIVE canaries, so no offline test may import it to drive
+ * that frame. Hoisting the leg body here makes the call site reachable from the
+ * offline, fetch-stubbed harness in `live-canary-silence.test.ts` while the spec
+ * keeps only the env gate and the `it()`.
+ */
+export async function runUnclassifiedFamilyCanary(
+  provider: Provider,
+  apiKey: string,
+  context: string,
+): Promise<void> {
+  const fetchLiveModels = {
+    openai: listOpenAIModels,
+    anthropic: listAnthropicModels,
+    gemini: listGeminiModels,
+  }[provider];
+  const models = await fetchLiveModels(apiKey);
+  assertNoUnclassifiedFamilies(models, provider, context);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The record correction

Commit `4b26308` ("test(drift): move the live-canary anti-silence work to the guard PR (#349)") removed the text-pinning anti-silence anchor for the live TEXT-lane model-family canary and said the work had **moved** to #349.

It did not. #349 has since merged, and neither `LIVE_CANARY_LEGS` nor the `freezes liveLeg.*` pins exist on #349 or on `main` — `git grep LIVE_CANARY_LEGS` returns nothing. The work was **deleted, not moved**. The commit message on `main` cannot be rewritten, so this PR makes the claim true by actually delivering the coverage.

## Why not resurrect the old anchor

It pinned **spans of text**, and was defeated four times at four successive frames — the detector, the `describe.skipIf` gate, the call site, and the fetcher. One of those pins even held regardless of what production code did, because the substring it matched is supplied by **vitest's own `toEqual` diff output**. That class does not close by adding a fifth pin.

## What this adds instead

`src/__tests__/drift/live-canary-silence.test.ts` — an **offline, fetch-stubbed, end-to-end behavioural harness**. It stubs `globalThis.fetch` to serve a `/models` payload carrying families no classification rule covers, drives the **real** chain (`listOpenAIModels` → `runUnclassifiedFamilyCanary` → `assertNoUnclassifiedFamilies` → `unclassifiedFamilies` → `formatDriftReport`), and asserts the **behaviour**: a failure comes out, it carries the `API DRIFT DETECTED:` literal the collector routes on, and it parses through the collector's own `parseDriftBlock` into one `critical` entry per offending family with `path: models/<family>`.

Routing literal verified at `scripts/drift-report-collector.ts:127` — `text.match(/API DRIFT DETECTED:\s*(.+)/)` — and emitted by `formatDriftReport` at `src/__tests__/drift/schema.ts:480`.

Parsing with the real collector (rather than substring-matching the family name) is what keeps the assertion non-vacuous — see RED 4 below, where vitest's diff *does* print the family names.

**One refactor was required.** The CALL SITE is one of the four frames, and `models.drift.ts` is a spec file whose top-level `describe`s are the LIVE canaries, so no offline test may import it. The three legs' bodies move into `runUnclassifiedFamilyCanary` in `text-drift.ts` (which registers no suites); the spec keeps only the env gate and the `it()`. Verified: all three legs still collect under `vitest list --config vitest.config.drift.ts`, and none appear in the offline suite.

## Red-green proof — four REDs, one per frame

Each mutation was applied on top of this harness, observed, then reverted **by edit** (tree verified clean against `192026e`).

**RED 1 — fetcher.** `providers.ts` `listOpenAIModels`: `return json.data.map((m) => m.id)` → `.slice(0, 0)`

```
AssertionError: the canary chain produced NO failure for a listing containing unclassified families — it is SILENCED somewhere between the fetcher and the assertion: expected null not to be null
 ❯ src/__tests__/drift/live-canary-silence.test.ts:128:11
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

**RED 2 — call site.** `text-drift.ts` `runUnclassifiedFamilyCanary`: `assertNoUnclassifiedFamilies(models, …)` → `assertNoUnclassifiedFamilies(models.slice(0, 0), …)`

```
AssertionError: the canary chain produced NO failure for a listing containing unclassified families — it is SILENCED somewhere between the fetcher and the assertion: expected null not to be null
 ❯ src/__tests__/drift/live-canary-silence.test.ts:128:11
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

**RED 3 — detector.** `unclassifiedFamilies` → `return [];` as its first statement

```
AssertionError: the canary chain produced NO failure for a listing containing unclassified families — it is SILENCED somewhere between the fetcher and the assertion: expected null not to be null
 ❯ src/__tests__/drift/live-canary-silence.test.ts:128:11
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

**RED 3b — the wrapper's own computation** (the frame that was previously UNGUARDED — the old doc comment said neutering it left every suite green). `assertNoUnclassifiedFamilies`: `const unclassified = unclassifiedFamilies(modelIds, provider)` → `const unclassified: string[] = []`

```
AssertionError: the canary chain produced NO failure for a listing containing unclassified families — it is SILENCED somewhere between the fetcher and the assertion: expected null not to be null
 ❯ src/__tests__/drift/live-canary-silence.test.ts:128:11
```

**RED 4 — formatter.** the whole `const report = … formatDriftReport(…) …` construction → `const report = "opaque drift message";`

```
AssertionError: expected 'opaque drift message: expected [ \'gp…' to contain 'API DRIFT DETECTED:'

Expected: "API DRIFT DETECTED:"
Received: "opaque drift message: expected [ 'gpt-quasar-7', 'gpt-zephyr' ] to deeply equal []"

 ❯ src/__tests__/drift/live-canary-silence.test.ts:134:21
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

RED 4 is the empirical proof of the vacuity trap the old anchor fell into: the received string shows vitest's diff handing over `gpt-quasar-7` and `gpt-zephyr` **for free**. A family-name substring assertion would have stayed green here. The marker assertion and `parseDriftBlock` are what catch it.

No mutation failed to red. No assertion was weakened to make a mutation red, and no assertion is present that was not watched failing.

**KNOWN-NEGATIVE control (stays GREEN):** a fully-classified listing (`[...includeFamilies.openai]`) must produce no failure. Green in every run above — it is one of the `2 passed` in each RED block. A guard that always fires is worse than one that never does.

## Offline / no network

The stub throws on any URL other than the provider listing endpoint, and the recorded URL list is asserted (`expect(fetchedUrls).toEqual([OPENAI_MODELS_URL])`), which also proves the fetcher really ran rather than being bypassed. No API key is read from the environment — a literal placeholder is passed in.

`OPENAI_API_KEY=sk-fake pnpm test` → **zero** occurrences of `api.openai.com` in the log; the only `401` hits are a `401ms` duration and a test title containing "upstream 401". No live round-trip.

## Gates

- `pnpm build` — clean (273 files)
- `OPENAI_API_KEY=sk-fake pnpm test` — `168 passed, 1 failed (169 files)` / `4814 passed, 1 failed (4815 tests)`, **0 skipped**. The one failure is the pre-existing wall-clock flake `timing-replay.test.ts > replaySpeed 2.0 halves the replay duration` (`expected 207 to be less than 200`) — it also fails on unmodified `origin/main` (`expected 223 to be less than 200`) and passes in isolation (`5 passed`).
- `pnpm lint` — clean
- `prettier --check .` — clean
- `pnpm test:drift` **not run** (costs live API calls). Collection verified via `vitest list --config vitest.config.drift.ts`.

## Scope

Three files: the new harness, `text-drift.ts`, `models.drift.ts`. Version-neutral — no `package.json`, `CHANGELOG.md`, `.claude-plugin/*`, `charts/*`, `packages/aimock-pytest/*`, `scripts/`, or `.github/**` touched. `git diff origin/main..HEAD | grep -E '^[-+].*pin:'` is empty: this adds behaviour, not pins.
