### PR TITLE
docs: restyle README header to match Channels SDK and OpenTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
-# aimock [![Unit Tests](https://github.com/CopilotKit/aimock/actions/workflows/test-unit.yml/badge.svg)](https://github.com/CopilotKit/aimock/actions/workflows/test-unit.yml) [![Drift Tests](https://github.com/CopilotKit/aimock/actions/workflows/test-drift.yml/badge.svg)](https://github.com/CopilotKit/aimock/actions/workflows/test-drift.yml) [![npm version](https://img.shields.io/npm/v/@copilotkit/aimock)](https://www.npmjs.com/package/@copilotkit/aimock)
+<div align="center">
+
+# aimock
+
+**Mock infrastructure for AI application testing — point your SDK at one local port and every provider, protocol, and service answers deterministically.**
+
+[**Quick start**](#quick-start) · [**The suite**](#the-aimock-suite) · [**Record & replay**](https://aimock.copilotkit.dev/record-replay) · [**Docs**](https://aimock.copilotkit.dev/docs)
+
+[![npm](https://img.shields.io/npm/v/@copilotkit/aimock.svg?label=%40copilotkit%2Faimock)](https://www.npmjs.com/package/@copilotkit/aimock)
+[![Unit Tests](https://github.com/CopilotKit/aimock/actions/workflows/test-unit.yml/badge.svg)](https://github.com/CopilotKit/aimock/actions/workflows/test-unit.yml)
+[![Drift Tests](https://github.com/CopilotKit/aimock/actions/workflows/test-drift.yml/badge.svg)](https://github.com/CopilotKit/aimock/actions/workflows/test-drift.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
+</div>
 
 https://github.com/user-attachments/assets/76815122-574a-48e1-b275-edae0a014667
 
-Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.
+<div align="center">
+
+One package, one port, zero dependencies. LLM APIs, image generation and
+editing, text-to-speech, transcription, audio translation and generation, video
+generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector
+databases, search, rerank, and moderation — no keys, no network, no surprise
+bills.
+
+</div>
 
 ## Quick Start
 


### PR DESCRIPTION
## What

Brings the aimock README header in line with the shared CopilotKit repo header shape used by [channels-sdk](https://github.com/CopilotKit/channels-sdk) and [OpenTag](https://github.com/CopilotKit/OpenTag).

The pattern those two share: a centered block holding the title, a bold one-line positioning statement, a nav row of key links, and stacked badges — then the demo video, then a centered caption.

## Changes

- **Badges out of the H1.** They were inline after `# aimock`, which made the title line wrap awkwardly. Now stacked on their own lines inside the centered block.
- **npm badge labeled** `@copilotkit/aimock`, matching channels-sdk's treatment.
- **Added MIT license badge** — both reference repos carry one.
- **Bold positioning statement** replaces the long enumeration as the hero line.
- **Nav row**: Quick start · The suite · Record & replay · Docs. Both in-page anchors resolve against existing sections (`## Quick Start`, `## The aimock Suite`).
- **Provider enumeration moved to the video caption** rather than dropped, so the LLM / MCP / A2A / AG-UI / vector / search keywords survive the tighter hero line.

No hero banner image was added — `docs/og-image.png` already contains the wordmark and tagline, so it would duplicate the H1. OpenTag has no banner either; the demo video carries the visual.

## Verification

Docs-only change, but ran the full pre-commit suite from CLAUDE.md:

- `pnpm run format:check` — clean
- `pnpm run lint` — clean
- `pnpm run test` — 176 files passed, 5234 tests passed, 46 skipped