### PR TITLE
fix(drift-sync): gate-3 cannot judge a deprecation, so it no longer vetoes one

### DIFF
--- a/scripts/drift-sync-check.ts
+++ b/scripts/drift-sync-check.ts
@@ -344,12 +344,21 @@ export function evaluateSyncCheck(
   // gate-3 (live re-collect) is skipped when it cannot observe THIS run's edit —
   // see EvaluateSyncCheckOptions.skipRecollect.
   if (opts.skipRecollect) {
+    // A skip with no stated reason reads in the log exactly like a gate that ran
+    // and passed, so it is a CONFIG ERROR rather than a silent default: the
+    // caller that turns gate-3 off must say what it could not observe.
+    if (!opts.skipRecollectReason) {
+      throw new SyncCheckConfigError(
+        "skipRecollect was set with no skipRecollectReason — a gate that is turned off " +
+          "must record why, or its verdict is indistinguishable from a gate that ran",
+      );
+    }
     return {
       ok: true,
       reason: SyncCheckReason.OK,
       detail:
         "drift-sync-check passed: changed files are data-only, classification pins intact " +
-        `(live re-collect NOT RUN — ${opts.skipRecollectReason ?? "no reason recorded"}; ` +
+        `(live re-collect NOT RUN — ${opts.skipRecollectReason}; ` +
         "this edit is carried by gate-1 + gate-2, not by a re-collect)",
       offendingFiles: [],
     };

--- a/scripts/drift-sync-check.ts
+++ b/scripts/drift-sync-check.ts
@@ -30,6 +30,23 @@
  * above is a plain data check. A sync that fails any of them is NOT resolved
  * and no PR opens (mirrors the predicate's fail-closed contract, spec §3).
  *
+ * WHAT GATE-3 IS AND IS NOT (run 31465219443, 2026-08-11). The re-collect runs
+ * in the same workspace as the fix, so it can FILTER a cheat but cannot PROVE
+ * correctness — that has always been its contract. What it also cannot do is
+ * answer a question about an edit it has no surface for: two consecutive runs of
+ * the identical changeset `74f6efa43753f7d0` (two gemini deprecations) got
+ * `gate-failed` and then `ok-applied`, because gate-3's input is a fresh LIVE
+ * observation of EVERY drift surface aimock has, and nothing about that is a
+ * function of the changeset. So gate-3 now:
+ *
+ *   * is SKIPPED, with the reason recorded in the verdict, when the caller knows
+ *     a re-collect cannot observe this run's edit (`skipRecollect`);
+ *   * REFUSES on a positive critical finding and NAMES the diffs, so the next
+ *     refusal is triageable from the log instead of being a bare count;
+ *   * stops claiming "clean re-collect" for a zero it cannot believe — a
+ *     quarantined or AG-UI-skipped report is reported as UNCONFIRMED, carried by
+ *     gates 1 and 2 (see `reportTrustNote`).
+ *
  * C5 only ADDS this script + its test. Wiring it into `fix-drift.yml` in place
  * of the "Assert drift truly resolved" step, and deleting
  * `drift-success-predicate.ts`, is C3's job.
@@ -145,12 +162,83 @@ export function runPinCheck(
 
 const DEFAULT_RECOLLECT_OUT = "drift-report.sync-check.json";
 
+/** One residual critical diff, identified well enough to triage without re-running anything. */
+export interface CriticalDiffRef {
+  provider: string;
+  scenario: string;
+  path: string;
+  id?: string;
+}
+
+/**
+ * Every `severity === "critical"` diff in a report, IDENTIFIED.
+ *
+ * The gate used to carry only a COUNT into its verdict, and the re-collect report
+ * itself (`drift-report.sync-check.json`) is never uploaded by the workflow. So
+ * `gate-failed … still reports 1 critical diff(s)` was the entire record of run
+ * 31465219443 — which diff fired that morning is NOT recoverable from it. Naming
+ * the diffs is what makes the next one diagnosable from the log alone.
+ */
+export function listCriticalDiffs(report: DriftReport): CriticalDiffRef[] {
+  return report.entries.flatMap((entry) =>
+    entry.diffs
+      .filter((d) => d.severity === "critical")
+      .map((d) => ({
+        provider: entry.provider,
+        scenario: entry.scenario,
+        path: d.path,
+        ...(d.id !== undefined ? { id: d.id } : {}),
+      })),
+  );
+}
+
 /** Count `severity === "critical"` diffs across every entry of a report. */
 export function countCriticalDiffs(report: DriftReport): number {
-  return report.entries.reduce(
-    (sum, entry) => sum + entry.diffs.filter((d) => d.severity === "critical").length,
-    0,
-  );
+  return listCriticalDiffs(report).length;
+}
+
+/** Render `listCriticalDiffs` output for a verdict detail line. */
+export function formatCriticalDiffs(diffs: readonly CriticalDiffRef[]): string {
+  return diffs.map((d) => `${d.provider}/${d.scenario}: ${d.id ?? d.path}`).join("; ");
+}
+
+/**
+ * Can a ZERO critical count in this report be believed as "the live suite is
+ * clean", or did the collector fail to make a trustworthy, complete observation?
+ *
+ * The collector writes `conclusion` from its own exit code
+ * (`conclusionForExitCode`): "clean" (0), "critical" (2), "quarantine" (5 — a
+ * failure it could not parse into a trustworthy finding) or "skipped" (1 — the
+ * AG-UI drift leg could not run, so `entries` is missing that whole surface).
+ * Only "clean" and "critical" are positive determinations.
+ *
+ * This gate used to read `entries` alone, so a quarantined or AG-UI-skipped
+ * re-collect counted zero criticals and was reported as a "clean re-collect" —
+ * an UNKNOWN collapsing into the answer that passes. Both mornings of the
+ * 74f6efa43753f7d0 pair quarantined on the same live Gemini WS timeout, and the
+ * 08-12 log claims a clean re-collect for it.
+ *
+ * A zero that cannot be believed does not become a REFUSAL — a refusal would red
+ * an unattended cron on someone else's flaky live surface. It stops being a CLAIM:
+ * the verdict says the re-collect could not confirm the edit, and gate-1 and
+ * gate-2 carry it. A positive critical finding is still a refusal (see
+ * `evaluateSyncCheck`) — an UNKNOWN must not veto, but a POSITIVE finding must.
+ */
+export function reportTrustNote(report: DriftReport): string | null {
+  const quarantined = report.quarantine?.length ?? 0;
+  if (quarantined > 0) {
+    return `the collector quarantined ${quarantined} failure(s) it could not parse into a trustworthy finding`;
+  }
+  if (report.conclusion === undefined) {
+    return "the report carries no `conclusion`, so the collector's own verdict on it is unknown";
+  }
+  if (report.conclusion === "skipped") {
+    return "the collector's AG-UI drift leg could not run, so the report is missing that surface entirely";
+  }
+  if (report.conclusion !== "clean" && report.conclusion !== "critical") {
+    return `the collector reported conclusion="${report.conclusion}", which is not a positive determination`;
+  }
+  return null;
 }
 
 /**
@@ -200,15 +288,19 @@ export interface SyncCheckDeps {
 export interface EvaluateSyncCheckOptions {
   /**
    * Run gate-1 (allowlist) + gate-2 (pin) but SKIP gate-3 (the live
-   * re-collect). Used by the sync core for a run that applied a mechanical
-   * registry edit but ALSO deferred a family to a human: a fresh collector run
-   * would still (correctly) report that deferred family as residual critical
-   * drift, so gate-3 is not a meaningful full-resolution check for such a run
-   * and — left on — would wrongly revert the valid mechanical edit. Gate-1 and
-   * gate-2 remain in force: the edit is still proven data-only with the frozen
-   * classification logic intact.
+   * re-collect), because for THIS run's edit a fresh collector run cannot
+   * answer the question gate-3 asks. Two such runs exist — see
+   * `gate3SkipReason` in drift-sync.ts for both, with their evidence. Gate-1
+   * and gate-2 remain in force: the edit is still proven data-only with the
+   * frozen classification logic intact.
    */
   skipRecollect?: boolean;
+  /**
+   * WHY gate-3 was skipped, quoted into the verdict detail. Required whenever
+   * `skipRecollect` is set: a skipped gate that does not say what it could not
+   * observe reads in the log exactly like a gate that ran and passed.
+   */
+  skipRecollectReason?: string;
 }
 
 export interface SyncCheckVerdict {
@@ -249,26 +341,46 @@ export function evaluateSyncCheck(
     };
   }
 
-  // gate-3 (live re-collect) is skipped for a run that ALSO deferred a family
-  // to a human — see EvaluateSyncCheckOptions.skipRecollect.
+  // gate-3 (live re-collect) is skipped when it cannot observe THIS run's edit —
+  // see EvaluateSyncCheckOptions.skipRecollect.
   if (opts.skipRecollect) {
     return {
       ok: true,
       reason: SyncCheckReason.OK,
       detail:
         "drift-sync-check passed: changed files are data-only, classification pins intact " +
-        "(live re-collect skipped — this run also deferred a family to a human)",
+        `(live re-collect NOT RUN — ${opts.skipRecollectReason ?? "no reason recorded"}; ` +
+        "this edit is carried by gate-1 + gate-2, not by a re-collect)",
       offendingFiles: [],
     };
   }
 
   const report = deps.recollect();
-  const criticalCount = countCriticalDiffs(report);
-  if (criticalCount > 0) {
+  const criticalDiffs = listCriticalDiffs(report);
+  if (criticalDiffs.length > 0) {
+    // A POSITIVE finding, so it refuses — and it names the diffs, because a bare
+    // count is not triageable after the fact (see `listCriticalDiffs`).
     return {
       ok: false,
       reason: SyncCheckReason.RESIDUAL_CRITICAL_DRIFT,
-      detail: `Clean re-collect after sync still reports ${criticalCount} critical diff(s) — sync did not resolve the drift`,
+      detail:
+        `Clean re-collect after sync still reports ${criticalDiffs.length} critical diff(s) — ` +
+        `sync did not resolve the drift: ${formatCriticalDiffs(criticalDiffs)}`,
+      offendingFiles: [],
+    };
+  }
+
+  // Zero criticals. Whether that zero is BELIEVABLE is a separate question — a
+  // quarantined or incomplete re-collect must not be reported as a clean one.
+  const trustNote = reportTrustNote(report);
+  if (trustNote !== null) {
+    return {
+      ok: true,
+      reason: SyncCheckReason.OK,
+      detail:
+        "drift-sync-check passed: changed files are data-only, classification pins intact " +
+        `(re-collect found no critical drift but could NOT CONFIRM the edit — ${trustNote}; ` +
+        "this edit is carried by gate-1 + gate-2)",
       offendingFiles: [],
     };
   }

--- a/scripts/drift-sync.ts
+++ b/scripts/drift-sync.ts
@@ -705,12 +705,15 @@ export interface SyncCoreDeps {
   writeProposalNote: (relPath: string, text: string) => void;
   /**
    * Run C5's drift-sync-check gate. `opts.skipRecollect` runs gate-1
-   * (allowlist) + gate-2 (pin) but SKIPS gate-3 (the live re-collect) — used
-   * when this run applied a mechanical edit AND also deferred a family to a
-   * human, so a fresh collector run would still (correctly) see that deferred
-   * family as residual critical drift.
+   * (allowlist) + gate-2 (pin) but SKIPS gate-3 (the live re-collect), for the
+   * runs where a fresh collector pass cannot answer gate-3's question — see
+   * {@link gate3SkipReason} for the two cases and their evidence.
+   * `opts.skipRecollectReason` carries WHY into the verdict detail.
    */
-  runSyncCheck: (opts?: { skipRecollect?: boolean }) => SyncCheckResultLike;
+  runSyncCheck: (opts?: {
+    skipRecollect?: boolean;
+    skipRecollectReason?: string;
+  }) => SyncCheckResultLike;
   /** Revert every file in `relPaths` (e.g. `git checkout -- <paths>`) after a failed gate. */
   revertFiles: (relPaths: string[]) => void;
   now?: () => Date;
@@ -736,6 +739,54 @@ export interface SyncCoreOutcome {
   detail: string;
   outcomes: FamilyOutcome[];
   skipped: { provider: Provider; reason: string }[];
+}
+
+/**
+ * WHY gate-3 (the live re-collect) cannot answer this run's question, or `null`
+ * when it can. The returned string is quoted verbatim into the gate's verdict.
+ *
+ * Gate-3 re-runs the WHOLE live drift suite and vetoes on its GLOBAL critical
+ * count. That is only a meaningful verdict on THIS run's edit when the suite has
+ * a surface that observes the edit. Two runs where it does not:
+ *
+ *  1. A MIXED RUN (a mechanical edit PLUS a family deferred to a human). A fresh
+ *     collector pass still (correctly) reports the deferred family as residual
+ *     critical drift, so gate-3 would revert the valid edit alongside it. This is
+ *     the long-standing D-M1 case.
+ *
+ *  2. A DEPRECATION-ONLY RUN. The edit appends a family literal to
+ *     `deprecatedFamilies`, and NOTHING in the collector's suite glob
+ *     (`src/__tests__/drift/**\/*.drift.ts`, per vitest.config.drift.ts) reads
+ *     `deprecatedFamilies`: the only LIVE model-family canary is the
+ *     UNCLASSIFIED direction (`unclassifiedFamilies` — live minus classified),
+ *     while the deprecation direction (`detectDeprecatedFamilies` — classified
+ *     minus live) is exercised only OFFLINE against injected payloads. A recorded
+ *     deprecation therefore cannot change a single collector output, so gate-3
+ *     can neither confirm nor refute it — it can only veto it on whatever
+ *     unrelated drift the live suite happened to see that morning. It did exactly
+ *     that: the identical changeset `74f6efa43753f7d0` was refused as
+ *     `gate-failed` on 2026-08-11 (run 31465219443, "still reports 1 critical
+ *     diff(s)") and applied as `ok-applied` on 2026-08-12 (run 31570802134, PR
+ *     #370) — a daily cron reddening at random on a correct edit, and reporting
+ *     it as "the mechanical edit was wrong".
+ *
+ *     That premise is PINNED by `drift-sync-gate-determinism.test.ts`: if a live
+ *     deprecation canary is ever added to a `*.drift.ts`, that test reds and
+ *     sends whoever added it here.
+ *
+ * An `added` run is NOT on this list, and must not be: appending to
+ * `includeFamilies` makes the unclassified canary stop reporting the family, so
+ * gate-3 genuinely observes that edit — including an approved addition that
+ * landed in the wrong provider's array, which the canary still reports.
+ */
+export function gate3SkipReason(outcomes: readonly FamilyOutcome[]): string | null {
+  if (outcomes.some((o) => o.action.startsWith("needs-human-"))) {
+    return "this run also deferred a family to a human, which a fresh collector pass would still report as residual critical drift";
+  }
+  if (!outcomes.some((o) => o.action === "added")) {
+    return "this run only RECORDED deprecations, and no live drift surface reads deprecatedFamilies — a re-collect cannot observe this edit";
+  }
+  return null;
 }
 
 /** Read-or-create a dedup note (write only on first sighting — re-fire never spams a duplicate). */
@@ -1006,14 +1057,16 @@ export function runDriftSyncCore(
   // A mechanical registry edit WAS applied — persist it and gate it. Gate-1
   // (allowlist) and gate-2 (pin) always apply: they cheaply prove the edit
   // stayed on the data-only surface and left the frozen classification logic
-  // intact. Gate-3 (the live re-collect) only makes sense when this run CLAIMS
-  // to have fully resolved the drift — i.e. no family was simultaneously
-  // deferred to a human. In a mixed run (a valid registry edit PLUS a family
-  // routed to a human), the re-collect would (correctly) still see that deferred
-  // family as residual drift and would wrongly revert the valid edit (D-M1,
-  // mixed-run leg), so skip gate-3 and report NEEDS_HUMAN with the edit kept.
+  // intact. Gate-3 (the live re-collect) runs only when the live suite has a
+  // surface that can actually observe THIS run's edit — `gate3SkipReason` names
+  // the two runs where it does not, with the evidence.
   deps.writeRegistrySource(registrySource);
-  const verdict = deps.runSyncCheck({ skipRecollect: anyNeedsHuman });
+  const skipReason = gate3SkipReason(outcomes);
+  const verdict = deps.runSyncCheck(
+    skipReason !== null
+      ? { skipRecollect: true, skipRecollectReason: skipReason }
+      : { skipRecollect: false },
+  );
   if (!verdict.ok) {
     deps.revertFiles([...touchedFiles]);
     return {
@@ -1246,7 +1299,10 @@ const REAL_SYNC_CORE_DEPS: SyncCoreDeps = {
         runPinCheck: () => runPinCheck(),
         recollect: () => recollect(),
       },
-      { skipRecollect: opts?.skipRecollect },
+      {
+        skipRecollect: opts?.skipRecollect,
+        skipRecollectReason: opts?.skipRecollectReason,
+      },
     );
     return { ok: verdict.ok, reason: verdict.reason, detail: verdict.detail };
   },

--- a/src/__tests__/drift-sync-check.test.ts
+++ b/src/__tests__/drift-sync-check.test.ts
@@ -15,6 +15,9 @@ import {
   isAllowedSyncFile,
   checkChangedFileAllowlist,
   countCriticalDiffs,
+  listCriticalDiffs,
+  formatCriticalDiffs,
+  reportTrustNote,
   evaluateSyncCheck,
   runPinCheck,
   recollect,
@@ -149,6 +152,66 @@ describe("countCriticalDiffs", () => {
   });
 });
 
+describe("listCriticalDiffs / formatCriticalDiffs", () => {
+  it("IDENTIFIES each critical diff, not just a count", () => {
+    const refs = listCriticalDiffs(report([0, 2]));
+    expect(refs).toEqual([
+      { provider: "provider-1", scenario: "scenario", path: "field-0" },
+      { provider: "provider-1", scenario: "scenario", path: "field-1" },
+    ]);
+  });
+
+  it("prefers a stable `id` over the prose-coupled `path` when one exists", () => {
+    const r = report([1]);
+    r.entries[0].diffs[0].id = "openai-realtime:no-ga-family";
+    expect(formatCriticalDiffs(listCriticalDiffs(r))).toBe(
+      "provider-0/scenario: openai-realtime:no-ga-family",
+    );
+  });
+
+  it("ignores non-critical diffs", () => {
+    const r = report([1]);
+    r.entries[0].diffs[0].severity = "warning";
+    expect(listCriticalDiffs(r)).toEqual([]);
+  });
+});
+
+describe("reportTrustNote — a zero that cannot be believed is not a clean re-collect", () => {
+  function withConclusion(conclusion: string | undefined, quarantine?: number): DriftReport {
+    const r = report([0]);
+    if (conclusion !== undefined) r.conclusion = conclusion;
+    if (quarantine !== undefined) {
+      r.quarantine = Array.from({ length: quarantine }, (_, i) => ({
+        provider: "unknown",
+        testName: `t-${i}`,
+        rawLocation: "",
+        message: "waitUntil timeout after 30000ms",
+      }));
+    }
+    return r;
+  }
+
+  it("trusts a positively-clean report", () => {
+    expect(reportTrustNote(withConclusion("clean"))).toBeNull();
+  });
+
+  it("trusts a report whose criticals ARE the determination", () => {
+    expect(reportTrustNote(withConclusion("critical"))).toBeNull();
+  });
+
+  it("does NOT trust a quarantined report (the 74f6efa43753f7d0 mornings' shape)", () => {
+    expect(reportTrustNote(withConclusion("quarantine", 2))).toContain("quarantined 2 failure(s)");
+  });
+
+  it("does NOT trust a report whose AG-UI leg could not run (entries are incomplete)", () => {
+    expect(reportTrustNote(withConclusion("skipped"))).toContain("AG-UI");
+  });
+
+  it("does NOT trust a report with no `conclusion` at all (UNKNOWN never passes as clean)", () => {
+    expect(reportTrustNote(withConclusion(undefined))).toContain("no `conclusion`");
+  });
+});
+
 describe("recollect", () => {
   it("fails closed (SyncCheckConfigError) when the collector produced no report file", () => {
     const runner = vi.fn((): CommandResult => ({ status: 0, output: "" }));
@@ -231,6 +294,49 @@ describe("evaluateSyncCheck — RED/GREEN value-test surface", () => {
     expect(verdict.ok).toBe(false);
     expect(verdict.reason).toBe(SyncCheckReason.RESIDUAL_CRITICAL_DRIFT);
     expect(verdict.detail).toContain("1 critical");
+  });
+
+  it("a refusal NAMES the residual diffs, so the log alone is triageable", () => {
+    const r = report([1]);
+    r.entries[0].diffs[0].id = "openai-realtime:no-ga-family";
+    const verdict = evaluateSyncCheck(deps({ recollect: () => r }));
+    expect(verdict.reason).toBe(SyncCheckReason.RESIDUAL_CRITICAL_DRIFT);
+    expect(verdict.detail).toContain("provider-0/scenario: openai-realtime:no-ga-family");
+  });
+
+  it("a SKIPPED gate-3 says in the verdict what it could not observe", () => {
+    const recollectFn = vi.fn(() => report([0]));
+    const verdict = evaluateSyncCheck(deps({ recollect: recollectFn }), {
+      skipRecollect: true,
+      skipRecollectReason: "no live drift surface reads deprecatedFamilies",
+    });
+    expect(verdict.ok).toBe(true);
+    expect(recollectFn).not.toHaveBeenCalled();
+    expect(verdict.detail).toContain("live re-collect NOT RUN");
+    expect(verdict.detail).toContain("no live drift surface reads deprecatedFamilies");
+    // …and never claims the thing it did not do.
+    expect(verdict.detail).not.toContain("clean re-collect");
+  });
+
+  it("an UNTRUSTWORTHY zero passes but is reported UNCONFIRMED, never as a clean re-collect", () => {
+    const quarantined = report([0]);
+    quarantined.conclusion = "quarantine";
+    quarantined.quarantine = [
+      { provider: "unknown", testName: "Gemini Live WS drift", rawLocation: "", message: "timeout" },
+    ];
+    const verdict = evaluateSyncCheck(deps({ recollect: () => quarantined }));
+    expect(verdict.ok).toBe(true);
+    expect(verdict.reason).toBe(SyncCheckReason.OK);
+    expect(verdict.detail).toContain("could NOT CONFIRM");
+    expect(verdict.detail).not.toContain("clean re-collect");
+  });
+
+  it("a positively-clean re-collect DOES claim a clean re-collect", () => {
+    const clean = report([0]);
+    clean.conclusion = "clean";
+    const verdict = evaluateSyncCheck(deps({ recollect: () => clean }));
+    expect(verdict.ok).toBe(true);
+    expect(verdict.detail).toContain("clean re-collect");
   });
 });
 

--- a/src/__tests__/drift-sync-check.test.ts
+++ b/src/__tests__/drift-sync-check.test.ts
@@ -318,11 +318,22 @@ describe("evaluateSyncCheck — RED/GREEN value-test surface", () => {
     expect(verdict.detail).not.toContain("clean re-collect");
   });
 
+  it("turning gate-3 OFF with no stated reason is a CONFIG ERROR, not a silent pass", () => {
+    expect(() => evaluateSyncCheck(deps({}), { skipRecollect: true })).toThrow(
+      SyncCheckConfigError,
+    );
+  });
+
   it("an UNTRUSTWORTHY zero passes but is reported UNCONFIRMED, never as a clean re-collect", () => {
     const quarantined = report([0]);
     quarantined.conclusion = "quarantine";
     quarantined.quarantine = [
-      { provider: "unknown", testName: "Gemini Live WS drift", rawLocation: "", message: "timeout" },
+      {
+        provider: "unknown",
+        testName: "Gemini Live WS drift",
+        rawLocation: "",
+        message: "timeout",
+      },
     ];
     const verdict = evaluateSyncCheck(deps({ recollect: () => quarantined }));
     expect(verdict.ok).toBe(true);

--- a/src/__tests__/drift-sync-core.test.ts
+++ b/src/__tests__/drift-sync-core.test.ts
@@ -621,10 +621,19 @@ describe("runDriftSyncCore", () => {
     // optional cleanup is safe — it no longer selects a different route.
     expect(registry.text).toContain("no remaining aimock reference");
 
-    // A real registry edit was made, so the real gate DOES run — and with the
-    // live re-collect ON, because this run deferred nothing to a human.
+    // A real registry edit was made, so the real gate DOES run — gate-1
+    // (allowlist) and gate-2 (pin), with gate-3's live re-collect OFF and the
+    // reason recorded. A recorded deprecation is invisible to every live drift
+    // surface (nothing in the collector's `*.drift.ts` glob reads
+    // `deprecatedFamilies`), so a re-collect can only veto this edit on
+    // unrelated drift — which is how the identical changeset 74f6efa43753f7d0
+    // was refused on 2026-08-11 and applied on 2026-08-12. See
+    // `gate3SkipReason` and drift-sync-gate-determinism.test.ts.
     expect(runSyncCheck).toHaveBeenCalledTimes(1);
-    expect(runSyncCheck).toHaveBeenCalledWith({ skipRecollect: false });
+    expect(runSyncCheck).toHaveBeenCalledWith({
+      skipRecollect: true,
+      skipRecollectReason: expect.stringContaining("no live drift surface reads deprecatedFamilies"),
+    });
   });
 
   it("RED->GREEN (deprecation, STILL-REFERENCED): also recorded, and the mock is NOT removed", () => {
@@ -924,9 +933,13 @@ describe("D-M1: recollect gate vs route-to-human invariant", () => {
     );
     expect(revertFiles).not.toHaveBeenCalled();
     // The gate ran (a registry edit WAS applied) but with the live re-collect
-    // skipped, because a family was simultaneously deferred to a human.
+    // skipped, because a family was simultaneously deferred to a human — and the
+    // verdict records that as the reason, not just the fact of the skip.
     expect(runSyncCheck).toHaveBeenCalledTimes(1);
-    expect(runSyncCheck).toHaveBeenCalledWith({ skipRecollect: true });
+    expect(runSyncCheck).toHaveBeenCalledWith({
+      skipRecollect: true,
+      skipRecollectReason: expect.stringContaining("deferred a family to a human"),
+    });
     // The registry edit was persisted (writeRegistrySource ran with the addition).
     expect(registry.text).toContain('"gpt-live"');
   });

--- a/src/__tests__/drift-sync-core.test.ts
+++ b/src/__tests__/drift-sync-core.test.ts
@@ -632,7 +632,9 @@ describe("runDriftSyncCore", () => {
     expect(runSyncCheck).toHaveBeenCalledTimes(1);
     expect(runSyncCheck).toHaveBeenCalledWith({
       skipRecollect: true,
-      skipRecollectReason: expect.stringContaining("no live drift surface reads deprecatedFamilies"),
+      skipRecollectReason: expect.stringContaining(
+        "no live drift surface reads deprecatedFamilies",
+      ),
     });
   });
 

--- a/src/__tests__/drift-sync-gate-determinism.test.ts
+++ b/src/__tests__/drift-sync-gate-determinism.test.ts
@@ -1,0 +1,485 @@
+/**
+ * The drift-sync gate must return the SAME VERDICT for the SAME CHANGESET.
+ *
+ * OBSERVED FAILURE this file reconstructs — two consecutive scheduled `Fix Drift`
+ * runs produced the byte-identical changeset key `74f6efa43753f7d0` (the same two
+ * gemini deprecations, recorded the same way) and the gate accepted it only once:
+ *
+ *   * 2026-08-11, run 31465219443 — `reason=gate-failed`:
+ *     "drift-sync-check rejected the sync [residual-critical-drift]: Clean
+ *      re-collect after sync still reports 1 critical diff(s) — sync did not
+ *      resolve the drift — reverted"
+ *   * 2026-08-12, run 31570802134 — `reason=ok-applied`, PR #370 opened, +2/-0.
+ *
+ * WHY IT COULD DIFFER — gate-3 re-runs the WHOLE live drift suite
+ * (`vitest --config vitest.config.drift.ts`, every provider and every surface)
+ * and vetoes on its GLOBAL critical count. Nothing about that count is a function
+ * of the changeset: the sync's own input is three `/models` listings, while
+ * gate-3's input is a fresh live observation of every drift surface aimock has,
+ * taken ~75s later. Two runs therefore share a changeset key while handing gate-3
+ * different input.
+ *
+ * AND FOR A DEPRECATION RECORD GATE-3 CANNOT OBSERVE THE EDIT AT ALL. The edit
+ * appends a family literal to `deprecatedFamilies` in model-registry.ts, and NO
+ * file in the collector's suite glob (`src/__tests__/drift/**\/*.drift.ts`) reads
+ * `deprecatedFamilies` — the only live model-family canary is the UNCLASSIFIED
+ * direction (`unclassifiedFamilies`, live-minus-classified). The deprecation
+ * direction (`detectDeprecatedFamilies`, classified-minus-live) is exercised only
+ * OFFLINE with injected payloads. So a recorded deprecation provably cannot
+ * change any collector output: gate-3 can neither confirm nor refute it, yet it
+ * could still veto it on whatever unrelated drift the live suite happened to see
+ * that morning. `assertNoLiveDeprecationCanary` below pins that premise, so if a
+ * live deprecation canary is ever added this test reds and says to re-enable
+ * gate-3 for the deprecation lane.
+ *
+ * The two fixture re-collects below are the two mornings' observations:
+ *   * `recollect0812` is VERBATIM from the 2026-08-12 drift-report artifact
+ *     (9131032270): zero entries, two quarantined Gemini Live WS timeouts.
+ *   * `recollect0811` is a FAITHFUL RECONSTRUCTION, not a capture. The 08-11 run
+ *     recorded only the COUNT ("1 critical diff(s)") — the gate prints no diff
+ *     identity and `drift-report.sync-check.json` is never uploaded — so which
+ *     diff it was is NOT recoverable from that run. The fixture therefore uses a
+ *     real collector-emitted critical shape (the OpenAI Realtime WS-handshake
+ *     diff, drift-report-collector.ts) standing in for "one critical diff
+ *     somewhere in the live suite, unrelated to the gemini deprecations".
+ */
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { includeFamilies } from "./drift/model-registry.js";
+import { MIN_LISTING_SIZE } from "./drift/deprecation-detector.js";
+import {
+  runDriftSyncCore,
+  computeChangesetKey,
+  SyncCoreReason,
+  MODEL_REGISTRY_REL_PATH,
+  type SyncCoreDeps,
+  type SyncCoreOutcome,
+  type ProviderChurnInput,
+} from "../../scripts/drift-sync.js";
+import { evaluateSyncCheck, SyncCheckReason } from "../../scripts/drift-sync-check.js";
+import type { DriftReport } from "../../scripts/drift-types.js";
+
+// ---------------------------------------------------------------------------
+// The premise gate-3's deprecation-lane skip rests on.
+// ---------------------------------------------------------------------------
+
+const DRIFT_SUITE_DIR = "src/__tests__/drift";
+
+/**
+ * The collector runs exactly `src/__tests__/drift/**\/*.drift.ts`
+ * (vitest.config.drift.ts). If none of those files reads `deprecatedFamilies`,
+ * then appending to that ledger cannot change a single collector output — which
+ * is precisely why gate-3 is skipped for a deprecation-only run.
+ *
+ * MUTATION-TESTABLE ON PURPOSE: add a live deprecation canary that imports
+ * `deprecatedFamilies` into any `*.drift.ts` and this reds, pointing at the
+ * `gate3CanObserveAppliedEdits` decision that must then change.
+ */
+function driftSuiteFilesReferencing(symbol: string): string[] {
+  return readdirSync(DRIFT_SUITE_DIR)
+    .filter((f) => f.endsWith(".drift.ts"))
+    .filter((f) => readFileSync(join(DRIFT_SUITE_DIR, f), "utf-8").includes(symbol));
+}
+
+describe("premise: the live drift suite cannot observe a recorded deprecation", () => {
+  it("no *.drift.ts in the collector's glob reads deprecatedFamilies", () => {
+    expect(driftSuiteFilesReferencing("deprecatedFamilies")).toEqual([]);
+  });
+
+  it("the collector's glob DOES read includeFamilies (so the guard above is not vacuous)", () => {
+    // Same read path, same glob, a symbol that IS present — proves the scan can
+    // find a reference at all, so the empty result above is a real absence.
+    expect(driftSuiteFilesReferencing("includeFamilies").length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures — the 2026-08-11/12 changeset.
+// ---------------------------------------------------------------------------
+
+/**
+ * The two families the real runs recorded. Asserted present-and-usable rather
+ * than assumed: `includeFamilies` and `deprecatedFamilies` both move under this
+ * repo's own automation, and a fixture that silently stops describing a real
+ * candidate would assert on an empty outcome list and pass vacuously.
+ */
+const RECORDED_PAIR = ["gemini-2.0-flash", "gemini-2.0-flash-lite"] as const;
+
+function geminiLiveListingWithoutRecordedPair(): string[] {
+  const missing = RECORDED_PAIR.filter((f) => !includeFamilies.gemini.has(f));
+  if (missing.length > 0) {
+    throw new Error(
+      `this reconstruction needs ${RECORDED_PAIR.join(" + ")} to still be in ` +
+        `includeFamilies.gemini, but ${missing.join(", ")} is absent — the 2026-08-11 ` +
+        `changeset can no longer be reconstructed from the live registry. Re-derive the ` +
+        `pair from includeFamilies.gemini rather than deleting the assertions.`,
+    );
+  }
+  const surviving = [...includeFamilies.gemini].filter(
+    (f) => !(RECORDED_PAIR as readonly string[]).includes(f),
+  );
+  // Families plus a dated snapshot of each, so the listing clears the
+  // fail-closed floor (a short listing is skipped, never a removal signal).
+  const ids = [...surviving, ...surviving.map((f) => `${f}-2025-01-01`)];
+  if (ids.length < MIN_LISTING_SIZE.gemini) {
+    throw new Error(
+      `fixture listing has ${ids.length} raw id(s), below gemini's fail-closed floor of ` +
+        `${MIN_LISTING_SIZE.gemini} — the detector would SKIP instead of reporting the pair.`,
+    );
+  }
+  return ids;
+}
+
+function fixtureRegistrySource(): string {
+  return [
+    "export const includeFamilies = {",
+    '  gemini: set("gemini", [',
+    ...[...includeFamilies.gemini].map((f) => `    "${f}",`),
+    "  ]),",
+    "};",
+    "export const deprecatedFamilies = {",
+    '  gemini: set("gemini", [',
+    "    // drift-sync appends recorded deprecations here.",
+    "  ]),",
+    "};",
+  ].join("\n");
+}
+
+/** The 2026-08-11/12 provider inputs: gemini checked, the other two not credentialed. */
+function churnInputs(): ProviderChurnInput[] {
+  return [{ provider: "gemini", liveModelIds: geminiLiveListingWithoutRecordedPair() }];
+}
+
+// ---------------------------------------------------------------------------
+// The two mornings' live re-collect observations.
+// ---------------------------------------------------------------------------
+
+/**
+ * 2026-08-11: one critical diff somewhere in the live suite. Reconstruction —
+ * see the file header for exactly what was and was not recoverable.
+ */
+function recollect0811(): DriftReport {
+  return {
+    timestamp: "2026-08-11T06:30:52.000Z",
+    generatedAt: "2026-08-11T06:30:52.000Z",
+    conclusion: "critical",
+    entries: [
+      {
+        provider: "OpenAI Realtime",
+        scenario: "WS handshake",
+        builderFile: "src/responses.ts",
+        builderFunctions: [],
+        typesFile: null,
+        sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
+        diffs: [
+          {
+            severity: "critical",
+            issue:
+              "OpenAI Realtime WS handshake did not complete — the live API returned an " +
+              "error event (invalid_request_error/session_expired).",
+            path: "session.session_expired",
+            expected: "(handshake completes: session.created/updated received)",
+            real: "error invalid_request_error: session expired",
+            mock: "<no mock leg — live handshake probe>",
+            id: "ws-handshake:session_expired",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/** 2026-08-12: VERBATIM from drift-report artifact 9131032270 — zero entries, two quarantines. */
+function recollect0812(): DriftReport {
+  const wsTimeout =
+    "Error: waitUntil timeout after 30000ms. Collected 0 messages: [] bodies=[]\n" +
+    "    at Timeout._onTimeout (/home/runner/work/aimock/aimock/src/__tests__/drift/ws-providers.ts:319:23)";
+  return {
+    timestamp: "2026-08-12T06:31:23.604Z",
+    generatedAt: "2026-08-12T06:31:23.604Z",
+    conclusion: "quarantine",
+    entries: [],
+    quarantine: [
+      {
+        provider: "unknown",
+        testName: "Gemini Live WS drift > WS text event sequence and shapes match",
+        rawLocation: "src/__tests__/drift/ws-providers.ts:319:23",
+        message: wsTimeout,
+      },
+      {
+        provider: "unknown",
+        testName: "Gemini Live WS drift > WS tool call event sequence matches",
+        rawLocation: "src/__tests__/drift/ws-providers.ts:319:23",
+        message: wsTimeout,
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Driving the REAL sync core through the REAL gate.
+// ---------------------------------------------------------------------------
+
+interface RunResult {
+  outcome: SyncCoreOutcome;
+  changesetKey: string;
+  registrySource: string;
+  reverted: string[];
+  recollectCalls: number;
+}
+
+/**
+ * Run the real `runDriftSyncCore` over the fixture changeset, with the real
+ * `evaluateSyncCheck` as the gate. Only the leaf observations are injected: the
+ * registry source text (in memory), the pin result, and the live re-collect
+ * report. Every decision under test — the churn diff, the mechanical edit, the
+ * gate composition, the skip decision, the revert — is real code.
+ */
+function runSync(recollect: () => DriftReport, inputs = churnInputs()): RunResult {
+  let registrySource = fixtureRegistrySource();
+  const reverted: string[] = [];
+  let recollectCalls = 0;
+
+  const deps: SyncCoreDeps = {
+    isReferenced: (family) => family === "gemini-2.0-flash",
+    isRecorded: () => false,
+    readRegistrySource: () => registrySource,
+    writeRegistrySource: (text) => {
+      registrySource = text;
+    },
+    readProposalNote: () => null,
+    writeProposalNote: () => {
+      throw new Error("this changeset writes no proposal note");
+    },
+    runSyncCheck: (opts) =>
+      evaluateSyncCheck(
+        {
+          getChangedFiles: () => [MODEL_REGISTRY_REL_PATH],
+          runPinCheck: () => ({ ok: true, output: "logic-pin.test.ts passed" }),
+          recollect: () => {
+            recollectCalls += 1;
+            return recollect();
+          },
+        },
+        opts,
+      ),
+    revertFiles: (paths) => reverted.push(...paths),
+    now: () => new Date("2026-08-11T06:29:00.000Z"),
+  };
+
+  const outcome = runDriftSyncCore(inputs, deps);
+  return {
+    outcome,
+    changesetKey: computeChangesetKey(outcome),
+    registrySource,
+    reverted,
+    recollectCalls,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RED: the same changeset, two verdicts.
+// ---------------------------------------------------------------------------
+
+describe("the 2026-08-11/12 changeset key 74f6efa43753f7d0", () => {
+  it("both mornings really are the SAME changeset (identical key, identical edit)", () => {
+    const day1 = runSync(recollect0811);
+    const day2 = runSync(recollect0812);
+
+    // The premise of the whole investigation: the key does not distinguish them.
+    expect(day1.changesetKey).toBe(day2.changesetKey);
+    expect(day1.changesetKey).not.toBe("");
+    expect(day1.outcome.outcomes.map((o) => `${o.action}:${o.provider}/${o.family}`).sort()).toEqual(
+      [
+        "deprecation-recorded:gemini/gemini-2.0-flash",
+        "deprecation-recorded:gemini/gemini-2.0-flash-lite",
+      ],
+    );
+  });
+
+  it("the mechanical edit is CORRECT on both mornings (+2 recorded, nothing else touched)", () => {
+    for (const recollect of [recollect0811, recollect0812]) {
+      const { registrySource } = runSync(recollect);
+      for (const family of RECORDED_PAIR) {
+        expect(registrySource).toContain(`"${family}"`);
+      }
+      // The ledger grew and includeFamilies did NOT shrink — the mock keeps serving.
+      for (const family of includeFamilies.gemini) {
+        expect(registrySource).toContain(`"${family}"`);
+      }
+    }
+  });
+
+  it("the gate reaches the SAME verdict on both mornings", () => {
+    const day1 = runSync(recollect0811);
+    const day2 = runSync(recollect0812);
+
+    expect(day1.outcome.reason).toBe(day2.outcome.reason);
+    expect(day1.outcome.ok).toBe(day2.outcome.ok);
+  });
+
+  it("neither morning reverts the correct edit", () => {
+    expect(runSync(recollect0811).reverted).toEqual([]);
+    expect(runSync(recollect0812).reverted).toEqual([]);
+  });
+
+  it("a deprecation-only run never pays for a live re-collect it cannot learn from", () => {
+    expect(runSync(recollect0811).recollectCalls).toBe(0);
+    expect(runSync(recollect0812).recollectCalls).toBe(0);
+  });
+
+  it("REPEAT-COUNT PROOF: 25 runs of each morning yield exactly ONE verdict", () => {
+    const verdicts = new Set<string>();
+    for (let i = 0; i < 25; i++) {
+      for (const recollect of [recollect0811, recollect0812]) {
+        const { outcome, changesetKey } = runSync(recollect);
+        verdicts.add(`${changesetKey}|${outcome.reason}|${outcome.ok}`);
+      }
+    }
+    expect([...verdicts]).toEqual([`74f6efa43753f7d0|${SyncCoreReason.OK_APPLIED}|true`]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NEGATIVE CONTROLS — a genuinely wrong edit is still caught.
+// ---------------------------------------------------------------------------
+
+/**
+ * An `added` run: a human approved a brand-new family, so the sync appends it to
+ * `includeFamilies`. THAT edit IS observable by the live suite — the unclassified
+ * canary stops reporting the family once it is classified — so gate-3 must run
+ * and must still veto a run whose re-collect proves the drift is unresolved.
+ */
+function approvedNewFamilyRun(recollect: () => DriftReport): RunResult {
+  let registrySource = fixtureRegistrySource();
+  const reverted: string[] = [];
+  let recollectCalls = 0;
+  const deps: SyncCoreDeps = {
+    isReferenced: () => false,
+    isRecorded: () => false,
+    readRegistrySource: () => registrySource,
+    writeRegistrySource: (text) => {
+      registrySource = text;
+    },
+    // An already-approved note for the new family — the sync applies it.
+    readProposalNote: () => "Decision: include\n",
+    writeProposalNote: () => {
+      throw new Error("the note already exists");
+    },
+    runSyncCheck: (opts) =>
+      evaluateSyncCheck(
+        {
+          getChangedFiles: () => [MODEL_REGISTRY_REL_PATH],
+          runPinCheck: () => ({ ok: true, output: "logic-pin.test.ts passed" }),
+          recollect: () => {
+            recollectCalls += 1;
+            return recollect();
+          },
+        },
+        opts,
+      ),
+    revertFiles: (paths) => reverted.push(...paths),
+    now: () => new Date("2026-08-11T06:29:00.000Z"),
+  };
+  // A live listing that carries the whole classified set PLUS one genuinely new
+  // family, so the addition half fires and the deprecation half reports nothing.
+  const families = [...includeFamilies.gemini];
+  const outcome = runDriftSyncCore(
+    [
+      {
+        provider: "gemini",
+        liveModelIds: [
+          ...families,
+          ...families.map((f) => `${f}-2025-01-01`),
+          "gemini-brand-new-family",
+        ],
+      },
+    ],
+    deps,
+  );
+  return {
+    outcome,
+    changesetKey: computeChangesetKey(outcome),
+    registrySource,
+    reverted,
+    recollectCalls,
+  };
+}
+
+function reportWithUnresolvedNewFamily(): DriftReport {
+  return {
+    timestamp: "2026-08-11T06:30:52.000Z",
+    generatedAt: "2026-08-11T06:30:52.000Z",
+    conclusion: "critical",
+    entries: [
+      {
+        provider: "Google Gemini",
+        scenario: "live /models family canary",
+        builderFile: "src/responses.ts",
+        builderFunctions: [],
+        typesFile: null,
+        sdkShapesFile: "src/__tests__/drift/sdk-shapes.ts",
+        diffs: [
+          {
+            severity: "critical",
+            issue: 'Unclassified model family "gemini-brand-new-family" in gemini /models',
+            path: "models/gemini-brand-new-family",
+            expected: "(family in includeFamilies ∪ excludeFamilies)",
+            real: "gemini-brand-new-family",
+            mock: "<no mock leg — live /models family canary>",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("negative controls — the gate still refuses a wrong edit", () => {
+  it("an `added` run IS gate-3-observable, so the re-collect really runs", () => {
+    const run = approvedNewFamilyRun(() => ({
+      timestamp: "t",
+      conclusion: "clean",
+      entries: [],
+    }));
+    expect(run.outcome.outcomes.map((o) => o.action)).toContain("added");
+    expect(run.recollectCalls).toBe(1);
+    expect(run.outcome.reason).toBe(SyncCoreReason.OK_APPLIED);
+  });
+
+  it("WRONG EDIT: an `added` run whose re-collect still reports the family -> reverted", () => {
+    const run = approvedNewFamilyRun(reportWithUnresolvedNewFamily);
+    expect(run.outcome.ok).toBe(false);
+    expect(run.outcome.reason).toBe(SyncCoreReason.GATE_FAILED);
+    expect(run.outcome.detail).toContain(SyncCheckReason.RESIDUAL_CRITICAL_DRIFT);
+    expect(run.reverted).toEqual([MODEL_REGISTRY_REL_PATH]);
+  });
+
+  it("WRONG EDIT: an off-allowlist file -> reverted, gate-1 never reaches the re-collect", () => {
+    const verdict = evaluateSyncCheck({
+      getChangedFiles: () => [MODEL_REGISTRY_REL_PATH, "src/__tests__/drift/sdk-shapes.ts"],
+      runPinCheck: () => ({ ok: true, output: "" }),
+      recollect: () => {
+        throw new Error("gate-1 must refuse before any re-collect");
+      },
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe(SyncCheckReason.OFF_ALLOWLIST_CHANGE);
+  });
+
+  it("WRONG EDIT: a moved classification pin -> refused even on the deprecation lane", () => {
+    const verdict = evaluateSyncCheck(
+      {
+        getChangedFiles: () => [MODEL_REGISTRY_REL_PATH],
+        runPinCheck: () => ({ ok: false, output: "FAIL logic-pin.test.ts > freezes PREVIEW_FAMILY" }),
+        recollect: () => {
+          throw new Error("gate-2 must refuse before any re-collect");
+        },
+      },
+      { skipRecollect: true, skipRecollectReason: "deprecation-record-only" },
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe(SyncCheckReason.PIN_CHECK_FAILED);
+  });
+});

--- a/src/__tests__/drift-sync-gate-determinism.test.ts
+++ b/src/__tests__/drift-sync-gate-determinism.test.ts
@@ -291,12 +291,12 @@ describe("the 2026-08-11/12 changeset key 74f6efa43753f7d0", () => {
     // The premise of the whole investigation: the key does not distinguish them.
     expect(day1.changesetKey).toBe(day2.changesetKey);
     expect(day1.changesetKey).not.toBe("");
-    expect(day1.outcome.outcomes.map((o) => `${o.action}:${o.provider}/${o.family}`).sort()).toEqual(
-      [
-        "deprecation-recorded:gemini/gemini-2.0-flash",
-        "deprecation-recorded:gemini/gemini-2.0-flash-lite",
-      ],
-    );
+    expect(
+      day1.outcome.outcomes.map((o) => `${o.action}:${o.provider}/${o.family}`).sort(),
+    ).toEqual([
+      "deprecation-recorded:gemini/gemini-2.0-flash",
+      "deprecation-recorded:gemini/gemini-2.0-flash-lite",
+    ]);
   });
 
   it("the mechanical edit is CORRECT on both mornings (+2 recorded, nothing else touched)", () => {
@@ -472,7 +472,10 @@ describe("negative controls — the gate still refuses a wrong edit", () => {
     const verdict = evaluateSyncCheck(
       {
         getChangedFiles: () => [MODEL_REGISTRY_REL_PATH],
-        runPinCheck: () => ({ ok: false, output: "FAIL logic-pin.test.ts > freezes PREVIEW_FAMILY" }),
+        runPinCheck: () => ({
+          ok: false,
+          output: "FAIL logic-pin.test.ts > freezes PREVIEW_FAMILY",
+        }),
         recollect: () => {
           throw new Error("gate-2 must refuse before any re-collect");
         },


### PR DESCRIPTION
The daily cron reddened on 2026-08-11 by reverting a **correct** mechanical edit, and the identical edit passed the next morning. Same changeset key `74f6efa43753f7d0` both days — run `31465219443` failed with `reason=gate-failed`, run `31570802134` succeeded and opened #370.

## Cause

`gate-3` re-collects the live drift suite and refuses on its **global** critical count. But **no `*.drift.ts` reads `deprecatedFamilies`** — the deprecation direction is offline-only; the sole live model-family canary probes the *unclassified* direction. So for a run whose entire changeset is recorded deprecations, gate-3 can neither confirm nor refute the edit. It can only veto it on drift that has nothing to do with it, which is exactly what happened.

`unchecked-providers=` was empty on the failing run, so the preflight believed every provider had been checked. The veto came from unrelated residual drift.

## Change

`gate3SkipReason` skips the re-collect for deprecation-only runs (and the pre-existing mixed case), recording the reason. Runs that add a family deliberately still run it. Refusals now **name** the residual diffs rather than reporting a bare count.

A fail-open is closed alongside: `reportTrustNote` no longer reports a quarantined, AG-UI-skipped, or `conclusion`-less report as a "clean re-collect" — a state both failing mornings passed through. A `skipRecollect` with no reason now throws `SyncCheckConfigError`.

`fef8476`'s property is preserved: gate-3 still refuses positively-determined residual drift on observable runs, and gates 1 and 2 are untouched.

## Verification

The reconstruction's real `computeChangesetKey` yields `74f6efa43753f7d0`, byte-identical to production, so the input is the one that failed.

Red: `+ "74f6efa43753f7d0|gate-failed|false"` alongside `"…|ok-applied|true"` — the same key producing both verdicts. Green: one verdict.

Because this is a non-determinism fix, a single green run proves nothing, so stability is the evidence: **25 separate processes → 1 distinct outcome**, and 20 separate-process gate-test runs → 1 distinct outcome. The probe is proven able to detect divergence — run against pre-fix `main` it yields **2** distinct outcomes, the 08-11 revert and the 08-12 pass.

Ten mutations, all red, including an over-broad skip and a no-reason refusal, plus a premise guard: adding a `deprecatedFamilies` reference to any `.drift.ts` reds the suite, so the claim "no live canary observes deprecations" cannot silently stop being true.

Negative controls: an `added` run with an unresolved family still reverts with `GATE_FAILED`; an off-allowlist change is refused before the re-collect; a moved checksum pin is refused even on the deprecation lane.

## Known incomplete, deliberately

`fix-drift.yml` invokes `drift-sync-check.ts` as a **separate step after the commit with no options**, so that step still runs gate-3 globally and can still veto at random — one step later. It never fired on 08-11 only because drift-sync had already exited 1. Closing it requires `runCli` to accept the skip decision on `process.argv` (it currently parses none, so a flag would be silently ignored) and `drift-sync.ts` to publish `gate3-skip=` beside `reason=`. That is a separate change; a flag added today would be a guard that reads as protection and does nothing.

`gate-1` is also vacuous at that invocation: it checks `git status --porcelain`, and the sync has already committed, so the list is empty and the allowlist examines nothing. Only gate-2 does real work there.

A mixed run (a new family *and* a deprecation) still uses the global count. Narrowing it needs a stable per-family diff `id` in `text-drift.ts`; matching on the prose `path` would be a guard that stops working the moment the prose changes.

On the success path `runDriftSyncCore` overwrites the gate's detail, so an `ok-applied` deprecation run does not state that gate-3 was skipped — the behaviour is correct, the observability is not.
