### PR TITLE
ci: pin pkg-pr-new to the lockfile; document why the pnpm toolchain cannot be integrity-pinned

### DIFF
--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -17,4 +17,24 @@ jobs:
         with: { node-version: 24, cache: pnpm }
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: npx pkg-pr-new publish
+      # `pnpm exec`, NOT `npx`. This step used to be `npx pkg-pr-new publish`,
+      # and `pkg-pr-new` was in neither package.json nor pnpm-lock.yaml — so npx
+      # resolved the `latest` dist-tag at run time and executed whatever bytes
+      # the registry served, with no integrity check of any kind. That is a
+      # live arbitrary-code-execution seam on every PR: a malicious publish or a
+      # registry/account compromise lands attacker code inside this job. It is
+      # also the ONLY `npx` target in this repo that is not already a
+      # devDependency (`tsx` and `vitest`, the others, resolve from the tree).
+      #
+      # `pkg-pr-new` is now an EXACT-pinned devDependency, so the
+      # `pnpm install --frozen-lockfile` above has already verified its tarball
+      # against the reviewed sha512 in pnpm-lock.yaml — substituted bytes fail
+      # the install with ERR_PNPM_TARBALL_INTEGRITY and this step never runs.
+      # `pnpm exec` then runs THOSE verified bytes out of node_modules and
+      # fetches nothing. Do not reintroduce `npx` here.
+      #
+      # WHEN THIS FAILS: pkg-pr-new cut a new release and you want it. Bump the
+      # exact version in package.json's devDependencies and regenerate the
+      # lockfile (`pnpm install`) so a reviewed integrity hash lands in the
+      # diff. Do not widen the specifier to a range to avoid that review.
+      - run: pnpm exec pkg-pr-new publish

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2",
     "openai": "^4.0.0",
+    "pkg-pr-new": "0.0.86",
     "prettier": "^3.6.2",
     "publint": "^0.3.12",
     "tsdown": "^0.12.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       openai:
         specifier: ^4.0.0
         version: 4.104.0(ws@8.20.0)
+      pkg-pr-new:
+        specifier: 0.0.86
+        version: 0.0.86
       prettier:
         specifier: ^3.6.2
         version: 3.8.1
@@ -2639,6 +2642,10 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  pkg-pr-new@0.0.86:
+    resolution: {integrity: sha512-BwPsw/e1Be7F0SfpxhNc2VSxX7uHgCy46Ck+2Z/vqCwXoePhUBrX/VbcawpAlZgMvQe2iwGbZIQ6HSj9bmCk8A==}
+    hasBin: true
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -5953,6 +5960,8 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  pkg-pr-new@0.0.86: {}
 
   postcss@8.5.8:
     dependencies:

--- a/src/__tests__/ci-toolchain-pinning.test.ts
+++ b/src/__tests__/ci-toolchain-pinning.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(__dirname, "../..");
+const workflowDir = resolve(repoRoot, ".github/workflows");
+const read = (p: string) => readFileSync(resolve(repoRoot, p), "utf8");
+
+const publishCommit = read(".github/workflows/publish-commit.yml");
+const manifest = JSON.parse(read("package.json")) as {
+  devDependencies?: Record<string, string>;
+  dependencies?: Record<string, string>;
+};
+const lockfile = read("pnpm-lock.yaml");
+
+/**
+ * Guards the ONE class of unpinned executable that survived the `uses:`-by-SHA
+ * sweep: a `run:` step that hands a package name to a runner which resolves it
+ * from the registry AT RUN TIME.
+ *
+ * `npx <pkg>` with `<pkg>` absent from the manifest downloads whatever the
+ * registry currently serves for the `latest` dist-tag and executes it, with no
+ * integrity check. `npx <pkg>` with `<pkg>` present as a dependency resolves
+ * from node_modules, whose bytes `pnpm install --frozen-lockfile` has already
+ * verified against the sha512 committed in pnpm-lock.yaml.
+ *
+ * So the invariant is NOT "never say npx" — it is "every package name a
+ * workflow executes must be governed by the lockfile".
+ */
+describe("no workflow executes a package the lockfile does not govern", () => {
+  const declared = new Set([
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.devDependencies ?? {}),
+  ]);
+
+  const workflows = readdirSync(workflowDir).filter(
+    (f) => f.endsWith(".yml") || f.endsWith(".yaml"),
+  );
+
+  it("finds workflows to check (guards against a silently empty sweep)", () => {
+    expect(workflows.length).toBeGreaterThan(5);
+  });
+
+  it.each(workflows)("%s runs no unpinned registry executable", (file) => {
+    const body = readFileSync(resolve(workflowDir, file), "utf8");
+    const offenders: string[] = [];
+
+    for (const raw of body.split("\n")) {
+      // Ignore comment-only lines: prose about npx is not an invocation.
+      const line = raw.replace(/^\s*#.*$/, "");
+      // `npx foo` / `pnpm dlx foo` / `npm exec foo` — the run-time resolvers.
+      // `pnpm exec` is deliberately NOT here: it only ever resolves from
+      // node_modules and fails loudly when the binary is absent.
+      const m = line.match(
+        /(?:^|[;&|(]\s*|\s)(?:npx|npm exec|pnpm dlx)\s+((?:@[\w.-]+\/)?[\w.-]+)/,
+      );
+      if (!m) continue;
+      const pkg = m[1];
+      if (pkg.startsWith("-")) continue; // a flag, not a package name
+      if (!declared.has(pkg)) offenders.push(`${pkg} (in: ${line.trim()})`);
+    }
+
+    expect(
+      offenders,
+      `${file} executes package(s) that are in neither package.json nor pnpm-lock.yaml, so the registry decides at run time what code runs: ${offenders.join(", ")}`,
+    ).toEqual([]);
+  });
+});
+
+describe("pkg-pr-new is byte-pinned, not resolved at run time", () => {
+  it("is an EXACT-version devDependency (no range for the registry to move)", () => {
+    const spec = manifest.devDependencies?.["pkg-pr-new"];
+    expect(spec).toBeDefined();
+    // No ^ ~ > < * x || - : an exact version is the only thing that keeps the
+    // reviewed integrity hash below authoritative.
+    expect(spec).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("carries a real sha512 integrity hash in the lockfile", () => {
+    const spec = manifest.devDependencies?.["pkg-pr-new"];
+    const entry = lockfile.match(
+      new RegExp(
+        `\\n  pkg-pr-new@${spec?.replace(/\./g, "\\.")}:\\n\\s+resolution: \\{integrity: (sha512-[A-Za-z0-9+/=]+)\\}`,
+      ),
+    );
+    expect(
+      entry,
+      "pnpm-lock.yaml has no integrity-bearing entry for the pinned pkg-pr-new",
+    ).not.toBeNull();
+    // sha512, base64: 64 raw bytes -> 88 chars with padding.
+    expect(entry?.[1].slice("sha512-".length)).toHaveLength(88);
+  });
+
+  it("the publish step runs the installed bytes, and does so AFTER the verifying install", () => {
+    expect(publishCommit).toContain("pnpm exec pkg-pr-new publish");
+    expect(publishCommit).not.toMatch(/^\s*-?\s*run:\s*npx pkg-pr-new/m);
+
+    const install = publishCommit.indexOf("pnpm install --frozen-lockfile");
+    const publish = publishCommit.indexOf("pnpm exec pkg-pr-new publish");
+    expect(install).toBeGreaterThan(-1);
+    expect(publish).toBeGreaterThan(install);
+  });
+});
+
+/**
+ * NOT A PIN, AND DELIBERATELY RECORDED AS SUCH.
+ *
+ * package.json's `packageManager` field names `pnpm@10.28.2` — a version with
+ * no integrity hash. The corepack spec allows `pnpm@<version>+sha512.<hash>`,
+ * and corepack DOES enforce that hash (a wrong one hard-fails with "Mismatch
+ * hashes"). `pnpm/action-setup`, which is what actually installs pnpm in CI,
+ * does NOT: its shipped dist/index.js at the SHA this repo pins evaluates
+ * `packageManager.startsWith("pnpm@") ? i.slice(5).split("+")[0] : void 0`,
+ * discarding the suffix before anything is fetched. Running that exact action
+ * bundle with a 128-zero hash installs pnpm 10.28.2 and exits 0, identically
+ * to running it with the genuine hash.
+ *
+ * This test therefore asserts the field stays HONEST — a bare version, with no
+ * integrity suffix implying a verification that nothing performs. If the pnpm
+ * toolchain is ever byte-pinned for real (switch to corepack, or fetch the
+ * tarball and sha256-check it the way test-drift.yml provisions Ollama), this
+ * test is the thing to update, along with the comment above.
+ */
+describe("the pnpm toolchain pin claims no more than it delivers", () => {
+  it("packageManager carries no integrity suffix that pnpm/action-setup would ignore", () => {
+    const pm = (JSON.parse(read("package.json")) as { packageManager?: string }).packageManager;
+    expect(pm).toMatch(/^pnpm@\d+\.\d+\.\d+$/);
+  });
+
+  it("every pnpm/action-setup use is itself pinned to a commit SHA", () => {
+    for (const file of readdirSync(workflowDir).filter((f) => f.endsWith(".yml"))) {
+      const body = readFileSync(resolve(workflowDir, file), "utf8");
+      for (const line of body.split("\n")) {
+        if (!/^\s*-?\s*uses:\s*pnpm\/action-setup@/.test(line)) continue;
+        expect(line, `${file}: pnpm/action-setup must be pinned by 40-char commit SHA`).toMatch(
+          /pnpm\/action-setup@[0-9a-f]{40}/,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes the last two unpinned executables in CI. **One is fixed. One cannot be, and this PR says so with evidence instead of pretending otherwise.**

## 1. `npx pkg-pr-new publish` — FIXED

`publish-commit.yml:20` ran `npx pkg-pr-new publish`, and `pkg-pr-new` was in **neither `package.json` nor `pnpm-lock.yaml`** — so npx resolved the `latest` dist-tag at run time and executed whatever the registry served, unverified. It was the **only** `npx` target in the repo not already a devDependency (`tsx` and `vitest`, the others, resolve from the installed tree).

Not latent: `pkg-pr-new@0.0.87` was published **hours** before this branch was cut. Every PR after that moment would have executed a build nobody here had looked at.

**In scope in that job (honestly):** zero `secrets.` references; `GITHUB_TOKEN` at `contents: read` on a **public** repo, so near-zero value; and `pkg-pr-new` is handed no token at all (it authenticates via GitHub App + run metadata). The real prize is the **pkg.pr.new publish channel** — a substituted CLI publishes arbitrary tarballs under this repo's preview URLs, which reviewers and users then `npm i`. Actions-cache poisoning into `drift-live-pr` (7 live provider keys, same PR scope) is a *possibility I did not test* and am **not** claiming.

Fix: exact-pinned devDependency + `pnpm exec`, so the preceding `pnpm install --frozen-lockfile` verifies the tarball against a reviewed sha512.

### Watched RED (sandboxed, `env -u`-scrubbed, no real credential present)

Committed step body, verbatim, against a local registry serving substituted bytes:

```
$ npx pkg-pr-new publish
npm warn exec The following package was not found and will be installed: pkg-pr-new@0.0.86
SUBSTITUTED-PKG-PR-NEW-RAN
STEP_EXIT=0
$ cat MARKER.txt
SUBSTITUTED pkg-pr-new EXECUTED argv=publish
```

Attacker code ran, wrote to disk, and **the step reported success**.

### Watched GREEN — refused

```
$ pnpm install --frozen-lockfile
 ERR_PNPM_TARBALL_INTEGRITY  Got unexpected checksum for ".../pkg-pr-new-0.0.86.tgz".
   Wanted "sha512-BwPsw/e1Be…bmCk8A=="   Got "sha512-3CDoOk/m0h0…XnS1NA=="
INSTALL_EXIT=1
$ ls MARKER.txt          -> No such file or directory
$ ls node_modules/.bin/  -> No such file or directory
$ pnpm exec pkg-pr-new publish
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "pkg-pr-new" not found
```

The demonstrated **absence** of the payload at an executor — no marker, no binary, the step cannot resolve its own command.

### Positive control — CI still works

```
$ pnpm install --frozen-lockfile   -> INSTALL_EXIT=0, + pkg-pr-new 0.0.86
installed dist/index.js sha256  = d1f4c92bbfad12699f7046646082d4075d84161b3275f29d9a7f3fb3cadb9d31
independently downloaded 0.0.86 = d1f4c92bbfad12699f7046646082d4075d84161b3275f29d9a7f3fb3cadb9d31
$ pnpm exec pkg-pr-new publish
Continuous Releases are only available in GitHub Actions.
```

Byte-identical to the reviewed tarball, and that refusal is the **real** CLI's own guard — my payload has no such message. "Refuse everything" cannot satisfy this half.

### Positive control on the REAL path — this PR's own `preview` job **passed**

```
Run pnpm install --frozen-lockfile   -> + pkg-pr-new 0.0.86
Run pnpm exec pkg-pr-new publish     -> ⚡️ Your npm packages are published.
                                        { owner: CopilotKit, repo: aimock, ref: 361 }
preview  pass
```

The lockfile-verified binary published the previews exactly as the unpinned `npx` used to. Nothing about CI's behaviour changed except what governs the bytes.

### RE-BREAK — 5 mutations, all red, workspace md5 identical before/after

| # | mutation | result |
|---|---|---|
| M1 | step reverted to today's `npx pkg-pr-new publish` | RED 1/21 |
| M2 | `pkg-pr-new` deleted from devDependencies | RED 2/21 |
| M3 | exact pin widened to `^0.0.86` | RED 2/21 |
| M4 | genuine corepack hash appended to `packageManager` | RED 1/21 |
| M5 | one `pnpm/action-setup@<sha>` unpinned to `@v6` | RED 1/21 |

M1 proves the guard reds on the state `main` is in **today** — the suite is not vacuous.

### `package.json` / `pnpm-lock.yaml`

`package.json`: **one added line**, `"pkg-pr-new": "0.0.86"`. Exact, not `^`, so Renovate cannot silently widen it. `pnpm-lock.yaml`: three hunks, **purely additive**.

- **package `version` is UNCHANGED** — `git diff -U0 package.json | grep -c '"version"'` → `0`; tree `1.38.0`, `HEAD~1` `1.38.0`.
- **No other dependency moved** — the lockfile diff contains **zero** deletion lines.

`0.0.86` not `0.0.87`: `.87` was published minutes before the pin was written, which reproduces in slow motion the window the pin exists to close. `.86` has been public since 2026-07-30, has **zero runtime deps and no install scripts**, and its integrity is agreed by three independent sources (packument, my own sha512 over the tarball, the lockfile).

## 2. The pnpm toolchain — **NOT PINNABLE**, evidence below

`"packageManager": "pnpm@10.28.2"` has no integrity hash. Corepack **does** enforce a `+sha512.<hash>` suffix — a 128-zero hash gives `Error: Mismatch hashes`, exit 1. But `pnpm/action-setup@0977fd99` (the SHA all 16 call sites pin) **strips it**. Its own source:

```ts
// packageManager is always exact `pnpm@<version>[+<integrity>]` per spec.
// Strip the integrity hash for self-update.
? packageManager.slice('pnpm@'.length).split('+')[0]
```

and the shipped bundle agrees: `startsWith("pnpm@")?i.slice(5).split("+")[0]:void 0`.

Proved by running that exact `dist/index.js` twice:

```
A) "pnpm@10.28.2+sha512." + "0"*128   (corepack REFUSES this)  -> EXIT=0, installed 10.28.2
B) "pnpm@10.28.2+sha512.41872f03…"    (the GENUINE hash)       -> EXIT=0, installed 10.28.2
```

**Identical outcome with a right hash and a wrong one — the suffix is never compared.** So I did **not** add one: it would read as an integrity pin while verifying nothing, which is exactly the defect class this repo has been deleting. **M4 now reds if anyone adds it.**

What *is* verified: the action bootstraps pnpm v11.19.0 via `npm ci` against lockfiles committed inside the action (byte-pinned transitively, since the action is SHA-pinned), then `pnpm self-update 10.28.2` fetches from the npm registry verified against **registry-served** metadata. That second hop is TOFU, not a hash reviewed here. The comment already at `test-drift.yml:205-209` states this correctly and needed no change.

Real routes, both out of scope (16 call sites, two in files another agent held this round): corepack (works, but is **removed in Node 25**, so it acquires its own expiry) or fetch-and-sha256 the Ollama way. Pinning one workflow and leaving fifteen would be an inconsistent toolchain and a worse trap than a documented gap.

## Guard suite

`src/__tests__/ci-toolchain-pinning.test.ts`, 21 tests. Asserts the **general** invariant — every package name any workflow hands to `npx`/`pnpm dlx`/`npm exec` must be manifest-declared — so a future unpinned executable anywhere reds too. `pnpm exec` is deliberately excluded (resolves only from `node_modules`, fails loudly when absent — as GREEN-A showed). Comment lines are stripped before matching; a `workflows.length > 5` assertion prevents a silently empty sweep.

## Gates — real exit codes, read from logs, never through a pipe

`pnpm install --frozen-lockfile` 0 · `pnpm build` 0 · **`pnpm test` 0 — 173 files, 5087 tests, all passed** (no known flakes fired) · `pnpm test:drift` 0 (18 passed/8 skipped files, 119/66 tests) · `tsc --noEmit` 0 · `pnpm lint` 0 · `prettier --check` on all 4 changed files 0 · `actionlint` 0 · `bash -n` on all 3 changed `run:` bodies 0 · `zizmor --min-severity medium` 0, "No findings to report" · `pnpm test:exports` 0 (all four resolvers 🟢).

## Scope

`publish-release.yml` and `test-pytest.yml` **untouched**. `CHANGELOG.md`, `.claude-plugin/*`, `charts/*`, `packages/aimock-pytest/*` untouched. No credential read/echoed/persisted; every sandbox run under `env -u` scrubbing. No workflow run triggered. Explicit file list on commit, never `git add -A`.
