### PR TITLE
fix(drift): key the delta by scenario — a new critical drift was landing in advisory

### DIFF
--- a/scripts/drift-delta.ts
+++ b/scripts/drift-delta.ts
@@ -20,19 +20,31 @@
  * Pure and side-effect-free — no filesystem, no network, no process state.
  */
 
-import type { DriftClass, DriftReport } from "./drift-types.js";
+// `DriftClass` is imported as a VALUE (not `import type`): CLASS_RANK is keyed by
+// its members so a new member is a compile error until it is given a rank.
+import { DriftClass } from "./drift-types.js";
+import type { DriftReport } from "./drift-types.js";
 
 /**
  * A single failure identified by the delta layer.
  *
- * A failure is keyed by `provider` + per-item `id` (NOT `path`, which is a
- * generic bucket like `"knownVoiceModelFamilies"` that would collapse N
- * distinct model drifts into one key). `class` is carried through purely for
+ * A failure is keyed by `provider` + `scenario` + per-item `id` (NOT `path`,
+ * which is a generic bucket like `"knownVoiceModelFamilies"` that would collapse
+ * N distinct model drifts into one key). `class` is carried through purely for
  * annotation and never participates in routing.
+ *
+ * `scenario` is load-bearing: a `DriftEntry` is one provider+scenario pair, and
+ * distinct scenarios of the same provider assert overlapping wire shapes — both
+ * `openaiChatCompletionShape` (non-streaming text) and the tool-call shape carry
+ * `usage.prompt_tokens` (src/__tests__/drift/sdk-shapes.ts). Without it, drift
+ * already on main in one scenario ABSORBS a genuinely new drift on the same field
+ * in another, and the gate passes silently. See `keyOf`.
  */
 export interface DeltaKey {
   /** Provider the failing entry belongs to (e.g. "anthropic"). */
   provider: string;
+  /** Scenario within the provider (e.g. "non-streaming tool call"). */
+  scenario: string;
   /** Stable per-item key (e.g. a model id). Falls back to path when absent. */
   id: string;
   /** Coarse classification — annotation only, never routes block vs advisory. */
@@ -50,19 +62,53 @@ export interface DeltaResult {
 }
 
 /**
- * Build the canonical string key for a failure. Keys by provider + per-item id.
- * When a diff has no `id` (legacy diffs), fall back to its `path` so it still
- * participates in the delta rather than being dropped — this is a coarse bucket
- * but preserves the block/advisory distinction across reports.
+ * Build the canonical string key for a failure: provider + scenario + per-item id.
+ *
+ * When a diff has no `id` (legacy diffs), the caller falls back to its `path` so
+ * it still participates in the delta rather than being dropped — this is a coarse
+ * bucket but preserves the block/advisory distinction across reports.
+ *
+ * SCENARIO IS PART OF THE KEY. It used to be `provider::id` only, which was
+ * fail-SILENT: `id` defaults to the diff's wire `path`, and the same wire path is
+ * asserted by several scenarios of one provider. So a base report already drifting
+ * on `OpenAI Chat` / `usage.prompt_tokens` in the non-streaming-text scenario made
+ * a NEW critical drift on the same field in the tool-call scenario key-identical to
+ * it — both-present → `advisory` → the required check PASSED on drift the diff
+ * introduced. (Bound: it only bit when the base already carried that exact
+ * provider+path; a brand-new field or model id always keyed new and blocked.)
+ *
+ * JSON-encoded rather than `::`-joined so no separator can appear inside a
+ * component: a scenario or id containing the separator would otherwise let two
+ * different tuples produce one key — re-creating the collapse this fixes.
  */
-function keyOf(provider: string, id: string): string {
-  return `${provider}::${id}`;
+function keyOf(provider: string, scenario: string, id: string): string {
+  return JSON.stringify([provider, scenario, id]);
 }
 
 /**
- * Flatten a report into a map of `key → DeltaKey`. When multiple diffs collapse
- * to the same key, the last one wins for annotation purposes (the routing
- * decision does not depend on which representative is retained).
+ * Severity rank for collision resolution. Higher wins. Absent `class` (legacy
+ * diffs) ranks lowest so any classified diff is preferred as the representative.
+ */
+const CLASS_RANK: Readonly<Record<DriftClass, number>> = {
+  [DriftClass.Critical]: 4,
+  [DriftClass.Quarantine]: 3,
+  [DriftClass.Advisory]: 2,
+  [DriftClass.None]: 1,
+};
+
+function classRank(cls: DriftClass | undefined): number {
+  return cls === undefined ? 0 : CLASS_RANK[cls];
+}
+
+/**
+ * Flatten a report into a map of `key → DeltaKey`.
+ *
+ * Two diffs can still collide on one key (two assertions in the SAME scenario
+ * reporting the same path). That used to be resolved LAST-WINS, which made the
+ * retained `class` depend on report order — `[Critical, Advisory]` annotated the
+ * key `advisory` and the reversed order annotated it `critical`. Routing never
+ * depended on it, but the annotation printed on a blocking key did. The MOST
+ * SEVERE class now wins, so the representative is deterministic.
  */
 function indexReport(report: DriftReport): Map<string, DeltaKey> {
   const index = new Map<string, DeltaKey>();
@@ -72,8 +118,17 @@ function indexReport(report: DriftReport): Map<string, DeltaKey> {
       // Changing how a diff keys re-keys it against the origin/main base while the
       // change is unmerged — see the transition note on isBaseReportReusable.
       const id = diff.id ?? diff.path;
-      const key = keyOf(entry.provider, id);
-      index.set(key, { provider: entry.provider, id, class: diff.class });
+      const key = keyOf(entry.provider, entry.scenario, id);
+      const existing = index.get(key);
+      if (existing !== undefined && classRank(existing.class) >= classRank(diff.class)) {
+        continue;
+      }
+      index.set(key, {
+        provider: entry.provider,
+        scenario: entry.scenario,
+        id,
+        class: diff.class,
+      });
     }
   }
   return index;
@@ -141,6 +196,16 @@ const REUSABLE_CONCLUSIONS: ReadonlySet<string> = new Set(["clean", "success"]);
  * EXPECTED during such a transition, it only fires if real drift appears while the
  * PR is open, and it clears the moment the change reaches main and the next base is
  * collected by the new code.
+ *
+ * That hazard is specific to changing how the COLLECTOR assigns `diff.id`, because
+ * the id is baked into the base report's JSON. It does NOT apply to changing
+ * `keyOf`/`indexReport` here: the delta gate imports this module from the PR
+ * checkout and indexes BOTH reports with it, so a key-shape change is applied
+ * symmetrically and a cached base report stays valid. What must hold is that every
+ * key COMPONENT is present in the persisted report — `scenario` is a required
+ * `DriftEntry` field the collector always populates (`extractScenario` falls back
+ * to the whole context string), so scenario-scoped keys are computable from any
+ * base report the reuse guard accepts.
  */
 export function isBaseReportReusable(
   report: DriftReport | null | undefined,

--- a/src/__tests__/drift-delta.test.ts
+++ b/src/__tests__/drift-delta.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { computeDelta, isBaseReportReusable } from "../../scripts/drift-delta.js";
 import type { DeltaKey } from "../../scripts/drift-delta.js";
 import { DriftClass } from "../../scripts/drift-types.js";
-import type { DriftReport, ParsedDiff } from "../../scripts/drift-types.js";
+import type { DriftEntry, DriftReport, ParsedDiff } from "../../scripts/drift-types.js";
 
 // ---------------------------------------------------------------------------
 // drift-delta: the delta-gating core.
@@ -51,6 +51,31 @@ function keys(list: DeltaKey[]): string[] {
   return list.map((k) => `${k.provider}:${k.id}`).sort();
 }
 
+/** A single entry with an explicit scenario, for multi-scenario reports. */
+function entryOf(provider: string, scenario: string, diffs: ParsedDiff[]): DriftEntry {
+  return {
+    provider,
+    scenario,
+    builderFile: "b.ts",
+    builderFunctions: ["f"],
+    typesFile: null,
+    sdkShapesFile: "shapes.ts",
+    diffs,
+  };
+}
+
+function reportOfEntries(
+  entries: DriftEntry[],
+  timestamp = "2026-08-04T00:00:00.000Z",
+): DriftReport {
+  return { timestamp, entries };
+}
+
+/** `provider:scenario:id` — the full identity the delta layer must key on. */
+function scopedKeys(list: DeltaKey[]): string[] {
+  return list.map((k) => `${k.provider}:${k.scenario}:${k.id}`).sort();
+}
+
 // ---------------------------------------------------------------------------
 // The M-1 golden regression (#292).
 //
@@ -75,7 +100,12 @@ describe("M-1 golden: new-in-head critical MUST block regardless of class", () =
     const advisory: DeltaKey[] = [];
     for (const entry of r.entries) {
       for (const d of entry.diffs) {
-        const dk: DeltaKey = { provider: entry.provider, id: d.id ?? d.path, class: d.class };
+        const dk: DeltaKey = {
+          provider: entry.provider,
+          scenario: entry.scenario,
+          id: d.id ?? d.path,
+          class: d.class,
+        };
         if (d.class === DriftClass.Critical) advisory.push(dk);
         else block.push(dk);
       }
@@ -156,6 +186,119 @@ describe("computeDelta routing by key presence", () => {
     const head = report("cohere", [diff({ path: "legacyBucket" })]); // no id
     const { block } = computeDelta(base, head);
     expect(keys(block)).toEqual(["cohere:legacyBucket"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SCENARIO must be part of the delta key.
+//
+// `keyOf` used to be `provider::id`, with `id` defaulting to the diff's `path`.
+// A `path` is a wire path (`usage.prompt_tokens`), and the SAME wire path is
+// asserted by MANY scenarios of the same provider — `openaiChatCompletionShape`
+// (non-streaming text) and the tool-call shape both carry `usage.prompt_tokens`
+// (src/__tests__/drift/sdk-shapes.ts). So a drift already present on main in
+// scenario A absorbed a genuinely NEW drift on the same field in scenario B:
+// both collapsed to one key, the key was base-present, and the new finding was
+// routed to `advisory` — a FAIL-SILENT pass of the required check on drift the
+// diff introduced.
+// ---------------------------------------------------------------------------
+describe("delta key includes scenario (fail-silent collapse)", () => {
+  const driftedField = () =>
+    diff({ path: "usage.prompt_tokens", id: "usage.prompt_tokens", class: DriftClass.Advisory });
+  const newCritical = () =>
+    diff({ path: "usage.prompt_tokens", id: "usage.prompt_tokens", class: DriftClass.Critical });
+
+  const base = reportOfEntries([entryOf("OpenAI Chat", "non-streaming text", [driftedField()])]);
+  const head = reportOfEntries([
+    entryOf("OpenAI Chat", "non-streaming text", [driftedField()]),
+    entryOf("OpenAI Chat", "non-streaming tool call", [newCritical()]),
+  ]);
+
+  it("a new critical drift on the same path in a DIFFERENT scenario BLOCKS", () => {
+    const { block, advisory, fixed } = computeDelta(base, head);
+    expect(scopedKeys(block)).toEqual(["OpenAI Chat:non-streaming tool call:usage.prompt_tokens"]);
+    expect(block[0].class).toBe(DriftClass.Critical);
+    expect(scopedKeys(advisory)).toEqual(["OpenAI Chat:non-streaming text:usage.prompt_tokens"]);
+    expect(fixed).toEqual([]);
+  });
+
+  it("KNOWN-NEGATIVE control: an unchanged base/head pair still blocks nothing", () => {
+    const { block, advisory, fixed } = computeDelta(head, head);
+    expect(block).toEqual([]);
+    expect(fixed).toEqual([]);
+    // Both scenarios survive as DISTINCT advisory keys — pre-existing drift
+    // stays pre-existing; the scenario scoping must not manufacture a block.
+    expect(scopedKeys(advisory)).toEqual([
+      "OpenAI Chat:non-streaming text:usage.prompt_tokens",
+      "OpenAI Chat:non-streaming tool call:usage.prompt_tokens",
+    ]);
+  });
+
+  it("a scenario disappearing from head is `fixed`, not silently absorbed", () => {
+    const { block, advisory, fixed } = computeDelta(head, base);
+    expect(block).toEqual([]);
+    expect(scopedKeys(advisory)).toEqual(["OpenAI Chat:non-streaming text:usage.prompt_tokens"]);
+    expect(scopedKeys(fixed)).toEqual(["OpenAI Chat:non-streaming tool call:usage.prompt_tokens"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A residual collision (same provider + scenario + id, e.g. two assertions in
+// one scenario reporting the same path) used to be resolved LAST-WINS, which
+// made the annotated `class` depend on report order: [Critical, Advisory]
+// annotated the key `advisory`, and the reversed order annotated it `critical`.
+// Routing never depended on it, but the human-facing annotation on a blocking
+// key did. The more severe class must win, deterministically.
+// ---------------------------------------------------------------------------
+describe("colliding keys resolve to the MOST SEVERE class, order-independently", () => {
+  const empty = reportOfEntries([entryOf("OpenAI Chat", "non-streaming text", [])]);
+
+  function collision(classes: DriftClass[]): DriftReport {
+    return reportOfEntries([
+      entryOf(
+        "OpenAI Chat",
+        "non-streaming text",
+        classes.map((c) =>
+          diff({ path: "usage.prompt_tokens", id: "usage.prompt_tokens", class: c }),
+        ),
+      ),
+    ]);
+  }
+
+  it("critical wins whether it is seen first or last", () => {
+    const first = computeDelta(empty, collision([DriftClass.Critical, DriftClass.Advisory]));
+    const last = computeDelta(empty, collision([DriftClass.Advisory, DriftClass.Critical]));
+    expect(first.block).toHaveLength(1);
+    expect(last.block).toHaveLength(1);
+    expect(first.block[0].class).toBe(DriftClass.Critical);
+    expect(last.block[0].class).toBe(DriftClass.Critical);
+  });
+
+  it("quarantine outranks advisory and none, in both orders", () => {
+    const first = computeDelta(empty, collision([DriftClass.Quarantine, DriftClass.None]));
+    const last = computeDelta(empty, collision([DriftClass.None, DriftClass.Quarantine]));
+    expect(first.block[0].class).toBe(DriftClass.Quarantine);
+    expect(last.block[0].class).toBe(DriftClass.Quarantine);
+  });
+
+  it("a classified diff outranks an unclassified (legacy) one, in both orders", () => {
+    const classed = () =>
+      diff({ path: "usage.prompt_tokens", id: "usage.prompt_tokens", class: DriftClass.Critical });
+    const legacy = () => {
+      const d = diff({ path: "usage.prompt_tokens", id: "usage.prompt_tokens" });
+      delete d.class;
+      return d;
+    };
+    const first = computeDelta(
+      empty,
+      reportOfEntries([entryOf("OpenAI Chat", "non-streaming text", [classed(), legacy()])]),
+    );
+    const last = computeDelta(
+      empty,
+      reportOfEntries([entryOf("OpenAI Chat", "non-streaming text", [legacy(), classed()])]),
+    );
+    expect(first.block[0].class).toBe(DriftClass.Critical);
+    expect(last.block[0].class).toBe(DriftClass.Critical);
   });
 });
 


### PR DESCRIPTION
## The bug: fail-SILENT — a new critical drift was classified `advisory` and the gate PASSED

`scripts/drift-delta.ts` built the delta key as `` `${provider}::${id}` `` with `const id = diff.id ?? diff.path`. `parseDriftBlock` sets `id: path`, so the key is effectively **provider + wire path** — and `scenario` (the other half of a `DriftEntry`'s identity) was absent from it.

The same wire path is asserted by *many* scenarios of one provider: `openaiChatCompletionShape` (non-streaming text) and the tool-call shape both carry `usage.prompt_tokens` (`src/__tests__/drift/sdk-shapes.ts:35,81`; scenarios `"non-streaming text"` / `"non-streaming tool call"`, `src/__tests__/drift/openai-chat.drift.ts:162,266`).

So a drift already present on main in scenario A **absorbed** a genuinely new critical drift on the same field in scenario B: one key, base-present, routed to `advisory`, `block` empty, `process.exit(0)`. No error, no annotation, required check green.

### RED (real `computeDelta`, `origin/main` code)

base = `[OpenAI Chat / non-streaming text / usage.prompt_tokens]`
head = base + `[OpenAI Chat / non-streaming tool call / usage.prompt_tokens, class critical]`

```
block   : []
advisory: [{"provider":"OpenAI Chat","id":"usage.prompt_tokens","class":"critical"}]
fixed   : []
gate exit code would be: 0
```

### GREEN (same inputs, after the fix)

```
block   : [{"provider":"OpenAI Chat","scenario":"non-streaming tool call","id":"usage.prompt_tokens","class":"critical"}]
advisory: [{"provider":"OpenAI Chat","scenario":"non-streaming text","id":"usage.prompt_tokens","class":"advisory"}]
fixed   : []
gate exit code would be: 1
```

### Bound

It only bit when the base already carried that **exact provider + path**. A brand-new field, a new model id, or a provider with no base drift always keyed new and blocked correctly. That is why it never showed up as a false green in practice — it needed a pre-existing drift on main to hide behind.

## Second defect: order-dependent last-wins collapse

A residual collision (two assertions in the *same* scenario reporting the same path) was resolved last-wins, so the `class` printed on a **blocking** key depended on report order. Real pre/post output, both orders, same provider+scenario+id:

```
=== PRE-FIX (origin/main): same provider+scenario+id, two classes ===
  [Critical, Advisory] block: ["advisory"]
  [Advisory, Critical] block: ["critical"]
=== POST-FIX ===
  [Critical, Advisory] block: ["critical"]
  [Advisory, Critical] block: ["critical"]
```

Routing never depended on `class` (the #292 invariant is untouched — routing is still key-presence only), but the annotation a human reads on a hard failure did. The most severe class now wins: `critical > quarantine > advisory > none > (absent)`. `CLASS_RANK` is typed `Record<DriftClass, number>`, so adding a `DriftClass` member is a compile error until it is ranked.

## Known-negative control — no false blocks

An unchanged base/head pair still blocks nothing; scenario scoping must not turn pre-existing drift into a block. Both scenarios survive as *distinct* advisory keys:

```
=== CONTROL: unchanged base/head ===
block   : []
advisory: [ non-streaming text / usage.prompt_tokens (advisory),
            non-streaming tool call / usage.prompt_tokens (critical) ]
fixed   : []
```

Covered by a named test (`KNOWN-NEGATIVE control: an unchanged base/head pair still blocks nothing`), plus a `fixed`-direction test so a scenario disappearing from head is reported rather than silently absorbed.

## Cached base reports stay valid

The earlier key-shape incident in this area (`gaModels` → `gaRealtimeModels`) invalidated the cached base because the key lived in the **collector's persisted `diff.id`**. This change is different in kind: the delta gate imports `drift-delta.ts` **from the PR checkout** and indexes *both* reports with it (`.github/workflows/test-drift.yml`, "Delta gate" step), so a `keyOf` change applies symmetrically to base and head — no transitional block/fixed churn.

The requirement is that every key component exists in the persisted JSON. `scenario` is a **required** `DriftEntry` field, populated on every collector path since the pipeline's first commit (`extractScenario` falls back to the whole context string when there are no parens), so scenario-scoped keys are computable from any base report `isBaseReportReusable` accepts — and that guard already rejects anything not same-UTC-day. The transition note on `isBaseReportReusable` now records this distinction.

One follow-up for whoever owns `.github/**` (deliberately untouched here): the gate's annotation formats a key as `${k.provider} ${k.id}`, so two blocked keys differing only in scenario print identically. `DeltaKey.scenario` is now available to include — additive, no behaviour change.

## Gates

- `pnpm build` — clean
- `pnpm test` — **169 files, 4821 tests, 0 skipped, 0 failed** (no `timing-replay` flake this run)
- `pnpm lint` — clean; `prettier --check .` — clean
- `tsc --noEmit` on both tsconfigs — clean; the delta-related test files typecheck standalone (the newly required `scenario` field surfaced one stale `DeltaKey` literal in the #292 simulation stub, fixed)
- `pnpm test:drift` **not run**: this is a pure, side-effect-free reduction of two JSON reports with no live surface, and the offline suite drives the real `computeDelta` directly. Running it would spend live API calls for no additional signal.
- Version-neutral: no `package.json`, `CHANGELOG.md`, `.claude-plugin/*`, `charts/*`, `packages/aimock-pytest/*`, or `.github/**` file touched. `git diff origin/main..HEAD | grep -E '^[-+].*pin:'` is empty.
