### PR TITLE
fix(release): read the pytest npm pin without importing the package

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -179,7 +179,10 @@ jobs:
 
       - name: Verify pinned npm release is published
         run: |
-          VERSION=$(python -c "import sys; sys.path.insert(0, 'packages/aimock-pytest/src'); from aimock_pytest._version import AIMOCK_VERSION; print(AIMOCK_VERSION)")
+          # Read the pin WITHOUT importing the package: aimock_pytest/__init__.py
+          # imports _server, which imports `requests`, and no Python deps are
+          # installed at this point in the job. runpy executes _version.py alone.
+          VERSION=$(python -c "import runpy; print(runpy.run_path('packages/aimock-pytest/src/aimock_pytest/_version.py')['AIMOCK_VERSION'])")
           npm view "@copilotkit/aimock@${VERSION}" version
 
       - name: Install build tools


### PR DESCRIPTION
The PyPI half of the v1.38.0 release failed. npm `1.38.0`, the `v1.38.0` tag and the GitHub release all went out; `publish-pytest` failed, so **PyPI is stranded on `0.5.0` while the pin says `1.38.0`**.

**Cause — the guard could never run.** The "Verify pinned npm release is published" step read the pin with `from aimock_pytest._version import AIMOCK_VERSION`. That executes `aimock_pytest/__init__.py`, which imports `_server`, which imports `requests` — and no Python deps are installed at that point in the job. Run [30947561858](https://github.com/CopilotKit/aimock/actions/runs/30947561858): `ModuleNotFoundError: No module named 'requests'`. Deterministic — it would fail on **every** release, and it is the guard that exists to prove npm published before a wheel is uploaded.

**Fix.** `runpy.run_path` executes `_version.py` alone. That file is a docstring plus one assignment with no imports of its own, so the pin reads with nothing installed.

**Verified, not assumed:**
- `runpy` on the bare file → `1.38.0`, rc=0, with no package on the path.
- Control: the old form against a package whose `__init__` imports a missing module → `ModuleNotFoundError`, rc=1 — CI's exact failure reproduced.
- A missing `AIMOCK_VERSION` now raises `KeyError` rather than printing empty, so the guard still **fails closed**.
- `actionlint` clean. Workflow-only diff; no version-bearing file touched.

**After this merges**, dispatch `Release` to finish the v1.38.0 rollout: the npm publish no-ops (1.38.0 already published, the version gate skips it) and `publish-pytest` proceeds to upload `aimock-pytest 0.5.2` pinned to a version that is genuinely on npm.