### PR TITLE
fix(drift): the daily cron dies at jq — PR listings no longer travel through argv

### DIFF
--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -489,6 +489,24 @@ jobs:
           CHANGESET_KEY: ${{ steps.sync.outputs.changeset_key }}
         run: |
           set -euo pipefail
+          # ---- RECORD WHAT ACTUALLY HAPPENS IN HERE ----------------------------
+          # Actions hands a later step only `outcome` — success/failure/skipped —
+          # so the gate-failure alert below cannot see WHY this step died and used
+          # to print a hand-written list of the causes someone imagined. Persist
+          # the real exit code and the real stderr so it can quote them instead.
+          # Same six lines in the sibling needs-human step; see the alert for the
+          # incident that earned them.
+          #
+          # stderr is captured to a file and REPLAYED to the console on exit
+          # (fd 3 holds the console), so nothing is lost from the job log — it
+          # just lands at the end of the step rather than interleaved. A `tee`
+          # through process substitution would keep the interleaving but races
+          # with step exit, and a truncated last line is the one line this reads.
+          DRIFT_STATUS_DIR="${RUNNER_TEMP}/drift-step-status"
+          mkdir -p "$DRIFT_STATUS_DIR"
+          exec 3>&2
+          exec 2> "${DRIFT_STATUS_DIR}/pr.err"
+          trap 'rc=$?; printf "%s\n" "$rc" > "${DRIFT_STATUS_DIR}/pr.rc"; exec 2>&3; cat "${DRIFT_STATUS_DIR}/pr.err" >&2; exit $rc' EXIT
           # De-dup (idempotent across daily re-fires): the mechanical edit is
           # never auto-merged, so an un-merged drift is re-detected every cron run
           # and would otherwise open a brand-new PR each day. Skip when an open PR
@@ -931,6 +949,26 @@ jobs:
           CHANGESET_KEY: ${{ steps.sync.outputs.changeset_key }}
         run: |
           set -euo pipefail
+          # ---- RECORD WHAT ACTUALLY HAPPENS IN HERE ----------------------------
+          # Actions hands a later step only `outcome` — success/failure/skipped —
+          # so the gate-failure alert below cannot see WHY this step died and used
+          # to print a hand-written list of the causes someone imagined. On
+          # 2026-08-06 and 2026-08-07 it printed "push rejected, gh pr create
+          # error, or PR-match polling exhausted" while THIS step had actually
+          # died with `jq: Argument list too long` and exit 126, which is none of
+          # the three. Persist the real exit code and the real stderr so the alert
+          # can quote them. Same six lines in the sibling ok-applied PR step.
+          #
+          # stderr is captured to a file and REPLAYED to the console on exit
+          # (fd 3 holds the console), so nothing is lost from the job log — it
+          # just lands at the end of the step rather than interleaved. A `tee`
+          # through process substitution would keep the interleaving but races
+          # with step exit, and a truncated last line is the one line this reads.
+          DRIFT_STATUS_DIR="${RUNNER_TEMP}/drift-step-status"
+          mkdir -p "$DRIFT_STATUS_DIR"
+          exec 3>&2
+          exec 2> "${DRIFT_STATUS_DIR}/needs_human_pr.err"
+          trap 'rc=$?; printf "%s\n" "$rc" > "${DRIFT_STATUS_DIR}/needs_human_pr.rc"; exec 2>&3; cat "${DRIFT_STATUS_DIR}/needs_human_pr.err" >&2; exit $rc' EXIT
           HEAD_SHA="$(git rev-parse HEAD)"
 
           # An EMPTY key must fail CLOSED rather than fall through to an
@@ -1818,8 +1856,10 @@ jobs:
       # The ok-applied arm is deliberately WIDE — `failure()`, not narrowly
       # `steps.assert.outcome == 'failure'` — because the defense-in-depth Assert
       # step can SUCCEED and a LATER step still fail the job (Push branch + create
-      # PR: a rejected push, a `gh pr create` error, or the head-SHA PR-match polling
-      # loop exhausting its attempts). Narrower, that window leaves reason ==
+      # PR can fail for ANY reason — a rejected push, a `gh pr create` error, an
+      # exhausted head-SHA PR-match poll, or, as on 2026-08-07, an E2BIG inside a
+      # jq call, which is why the alert below quotes evidence instead of guessing
+      # from a list like this one). Narrower, that window leaves reason ==
       # 'ok-applied' (non-empty, so the early-infra catch-all below stays silent) and
       # assert == 'success' (so this alert stays silent too): a silent failure on an
       # unattended daily cron.
@@ -1853,6 +1893,44 @@ jobs:
           # A REAL newline — see the cancellation alert above for why a
           # double-quoted "\n" renders literally in Slack instead.
           NL=$'\n'
+          # ---- QUOTE THE FAILURE, DO NOT ENUMERATE GUESSES ----------------------
+          # This alert used to name a failing step and then append a hand-written
+          # list of the causes someone imagined for it. On 2026-08-06 and
+          # 2026-08-07 (runs 31079603526 / 31154443828) it said "push rejected, gh
+          # pr create error, or PR-match polling exhausted" on two consecutive
+          # mornings while the persist step had actually died with
+          # `/usr/bin/jq: Argument list too long` and exit 126 — an E2BIG in a
+          # marker-self-heal `jq --argjson`, which is none of the three. Naming a
+          # plausible cause is WORSE than naming none: it sends triage at the push
+          # credential and the PR-match poll, and the real defect survives for as
+          # many mornings as it takes someone to open the raw log.
+          #
+          # Both PR steps now record their real exit code and stderr under
+          # RUNNER_TEMP. Report THOSE. A missing record is itself reported as
+          # missing — never smoothed over with a guess.
+          DRIFT_STATUS_DIR="${RUNNER_TEMP}/drift-step-status"
+          step_evidence() {
+            local rc_f="${DRIFT_STATUS_DIR}/$1.rc" err_f="${DRIFT_STATUS_DIR}/$1.err" rc last
+            if [ ! -r "$rc_f" ]; then
+              printf ' — NO exit code was recorded, so it died before its own status prologue ran (a runner-level fault, not a fault in the step body)'
+              return 0
+            fi
+            rc="$(cat "$rc_f")"
+            # An empty stderr makes grep exit 1, and `pipefail` propagates that.
+            # It does NOT currently kill the alert — bash suppresses errexit for a
+            # function body running inside a command substitution, which is the
+            # only way this is called — so `|| true` is belt-and-braces against a
+            # future direct call, not a load-bearing guard, and no test below
+            # claims otherwise. What IS load-bearing is the `${last:-…}` default:
+            # without it an empty stderr renders as nothing at all, and the alert
+            # is contentless again on exactly the runs it exists to report.
+            #
+            # Bounded to 300 chars so one enormous stderr line cannot bloat the
+            # Slack payload (or push `jq -n --arg text` back towards the argv cap
+            # this incident was about).
+            last="$( { grep -v '^[[:space:]]*$' "$err_f" 2>/dev/null || true; } | tail -n 1 | cut -c1-300 )"
+            printf ' — exited %s; last stderr: %s' "$rc" "${last:-(the step wrote nothing to stderr)}"
+          }
           if [ "${SYNC_REASON}" = "sync-crashed" ]; then
             FAILING_STEP="Run deterministic drift sync (drift-sync.ts exited ${SYNC_EXIT_CODE:-?} and the run is UNCLASSIFIABLE — it printed no usable reason= line, or it reported a clean one and then died anyway; see the drift-sync-log artifact)"
           elif [ "${SYNC_REASON}" = "provider-unchecked" ]; then
@@ -1870,7 +1948,7 @@ jobs:
           # (reachable only with the persist step at 'success', which this alert never
           # fires in).
           elif [ "${SYNC_REASON}" = "needs-human" ] && [ "${NEEDS_HUMAN_PR_OUTCOME}" = "failure" ]; then
-            FAILING_STEP="Persist needs-human note + open PR (push rejected, gh pr create error, or PR-match polling exhausted — the needs-human note may not have been persisted)"
+            FAILING_STEP="Persist needs-human note + open PR$(step_evidence needs_human_pr) — the needs-human note may not have been persisted"
           elif [ "${SYNC_REASON}" = "needs-human" ] && [ "${NEEDS_HUMAN_PR_OUTCOME}" = "skipped" ]; then
             FAILING_STEP="Persist needs-human note + open PR was SKIPPED because an EARLIER step failed (it is gated on success()) — the needs-human note was NOT persisted, so the decision is not reachable in the repo"
           elif [ "${ASSERT_OUTCOME}" = "failure" ]; then
@@ -1878,7 +1956,7 @@ jobs:
           elif [ "${GIT_PUSH_CFG_OUTCOME}" = "failure" ]; then
             FAILING_STEP="Configure git for push (the push credential could not be injected, so neither PR path could push)"
           elif [ "${PR_OUTCOME}" = "failure" ]; then
-            FAILING_STEP="Push branch + create PR"
+            FAILING_STEP="Push branch + create PR$(step_evidence pr)"
           else
             # Never contentless: the steps with no `id:` (both artifact uploads)
             # cannot be named, so report the state this alert actually observed

--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -621,9 +621,35 @@ jobs:
           # relied on for completeness — that is exactly why it is unioned with a
           # query whose population is bounded by the repo's unmerged PRs.
           assert_listing_complete "unmerged-PR listing this step's marker self-heal reads" "$UNMERGED"
-          MANAGED="$(jq -cn --argjson a "$MANAGED" --argjson b "$UNMERGED" \
-            '($a | map(.number)) as $seen
-             | $a + [$b[] | . as $p | select(($seen | index($p.number)) == null)]')"
+          # A PR LISTING MUST NEVER TRAVEL THROUGH argv. Linux caps a SINGLE
+          # argument at MAX_ARG_STRLEN — 128 KiB, fixed at 32 pages and
+          # INDEPENDENT of the far larger total ARG_MAX (2 MiB on the runner) —
+          # so `--argjson a "$MANAGED"` makes execve fail E2BIG, which bash
+          # reports as "Argument list too long" and the step dies with exit 126
+          # before jq runs at all. That is a hard daily red, not a degraded
+          # answer, and it is what killed this cron on 2026-08-06 and 2026-08-07
+          # (runs 31079603526 / 31154443828, both at this same union in the
+          # sibling needs-human step). Measured on this repo 2026-08-07: this
+          # step's plain listing 801 KB and its is:unmerged listing 131 KB —
+          # BOTH over the per-argument cap on their own, so the total is not the
+          # binding constraint and trimming one payload would not have helped.
+          # Lowering --limit is NOT the fix either: the window is load-bearing
+          # (see above), and shrinking it re-opens the silent "not proposed"
+          # answer that duplicate PRs come from.
+          #
+          # `--slurpfile` reads through a file descriptor instead, so size is
+          # bounded by the filesystem, not by execve. It binds an ARRAY OF THE
+          # FILE'S JSON VALUES: a file holding one array binds `[[…]]`, so every
+          # reference is `$a[0]`, never `$a`. Getting that wrong does not error —
+          # it silently compares an array-of-array against PR numbers and matches
+          # nothing, which is the same duplicate-PR failure by another route.
+          MANAGED_FILE="${RUNNER_TEMP}/drift-managed.json"
+          UNMERGED_FILE="${RUNNER_TEMP}/drift-unmerged.json"
+          printf '%s' "$MANAGED" > "$MANAGED_FILE"
+          printf '%s' "$UNMERGED" > "$UNMERGED_FILE"
+          MANAGED="$(jq -cn --slurpfile a "$MANAGED_FILE" --slurpfile b "$UNMERGED_FILE" \
+            '($a[0] | map(.number)) as $seen
+             | $a[0] + [$b[0][] | . as $p | select(($seen | index($p.number)) == null)]')"
           MINE="$(printf '%s' "$MANAGED" | jq -c --arg k "$CHANGESET_KEY" '
             map(select((.state == "OPEN" or .state == "CLOSED")
                        and (.headRefName | test("^fix/drift-"))
@@ -700,9 +726,22 @@ jobs:
           # self-heal's branch-key anchor never selects, and the self-heal reaches
           # the closed PRs whose body no longer contains the key at all. Self-heal
           # entries win on collision — they carry the post-repair body.
-          ALL_PRS="$(jq -cn --argjson a "$ALL_PRS" --argjson b "$REASSERTED" \
-            '($b | map(.number)) as $healed
-             | [$a[] | . as $p | select(($healed | index($p.number)) == null)] + $b')"
+          #
+          # Through FILES, not argv, for the MAX_ARG_STRLEN reason spelled out on
+          # the self-heal union above. Neither operand is bounded: REASSERTED
+          # carries the FULL body of every bot-managed PR it selected (measured
+          # 34 KB across this repo's current bot PRs, against a 60 KB largest
+          # single body and GitHub's 65 KB body ceiling — so three such PRs clear
+          # the 128 KiB cap), and every self-heal APPENDS to a body, so the
+          # payload only grows. This site had not crashed yet purely because the
+          # ok-applied path did not run on the mornings the needs-human one did.
+          ALL_PRS_FILE="${RUNNER_TEMP}/drift-all-prs.json"
+          REASSERTED_FILE="${RUNNER_TEMP}/drift-reasserted.json"
+          printf '%s' "$ALL_PRS" > "$ALL_PRS_FILE"
+          printf '%s' "$REASSERTED" > "$REASSERTED_FILE"
+          ALL_PRS="$(jq -cn --slurpfile a "$ALL_PRS_FILE" --slurpfile b "$REASSERTED_FILE" \
+            '($b[0] | map(.number)) as $healed
+             | [$a[0][] | . as $p | select(($healed | index($p.number)) == null)] + $b[0]')"
           # PRECEDENCE: a still-OPEN PR carrying this marker is a PENDING proposal
           # and WINS, so it is tested BEFORE the closed-rejection test below. A
           # closure is only a rejection once NO open PR still carries the changeset.
@@ -1038,9 +1077,34 @@ jobs:
           # completeness — which is exactly why it is unioned with a query whose
           # population is bounded by the repo's unmerged PRs.
           assert_listing_complete "unmerged-PR listing this step's marker self-heal reads" "$UNMERGED"
-          MANAGED="$(jq -cn --argjson a "$MANAGED" --argjson b "$UNMERGED" \
-            '($a | map(.number)) as $seen
-             | $a + [$b[] | . as $p | select(($seen | index($p.number)) == null)]')"
+          # THIS IS THE LINE THAT KILLED THE CRON on 2026-08-06 and 2026-08-07
+          # (runs 31079603526 / 31154443828, both `jq: Argument list too long`,
+          # exit 126, at script line 150). A PR LISTING MUST NEVER TRAVEL THROUGH
+          # argv: Linux caps a SINGLE argument at MAX_ARG_STRLEN — 128 KiB, fixed
+          # at 32 pages and INDEPENDENT of the far larger total ARG_MAX (2 MiB on
+          # the runner) — so `--argjson a "$MANAGED"` makes execve fail E2BIG and
+          # the step dies before jq runs at all. Measured on this repo
+          # 2026-08-07: this step's plain listing 988 KB and its is:unmerged
+          # listing 182 KB (it also asks for `files` and `author`, so it is the
+          # larger of the two steps' listings) — BOTH over the per-argument cap
+          # on their own, which is why the total was never the binding
+          # constraint. Lowering --limit is NOT the fix: the window is
+          # load-bearing (see above) and shrinking it re-opens the silent "not
+          # proposed" answer that duplicate PRs come from.
+          #
+          # `--slurpfile` reads through a file descriptor instead, so size is
+          # bounded by the filesystem, not by execve. It binds an ARRAY OF THE
+          # FILE'S JSON VALUES: a file holding one array binds `[[…]]`, so every
+          # reference is `$a[0]`, never `$a`. Getting that wrong does not error —
+          # it silently compares an array-of-array against PR numbers and matches
+          # nothing, which is the same duplicate-PR failure by another route.
+          MANAGED_FILE="${RUNNER_TEMP}/drift-managed.json"
+          UNMERGED_FILE="${RUNNER_TEMP}/drift-unmerged.json"
+          printf '%s' "$MANAGED" > "$MANAGED_FILE"
+          printf '%s' "$UNMERGED" > "$UNMERGED_FILE"
+          MANAGED="$(jq -cn --slurpfile a "$MANAGED_FILE" --slurpfile b "$UNMERGED_FILE" \
+            '($a[0] | map(.number)) as $seen
+             | $a[0] + [$b[0][] | . as $p | select(($seen | index($p.number)) == null)]')"
           # `has("author")`, not "the login is non-empty": gh always emits every key
           # it was asked for, so an ABSENT key means the `--json` list above (or
           # gh's payload shape) changed and half of bot_managed's coverage went with
@@ -1280,9 +1344,21 @@ jobs:
           # edit, so a PR whose marker this step just restored is likely still
           # absent here, while the self-heal reaches the closed PRs whose body no
           # longer contains the key at all.
-          ALL_PRS="$(jq -cn --argjson a "$ALL_PRS" --argjson b "$REASSERTED" \
-            '($b | map(.number)) as $healed
-             | [$a[] | . as $p | select(($healed | index($p.number)) == null)] + $b')"
+          #
+          # Through FILES, not argv, for the MAX_ARG_STRLEN reason spelled out on
+          # the self-heal union above. Neither operand is bounded: REASSERTED
+          # carries the FULL body of every bot-managed PR it selected (measured
+          # 34 KB across this repo's current bot PRs, against a 60 KB largest
+          # single body and GitHub's 65 KB body ceiling — so three such PRs clear
+          # the 128 KiB cap), and every self-heal APPENDS to a body, so the
+          # payload only grows.
+          ALL_PRS_FILE="${RUNNER_TEMP}/drift-all-prs.json"
+          REASSERTED_FILE="${RUNNER_TEMP}/drift-reasserted.json"
+          printf '%s' "$ALL_PRS" > "$ALL_PRS_FILE"
+          printf '%s' "$REASSERTED" > "$REASSERTED_FILE"
+          ALL_PRS="$(jq -cn --slurpfile a "$ALL_PRS_FILE" --slurpfile b "$REASSERTED_FILE" \
+            '($b[0] | map(.number)) as $healed
+             | [$a[0][] | . as $p | select(($healed | index($p.number)) == null)] + $b[0]')"
           # Only OPEN PRs can carry a still-pending decision; the guards below
           # keep using this narrowed view.
           OPEN_PRS="$(printf '%s' "$ALL_PRS" | jq -c 'map(select(.state == "OPEN"))')"

--- a/src/__tests__/fix-drift-workflow.test.ts
+++ b/src/__tests__/fix-drift-workflow.test.ts
@@ -5569,3 +5569,186 @@ describe("fix-drift.yml — every alert's payload is POSTed, and arrives as vali
     });
   }
 });
+
+// ---------------------------------------------------------------------------
+// A PR LISTING MUST NEVER TRAVEL THROUGH argv.
+//
+// On 2026-08-06 and 2026-08-07 this cron died at 07:05Z and 06:34Z with
+//
+//   /home/runner/work/_temp/….sh: line 150: /usr/bin/jq: Argument list too long
+//   ##[error]Process completed with exit code 126.
+//
+// at the marker self-heal's `jq -cn --argjson a "$MANAGED" --argjson b
+// "$UNMERGED"`. Linux caps a SINGLE argument at MAX_ARG_STRLEN — 128 KiB, fixed
+// at 32 pages — INDEPENDENTLY of the far larger total ARG_MAX (2 MiB on the
+// runner, measured). Both listings were over that cap on their own (988 KB and
+// 182 KB on 2026-08-07), so no amount of total-size headroom would have saved
+// it and trimming one operand would not have either.
+//
+// The guards below EXECUTE both PR-open step bodies against a population shaped
+// like this repo's real one, so they answer "does the step survive today's data"
+// rather than "does the source mention --slurpfile". They are deliberately
+// platform-agnostic: the fixture is sized past the per-argument cap on Linux AND
+// past the total ARG_MAX on macOS, so the RED is the same red on a dev box and
+// on the runner.
+// ---------------------------------------------------------------------------
+describe("fix-drift.yml — no PR listing is passed through argv (E2BIG killed this cron twice)", () => {
+  const BOT = { login: "app/copilotkit-devops-bot" };
+  const HUMAN = { login: "octocat" };
+  const REGISTRY = "src/__tests__/drift/model-registry.ts";
+  const NOTE = "drift-proposals/2026-08-07-new-family.md";
+  const KEY = "1111222233334444";
+  const MATCH = '{"url":"https://x/pr/900","number":900}';
+
+  /**
+   * The shape `gh pr list` returns for THIS repo, measured 2026-08-07:
+   * `--state all --limit 200` comes back FULL at 200, of which only 26 are
+   * unmerged. Bodies are sized so the whole listing clears 1 MB, as the real one
+   * does — that is what makes the argv route fail, and a fixture of a dozen tiny
+   * PRs is exactly the fixture that let this ship.
+   */
+  const productionShapedPopulation = (): PrFixture[] => {
+    const body = `## drift-sync report\n\n${"filler line to size this body realistically\n".repeat(140)}`;
+    return Array.from({ length: 200 }, (_, i) => {
+      const number = 400 - i;
+      // 10 unmerged (well under the 200 limit, so `assert_listing_complete`
+      // passes — as it does in production), the rest MERGED.
+      const state: PrFixture["state"] = i < 5 ? "OPEN" : i < 10 ? "CLOSED" : "MERGED";
+      return {
+        number,
+        url: `https://x/pr/${number}`,
+        state,
+        headRefName: `feature/unrelated-${number}`,
+        body,
+        files: [{ path: `src/whatever-${number}.ts` }],
+        author: HUMAN,
+      };
+    });
+  };
+
+  const cases: Array<{ id: "pr" | "needs_human_pr"; committed: Record<string, string> }> = [
+    { id: "pr", committed: { [REGISTRY]: "// edited\n" } },
+    { id: "needs_human_pr", committed: { [NOTE]: "# needs human\n" } },
+  ];
+
+  for (const { id, committed } of cases) {
+    it(`${id}: survives a ~1 MB PR listing instead of dying with exit 126`, () => {
+      const prs = productionShapedPopulation();
+      const listingBytes = JSON.stringify(prs).length;
+      expect(
+        listingBytes,
+        "the fixture is too small to reach either platform's argv ceiling, so this guard " +
+          "cannot fail and proves nothing about the bug it exists for",
+      ).toBeGreaterThan(1_100_000);
+
+      const r = observePrStep(id, { changesetKey: KEY, committed, prs, matchOut: MATCH });
+
+      expect(
+        r.stdio,
+        `${id}: a PR listing still reaches jq through the argument vector — execve fails E2BIG ` +
+          "and the step dies before jq runs, which is the daily red of 2026-08-06/07",
+      ).not.toContain("Argument list too long");
+      expect(
+        r.stepExit,
+        `${id}: exited ${r.stepExit} on a production-shaped PR listing — 126 is the E2BIG ` +
+          `signature. Output: ${r.stdio}`,
+      ).toBe(0);
+      // …and the step did its JOB on that listing, rather than surviving by
+      // reading nothing: an exit 0 that opened no PR is not a fix.
+      expect(r.created, `${id}: survived the big listing but opened no PR: ${r.stdio}`).toBe(true);
+    });
+  }
+
+  it("a SATURATED 200-of-200 plain listing is not itself a refusal (the audit is on is:unmerged)", () => {
+    // Claim under test, and the reason fixing the E2BIG is enough to make the
+    // cron GREEN rather than merely fail differently: `assert_listing_complete`
+    // is applied to the `is:unmerged` listing and to the changeset-keyed search,
+    // NOT to the plain `--state all` one — which is EXPECTED to saturate,
+    // because merged PRs alone exceed the limit. On 2026-08-07 the real repo
+    // measured 200-of-200 plain and 26 unmerged, so the audit does not fire.
+    const prs = productionShapedPopulation();
+    expect(prs.length, "the plain listing must be saturated for this to test anything").toBe(200);
+    expect(
+      prs.filter((p) => p.state !== "MERGED").length,
+      "the unmerged listing must stay well under the limit, as it does in production",
+    ).toBeLessThan(200);
+
+    const r = observePrStep("needs_human_pr", {
+      changesetKey: KEY,
+      committed: { [NOTE]: "# needs human\n" },
+      prs,
+      matchOut: MATCH,
+    });
+    expect(
+      r.stdio,
+      "a saturated PLAIN listing now refuses the run, so the cron trades an E2BIG for a " +
+        "truncation refusal and is still red every morning",
+    ).not.toContain("came back FULL at its --limit");
+    expect(r.stepExit, r.stdio).toBe(0);
+  });
+
+  it("the file-routed union keeps the union's SEMANTICS — `$a[0]`, not `$a`", () => {
+    // `--slurpfile` binds an ARRAY OF THE FILE'S JSON VALUES, so a file holding
+    // one array binds `[[…]]`. Swapping `--argjson a` for `--slurpfile a`
+    // without rewriting every `$a` to `$a[0]` changes what the filter compares,
+    // and the self-heal then matches nothing — the same duplicate-PR failure the
+    // union exists to prevent, arrived at from the other side. This asserts the
+    // union still does its job: a PR reachable ONLY through the is:unmerged
+    // listing (CLOSED, so it carries a human REJECTION) is still seen.
+    const rejected: PrFixture = {
+      number: 77,
+      url: "https://x/pr/77",
+      state: "CLOSED",
+      headRefName: `drift-needs-human/2026-07-01-4242-${KEY}`,
+      body: `a human rejected this\n<!-- drift-changeset: ${KEY} -->\n`,
+      files: [{ path: NOTE }],
+      author: BOT,
+    };
+    const r = observePrStep("needs_human_pr", {
+      changesetKey: KEY,
+      committed: { [NOTE]: "# needs human\n" },
+      prs: [...productionShapedPopulation(), rejected],
+      matchOut: MATCH,
+    });
+    expect(
+      r.created,
+      "the closed REJECTION reachable only through the is:unmerged half of the union was lost, " +
+        `so this run re-proposed a changeset a human already refused: ${r.stdio}`,
+    ).toBe(false);
+    expect(r.outputs.rejected, r.stdio).toBe("77");
+    expect(r.stepExit, r.stdio).toBe(0);
+  });
+
+  it("no `--arg`/`--argjson` in the whole file carries a gh-derived listing", () => {
+    // The site that crashed was simply the first one the needs-human path
+    // reached. This is a CLASS: every unbounded payload is one merged PR away
+    // from being the next 06:34Z red, so sweep the file rather than the line.
+    const unbounded = [
+      "MANAGED",
+      "UNMERGED",
+      "ALL_PRS",
+      "OPEN_PRS",
+      "REASSERTED",
+      "MINE",
+      "PR_JSON",
+    ];
+    const offenders: string[] = [];
+    for (const [i, line] of wf.split("\n").entries()) {
+      if (/^\s*#/.test(line)) continue;
+      for (const v of unbounded) {
+        if (new RegExp(`--argjson\\s+\\w+\\s+"\\$\\{?${v}\\b`).test(line)) {
+          offenders.push(`${i + 1}: ${line.trim()}`);
+        }
+        if (new RegExp(`--arg\\s+\\w+\\s+"\\$\\{?${v}\\b`).test(line)) {
+          offenders.push(`${i + 1}: ${line.trim()}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      "an unbounded gh-derived payload is being passed to jq through the argument vector — " +
+        "Linux kills that at 128 KiB per argument with E2BIG and exit 126, whatever the total " +
+        `ARG_MAX is. Route it through --slurpfile/--rawfile or stdin:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/src/__tests__/fix-drift-workflow.test.ts
+++ b/src/__tests__/fix-drift-workflow.test.ts
@@ -991,6 +991,12 @@ function assembleSlackMessage(step: Step, envOverride: Record<string, string> = 
       [...lines.slice(0, last + 1), `printf '%s' "$MSG" > ${JSON.stringify(outFile)}`].join("\n"),
     );
     const env: Record<string, string> = { ...process.env } as Record<string, string>;
+    // The runner ALWAYS provides RUNNER_TEMP, and the gate-failure alert reads
+    // the failing step's recorded exit code and stderr out of it. Leaving it
+    // unset here is the harness under-modelling the runner, not a defect in the
+    // step: under `set -u` an unset RUNNER_TEMP aborts a body the real runner
+    // executes fine. A caller that cares what is IN that directory overrides it.
+    env.RUNNER_TEMP = dir;
     // Non-empty placeholders for everything the step declares, so `set -u` is
     // satisfied and each message takes its content-bearing branch.
     for (const key of Object.keys(step.env)) env[key] = `<${key}>`;
@@ -5750,5 +5756,129 @@ describe("fix-drift.yml — no PR listing is passed through argv (E2BIG killed t
         "Linux kills that at 128 KiB per argument with E2BIG and exit 126, whatever the total " +
         `ARG_MAX is. Route it through --slurpfile/--rawfile or stdin:\n${offenders.join("\n")}`,
     ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THE ALERT QUOTES THE FAILURE; IT DOES NOT ENUMERATE GUESSES.
+//
+// The gate-failure alert named a step and then appended a hand-written list of
+// the causes someone had imagined for it. For two consecutive mornings it
+// published "push rejected, gh pr create error, or PR-match polling exhausted"
+// while the step had actually died with `jq: Argument list too long` and exit
+// 126 — none of the three. A plausible wrong cause is worse than none: it sends
+// triage at the push credential and hides the defect for as long as it takes
+// someone to open the raw log.
+// ---------------------------------------------------------------------------
+describe("fix-drift.yml — the gate-failure alert reports the real exit code and stderr", () => {
+  const alertStep = (): Step => stepById("alert_gate");
+
+  /** Plant the status a failing PR step would have recorded, and read the alert. */
+  const alertWith = (
+    stepId: string,
+    record: { rc?: string; err?: string } | null,
+    envOverride: Record<string, string>,
+  ): string => {
+    const dir = mkdtempSync(join(tmpdir(), "fix-drift-alert-"));
+    try {
+      if (record) {
+        const status = join(dir, "drift-step-status");
+        mkdirSync(status, { recursive: true });
+        if (record.rc !== undefined) writeFileSync(join(status, `${stepId}.rc`), `${record.rc}\n`);
+        writeFileSync(join(status, `${stepId}.err`), record.err ?? "");
+      }
+      return assembleSlackMessage(alertStep(), { ...envOverride, RUNNER_TEMP: dir });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  const E2BIG =
+    "/home/runner/work/_temp/77c15c9e.sh: line 150: /usr/bin/jq: Argument list too long";
+
+  it("names the ACTUAL exit code and stderr of the failing persist step", () => {
+    const msg = alertWith(
+      "needs_human_pr",
+      { rc: "126", err: `some earlier noise\n${E2BIG}\n` },
+      {
+        SYNC_REASON: "needs-human",
+        NEEDS_HUMAN_PR_OUTCOME: "failure",
+        ASSERT_OUTCOME: "skipped",
+        GIT_PUSH_CFG_OUTCOME: "success",
+        PR_OUTCOME: "skipped",
+      },
+    );
+    expect(msg, `the alert does not report the step's real exit code: ${msg}`).toContain("126");
+    expect(msg, `the alert does not quote the step's real stderr: ${msg}`).toContain(
+      "Argument list too long",
+    );
+    expect(
+      msg,
+      "the alert still publishes a hand-written list of imagined causes — the exact text that " +
+        `misnamed runs 31079603526 and 31154443828: ${msg}`,
+    ).not.toContain("push rejected, gh pr create error, or PR-match polling exhausted");
+  });
+
+  it("names the ACTUAL exit code and stderr of the failing ok-applied PR step", () => {
+    const msg = alertWith(
+      "pr",
+      { rc: "128", err: "fatal: could not read Username for 'https://github.com'\n" },
+      {
+        SYNC_REASON: "ok-applied",
+        PR_OUTCOME: "failure",
+        NEEDS_HUMAN_PR_OUTCOME: "skipped",
+        ASSERT_OUTCOME: "success",
+        GIT_PUSH_CFG_OUTCOME: "success",
+      },
+    );
+    expect(msg, msg).toContain("128");
+    expect(msg, msg).toContain("could not read Username");
+  });
+
+  it("says so when NO status was recorded, rather than inventing a cause", () => {
+    // A step killed before its own prologue ran leaves no record. "I do not
+    // know" is a usable triage signal; a guess is not.
+    const msg = alertWith("needs_human_pr", null, {
+      SYNC_REASON: "needs-human",
+      NEEDS_HUMAN_PR_OUTCOME: "failure",
+      ASSERT_OUTCOME: "skipped",
+      GIT_PUSH_CFG_OUTCOME: "success",
+      PR_OUTCOME: "skipped",
+    });
+    expect(msg, msg).toContain("NO exit code was recorded");
+  });
+
+  it("an EMPTY stderr is reported AS empty, not rendered as nothing at all", () => {
+    // The failure this catches is the alert going contentless again: with no
+    // default for the stderr line, a step that died writing nothing to stderr
+    // produces "exited 1; last stderr: " and the reader learns nothing. Mutation
+    // -tested by deleting the `${last:-…}` default, which turns this red.
+    const msg = alertWith(
+      "needs_human_pr",
+      { rc: "1", err: "" },
+      {
+        SYNC_REASON: "needs-human",
+        NEEDS_HUMAN_PR_OUTCOME: "failure",
+        ASSERT_OUTCOME: "skipped",
+        GIT_PUSH_CFG_OUTCOME: "success",
+        PR_OUTCOME: "skipped",
+      },
+    );
+    expect(msg, msg).toContain("the step wrote nothing to stderr");
+  });
+
+  it("both PR steps actually RECORD the status the alert reads", () => {
+    // The alert's evidence is only as real as the prologue that writes it: if a
+    // step stops recording, every arm above degrades to "NO exit code was
+    // recorded" and the alert is contentless again — silently.
+    for (const id of ["pr", "needs_human_pr"] as const) {
+      const code = codeOf(stepById(id));
+      expect(code, `${id}: records no exit code for the gate-failure alert to quote`).toContain(
+        `${id}.rc`,
+      );
+      expect(code, `${id}: captures no stderr for the gate-failure alert to quote`).toContain(
+        `${id}.err`,
+      );
+    }
   });
 });


### PR DESCRIPTION
The `Fix Drift` cron has failed every morning since 2026-08-06. It is not a push rejection, a `gh pr create` error, or exhausted polling — the three causes the alert names. It is:

```
/home/runner/work/_temp/….sh: line 150: /usr/bin/jq: Argument list too long
##[error]Process completed with exit code 126.
```

## Cause

Four `jq` invocations union two PR listings by passing each one as a single `--argjson` value. Linux caps a **single argument** at 128 KiB (`MAX_ARG_STRLEN`); the listing measures **807 KB** today, so `execve` returns `E2BIG` and the step dies with exit 126. Total `ARG_MAX` is 2 MiB and was never the binding limit — the per-argument cap is.

This was introduced by an earlier fix in this series. `--limit` was raised to 200 to close a real silent bug, where a truncated listing answered "not proposed" for a PR that existed and opened a duplicate. The larger limit, against this repo's very large PR bodies, pushed the argument over the kernel ceiling. A silent wrong answer became a daily hard failure.

## Changes

The four union sites pass their payloads through `--slurpfile` instead of argv, reading via a file descriptor so size is irrelevant. `--slurpfile` wraps the file in an array, so each filter dereferences `$a[0]` / `$b[0]`.

Only one of the four had crashed: it is the one on the needs-human path, which is the path the cron took. The other three sit on the ok-applied path and fail as soon as it runs against a listing this size.

The gate-failure alert now quotes the failing step's **actual exit code and last stderr line** rather than a hardcoded list of three candidate causes. An alert that guesses at its own failure is what made this take two days to see.

## Verification

Red and green are the real `run:` bodies, executed under `bash -e` in a linux/amd64 container against the true payloads (988 KB and 182 KB), with only `gh` stubbed.

Red on `main`: both steps `RC=126`, `jq: Argument list too long`. Green with the fix: both `RC=0`, running through the union, self-heal, saturation guard, dedup, push and `pr create`.

Eleven mutations, each watched. One survived — `|| true` under `errexit` inside a command substitution, which bash does not treat as fatal. That test was retargeted at a mutation it can actually detect and the misleading comment corrected, rather than keeping a guard that cannot fail.

## Not changed, and why

The saturation guard is not a second failure waiting behind this one. It audits the `is:unmerged` listing (26 rows live) and the changeset-keyed search (0 rows live) — never the plain listing, which is expected to be full because merged PRs alone exceed the limit, and is unioned with a bounded query for exactly that reason. It passed on the real population the morning of the crash.

## Unproven

Nothing here proves the cron goes green on Actions. Only the next scheduled run, or a manual dispatch, does that.
