### PR TITLE
test(drift): the alert-state sweep reads a comparand in every spelling bash accepts

### DIFF
--- a/src/__tests__/fix-drift-workflow.test.ts
+++ b/src/__tests__/fix-drift-workflow.test.ts
@@ -704,6 +704,41 @@ function observeAlertPost(
 }
 
 /**
+ * A shell word that reads ONE variable: `$V`, `${V}`, `${V:-…}`, and any of
+ * those double-quoted.
+ *
+ * Deliberately loose about the quoting (`"$V` matches too). The sweep below
+ * reading a SUPERSET is the safe direction — a spurious state is one more state
+ * the body has to deliver in, whereas a spelling the sweep fails to recognise is
+ * a state NOBODY tests, which is the whole defect class this helper exists for.
+ */
+const SH_VAR_WORD = String.raw`"?\$\{?[A-Za-z_][A-Za-z0-9_]*(?::-[^}"\s]*)?\}?"?`;
+
+/** A shell word standing for a value: quoted either way, or bare. */
+const SH_VALUE_WORD = String.raw`(?:"[^"]*"|'[^']*'|[^\s;&|)\]]+)`;
+
+/** The variable NAME inside an {@link SH_VAR_WORD} match. */
+const shVarName = (word: string): string | null =>
+  /^"?\$\{?([A-Za-z_][A-Za-z0-9_]*)/.exec(word)?.[1] ?? null;
+
+const shUnquote = (word: string): string => word.replace(/^(["'])([\s\S]*)\1$/, "$2");
+
+/**
+ * ONE value that matches a shell pattern — a `case` arm, or the unquoted
+ * right-hand side of `[[ … == … ]]`, which bash reads as a glob rather than as
+ * a literal.
+ *
+ * `ok-*)` is every bit as much a comparand as `ok-applied)`, so it gets a
+ * witness (`ok-`) instead of being dropped. `null` where there is no cheap
+ * witness: a bracket class, and the bare `*)` catch-all — which distinguishes
+ * nothing, being the fall-through the base state already drives.
+ */
+function shPatternWitness(pattern: string): string | null {
+  if (/[[\]]/.test(pattern)) return null;
+  return pattern.replace(/\\(.)/g, "$1").replace(/\*/g, "").replace(/\?/g, "x") || null;
+}
+
+/**
  * Every (env var, value) state the step's OWN body distinguishes, read out of
  * the artifact.
  *
@@ -713,10 +748,16 @@ function observeAlertPost(
  * stood the catch-all down with nothing delivered, and both harnesses fed a
  * value (`""`, `<SYNC_REASON>`) that no comparison in the body matches.
  *
- * So the domain comes from the comparisons the body itself makes: every literal
- * an `env:`-declared variable is compared against, plus the empty string for
- * every variable tested with `-z`/`-n`. A branch added later extends the swept
- * domain by existing, which is what a fixture list cannot do.
+ * So the domain comes from the comparisons the body itself makes: every value an
+ * `env:`-declared variable is compared against, plus the empty string for every
+ * variable tested with `-z`/`-n`. A branch added later extends the swept domain
+ * by existing, which is what a fixture list cannot do — but only for the
+ * spellings this reads, so it reads every spelling bash accepts rather than the
+ * one the artifact happens to use today. `==` is a synonym the `[` builtin
+ * takes, `case` is how a multi-way branch is normally written, and neither
+ * shellcheck nor actionlint flags either: a maintainer reaching for one of them
+ * would have left the tested domain without a single tool saying so, and a
+ * stand-down hiding behind it would have been invisible here.
  *
  * `SLACK_WEBHOOK` is excluded: an empty webhook is the ONE state in which these
  * bodies are entitled not to POST, and it has its own guard.
@@ -725,17 +766,48 @@ function envStatesFrom(step: Step): Array<{ label: string; env: Record<string, s
   const body = runOf(step);
   const declared = new Set(Object.keys(step.env));
   const states = new Map<string, Record<string, string>>();
-  const add = (name: string, value: string): void => {
+  const add = (name: string | null, value: string | null): void => {
+    if (name === null || value === null) return;
     if (!declared.has(name) || name === "SLACK_WEBHOOK") return;
     states.set(`${name}=${JSON.stringify(value)}`, { [name]: value });
   };
+  // An equality test, in every spelling: `=`, `==` (the `[` builtin's synonym)
+  // or `!=`; the variable braced or not; the comparand double-quoted, single-
+  // quoted or bare. `[[ … ]]` needs nothing extra — the INNER bracket satisfies
+  // `\[`, and the inner `]` satisfies `\]`.
   for (const m of body.matchAll(
-    /\[\s+"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-)?\}"\s+(?:=|!=)\s+"([^"]*)"\s+\]/g,
+    new RegExp(String.raw`\[\s+(${SH_VAR_WORD})\s+(?:==?|!=)\s+(${SH_VALUE_WORD})\s+\]`, "g"),
   )) {
-    add(m[1], m[2]);
+    // `[ "$A" = "$B" ]` compares two variables and so names no value at all.
+    if (m[2].includes("$")) continue;
+    add(
+      shVarName(m[1]),
+      m[2].startsWith('"') ? shUnquote(m[2]) : shPatternWitness(shUnquote(m[2])),
+    );
   }
-  for (const m of body.matchAll(/\[\s+-[zn]\s+"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-)?\}"\s+\]/g)) {
-    add(m[1], "");
+  for (const m of body.matchAll(new RegExp(String.raw`\[\s+-[zn]\s+(${SH_VAR_WORD})\s+\]`, "g"))) {
+    add(shVarName(m[1]), "");
+  }
+  // `case "$V" in a | b-*) … ;; esac` — every arm names a value the body
+  // distinguishes exactly as an equality test does.
+  for (const m of body.matchAll(
+    new RegExp(String.raw`\bcase\s+(${SH_VAR_WORD})\s+in\b([\s\S]*?)\besac\b`, "g"),
+  )) {
+    const name = shVarName(m[1]);
+    for (const arm of m[2].split(";;")) {
+      // The arm's patterns run to its first `)`; everything after that is the
+      // code the arm runs, which may contain `)` of its own.
+      const close = arm.indexOf(")");
+      if (close === -1) continue;
+      for (const pattern of arm
+        .slice(0, close)
+        .replace(/^\s*\(/, "")
+        .split("|")) {
+        const word = pattern.trim();
+        if (!word || word.includes("$")) continue;
+        add(name, shPatternWitness(shUnquote(word)));
+      }
+    }
   }
   return [
     { label: "every declared value present", env: {} },
@@ -3660,6 +3732,53 @@ describe("fix-drift.yml — fail-silent repairs a revert must not be able to pas
         gate,
         `the alert-state sweep does not read ${want} out of the gate alert's own body, so ` +
           "that branch is never executed and an early stand-down hiding behind it is invisible",
+      ).toContain(want);
+    }
+    // …and it reads a comparand however it is SPELLED, not only the way the
+    // artifact happens to spell it today. Each row below is a real stand-down
+    // (`case "${SYNC_REASON}" in ok-applied) echo "posted=true"; exit 1 ;;
+    // esac`) that this file passed 130/130 on, actionlint clean: one keystroke
+    // outside the swept spelling and the zero-Slack window is open again with
+    // every assertion green. The bodies use none of these forms today, so the
+    // artifact cannot demonstrate the property — these do.
+    const spellings = (line: string): string[] =>
+      envStatesFrom({ ...stepById("alert_cancelled"), run: line }).map((s) => s.label);
+    for (const [want, how, line] of [
+      [
+        'SYNC_REASON="ok-applied"',
+        "`==`, the synonym `[` accepts for `=`",
+        'if [ "${SYNC_REASON}" == "ok-applied" ]; then :; fi',
+      ],
+      [
+        'SYNC_REASON="ok-applied"',
+        "an unbraced `$VAR`",
+        'if [ "$SYNC_REASON" = "ok-applied" ]; then :; fi',
+      ],
+      [
+        'SYNC_REASON="ok-applied"',
+        "a bare, unquoted comparand",
+        'if [ "${SYNC_REASON}" = ok-applied ]; then :; fi',
+      ],
+      [
+        'SYNC_REASON="ok applied"',
+        "a single-quoted comparand",
+        `if [ "\${SYNC_REASON}" = 'ok applied' ]; then :; fi`,
+      ],
+      [
+        'SYNC_REASON="ok-applied"',
+        "a `case` arm",
+        'case "${SYNC_REASON}" in needs-human | ok-applied) : ;; esac',
+      ],
+      [
+        'SYNC_REASON="ok-applied"',
+        "a GLOBBED `case` arm",
+        'case "${SYNC_REASON}" in ok-applied*) : ;; esac',
+      ],
+    ] as const) {
+      expect(
+        spellings(line),
+        `the sweep does not read a comparand written as ${how}, so a body branching that ` +
+          "way is driven in one fixture state only and an early stand-down behind it never runs",
       ).toContain(want);
     }
     // …and it reaches the empty-string states a `-z`/`-n` test distinguishes,


### PR DESCRIPTION
## What this closes

`envStatesFrom` drives the alert-delivery guard over **every state an alert body branches on**, read
out of the artifact rather than from a fixture list — so a branch added later widens the tested
domain by existing. That is the property that caught the last round's exploit.

It only recognised `[ "${V}" = "…" ]` (and `!=`, and `-z`/`-n`). A comparand spelled **any other
way** left the tested domain silently. `==` is a synonym the `[` builtin accepts, `case … in` is how
a multi-way branch is normally written, an unbraced `"$V"` and a bare right-hand side are one
keystroke from the swept form — and neither shellcheck nor actionlint says a word about any of them.

**Not a live defect.** OBSERVED by parsing the artifact with the file's own step parser: none of the
six Slack steps contains a `case`, a `==`, a `!=` or a `[[` today. This is a future-regression gap.

## Watched RED → GREEN, on the real failure surface

Each mutation puts a zero-Slack stand-down into `alert_cancelled`'s body, keyed on a value the
runner really produces — the catch-all's `posted=true` published having reached Slack **zero** times,
which is the total-silence window the whole mechanism exists to close:

```
case "${SYNC_REASON}" in ok-applied) echo "posted=true" >> "$GITHUB_OUTPUT"; exit 1 ;; esac
```

Baseline unmutated: **130 passed**. `actionlint` rc 0 on every mutant.

| stand-down spelled as | suite BEFORE | suite AFTER |
|---|---|---|
| `case "${V}" in ok-applied)` | **GREEN 130/130** | **RED** 1 failed / 129 |
| `case "${V}" in ok-app*)` (globbed arm) | **GREEN 130/130** | **RED** |
| `[ "${V}" == "ok-applied" ]` | **GREEN 130/130** | **RED** |
| `[[ "${V}" == "ok-applied" ]]` | **GREEN 130/130** | **RED** |
| `[ "$V" = "ok-applied" ]` (unbraced) | **GREEN 130/130** | **RED** |
| `[ "${V}" = ok-applied ]` (bare RHS) | **GREEN 130/130** | **RED** |
| `[ "${V}" = 'ok-applied' ]` (single-quoted) | **GREEN 130/130** | **RED** |
| `[[ "${V}" = "ok-applied" ]]` | RED (already, by accident) | **RED** |

```
AssertionError: Alert on job CANCELLATION (posts ahead of the artifact uploads): with
SYNC_REASON="ok-applied" the body reaches Slack 0 times instead of once — a state the runner
can produce short-circuits the POST, and it published posted="true": expected +0 to be 1
```

The globbed arm reports `with SYNC_REASON="ok-app"` — the witness derived from `ok-app*` — so the
glob handling is doing the work rather than a coincidence.

`.github/workflows/fix-drift.yml` was mutated **locally only**, restored by `cp` from a snapshot, and
is byte-identical to `main` (md5 `15ae112fdca47dcb221b0fab629e36f6`). `git checkout` was never run.

### `[[ … ]]` was already swept — a correction

The old regex opened `\[\s+`, which matches the **inner** bracket of `[[ `, and closed `\s+\]`, which
matches the first `]` of `]]`. That is why the `[[ … = … ]]` mutant was the one of eight that RED'd
before the fix. So the brackets stay single; what `[[ ]]` was really hiding is `==`.

## Mutation-check of the new code itself

Each row of the MODEL guard's spelling table dies to its **own** mutation — no two rows share one:

| mutation of the HARNESS | verdict |
|---|---|
| the `==` alternative removed from the equality operator | **RED** — "…written as `` `==` ``, the synonym `[` accepts for `=`" |
| `SH_VAR_WORD` requires braces | **RED** — "…an unbraced `$VAR`" |
| `SH_VALUE_WORD` drops the bare alternative | **RED** — "…a bare, unquoted comparand" |
| `SH_VALUE_WORD` drops the single-quoted alternative | **RED** — "…a single-quoted comparand" |
| `shPatternWitness` stops stripping `*` | **RED** — "…a GLOBBED `case` arm" |
| the whole `case` loop deleted | **RED** — "…a `case` arm" |
| the sweep collapsed to its base state (pre-existing anti-vacuity check) | **RED** |

A `[[ … == … ]]` row was **dropped** rather than added: it dies to the same `==` mutation as the
plain `[ … == … ]` row, and two tests that die to one mutation are one test.

## Cost

Swept-state counts per alert step are **byte-identical** before and after — `alert_cancelled=2
alert_rejected=2 alert_needs_human=2 alert_gate=10 notify_success=2 alert_catchall=3` — because no
body uses the new forms yet. **Zero new process spawns.**

| | delivery guard | MODEL guard |
|---|---|---|
| before, 3 runs | 754 / 573 / 585 ms | 1 / 1 / 1 ms |
| after, 3 runs | 544 / 608 / 708 ms | 4 / 3 / 4 ms |

~2% of the 30 000 ms budget, ~45× margin. Test count in the file is **130, unchanged** — the table
extends the existing MODEL `it(…)` rather than adding tests. One file, +128/−9.

## Gates (real exit codes, never a piped one)

| gate | rc | result |
|---|---|---|
| `pnpm build` (before tests) | 0 | Build complete, 277 files |
| `pnpm test` | 0 | **5024 passed (5024)**, 171 files |
| `pnpm test:drift` | 0 | 119 passed / 66 skipped |
| `pnpm exec tsc --noEmit` | 0 | clean |
| `pnpm lint` | 0 | clean |
| `pnpm format:check` | 0 | clean |
| `pnpm test:exports` | 0 | node10 / node16 CJS+ESM / bundler all green |

No version consumed: no `package.json`, `CHANGELOG.md`, `.claude-plugin/*`, `charts/*`,
`packages/aimock-pytest/*` or `pnpm-lock.yaml` change.

## Not in scope

GAP-1 (a POST is counted, never inspected) is **already closed** by `603c421` on
`drift/348-followup`, which POSTs to a recording socket and asserts the request arrived, its method,
its content-type and its `text`. Not duplicated here.
