### PR TITLE
fix(drift): classify the new Gemini families, and document the procedure that actually applies one

### DIFF
--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -928,10 +928,13 @@ jobs:
       # commitSyncChanges, but that commit lives only in the runner's working tree,
       # and the "Push branch + create PR" step above fires only on
       # reason == 'ok-applied'. So this step pushes a DISTINCT branch and opens a
-      # needs-human PR. NO AUTO-MERGE: a human sets `Decision: include` (or closes
-      # to reject) and merges, and the NEXT drift-sync run reads the approved note
-      # from main and applies the mechanical edit. Without a persisted note that
-      # two-run hand-off can never start.
+      # needs-human PR. NO AUTO-MERGE, and NO two-run hand-off for a new family:
+      # `includeFamilies` is checksum-pinned, so adding a family moves the pin and
+      # reds the freeze test gate-2 re-runs, while gate-1's allowlist bars drift-sync
+      # from re-pinning — a follow-up run reports `gate-failed`, not `ok-applied`. A
+      # human classifies BY HAND in one commit (registry + both re-pins + the note +
+      # the offline /models wave) and closes the PR. The note still has to persist:
+      # it is what makes the decision reachable and reviewable in the repo.
       #
       # Re-fire discipline (no PR spam): three layers, idempotent in EVERY run
       # shape, applied in this order. PRIMARY — skip when an open PR already carries
@@ -1563,12 +1566,17 @@ jobs:
             echo "structural mismatch). It wrote the note file(s) below and opened this PR so"
             echo "the decision is REACHABLE in the repo."
             echo ""
-            echo "> **Not auto-merged — a human decides.** For a *new-family* note: set the"
-            echo "> note's decision line to \`Decision: include\` (to classify it) or delete the"
-            echo "> note / close this PR (to reject), then **merge this PR**. The NEXT drift-sync"
-            echo "> run reads the approved note from \`main\` and mechanically applies the registry"
-            echo "> edit (still zero-LLM — a human-authored marker, not generated code), opening a"
-            echo "> separate data-only PR. That two-run hand-off is how the loop closes."
+            echo "> **Not auto-merged — a human decides, and applies it by hand.**"
+            echo "> For a *new-family* note, DO NOT expect merging this PR to apply anything:"
+            echo "> \`includeFamilies\` is checksum-pinned, and adding a family moves that pin,"
+            echo "> which reds the freeze test gate-2 re-runs. drift-sync cannot re-pin — the"
+            echo "> gate-1 allowlist permits only \`model-registry.ts\` and \`drift-proposals/\`."
+            echo "> So a follow-up run would report \`gate-failed\`, not \`ok-applied\`."
+            echo ">"
+            echo "> The procedure that actually works, in ONE commit: add the family to"
+            echo "> \`includeFamilies\` (or \`excludeFamilies\` to reject), re-pin BOTH checksums,"
+            echo "> resolve the note file(s) below, and update the offline \`/models\` wave."
+            echo "> Then close this PR. Prior examples: 72f85f8, 936b59c."
             echo ""
             echo "### Note file(s) in this PR"
             echo ""

--- a/drift-proposals/gemini-gemini-3.7-flash-new-family.md
+++ b/drift-proposals/gemini-gemini-3.7-flash-new-family.md
@@ -1,0 +1,40 @@
+# New / unclassified model family: gemini-3.7-flash
+
+Provider: gemini
+Detected: 2026-08-14
+Status: RESOLVED — decision recorded below and applied to the registry
+
+This model family appeared in a live /models listing but matches no classification rule (include, exclude, -preview, gemma). drift-sync never silently classifies a new family.
+
+## Decision
+
+<!-- drift-sync never auto-classifies a new family. To approve adding it to
+     the registry, change the line below to `Decision: include` — the NEXT
+     drift-sync run will then apply the mechanical registry edit (still
+     zero-LLM: this is a human-authored decision, not generated code). -->
+
+<!-- NOTE: the automated `Decision: include` path CANNOT apply this one. It
+     writes into `includeFamilies.gemini`, whose membership is checksum-pinned
+     in `logic-pin.test.ts` (DATA_FROZEN), and drift-sync-check gate-2 re-runs
+     that exact test after the edit. drift-sync cannot update the pin — the
+     gate-1 changed-file allowlist admits only `model-registry.ts` and
+     `drift-proposals/`, so `logic-pin.test.ts` is off-limits to it. Leaving
+     `Decision: include` here would therefore produce `reason=gate-failed` and
+     revert the edit, not `ok-applied`. Verified: the add moves the pin from
+     c2e2c56b… to 566fb89a… and reds `freezes includeFamilies.gemini
+     membership`. So the include is applied BY HAND together with its re-pin,
+     in one reviewed commit — the same way every prior classification landed
+     (72f85f8 claude-opus-5, aa51d0c gemini-3.5-flash-lite/3.6-flash). -->
+
+Decision: INCLUDE (applied — includeFamilies.gemini in
+`src/__tests__/drift/model-registry.ts`, with the `includeFamilies.gemini`
+re-pin in `src/__tests__/drift/logic-pin.test.ts`).
+
+Rationale: stable GA text tier. Google's live /models entry declares
+`supportedGenerationMethods: [generateContent, countTokens, createCachedContent,
+batchGenerateContent]` — byte-identical to the already-included
+`gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-2.5-flash` and `gemini-2.5-pro`
+— with `displayName: "Gemini 3.7 Flash"` and no preview, experimental,
+confidential or EAP marker. It declares no `bidiGenerateContent` (so it is not a
+Live/native-audio surface), no `embedContent`, and no `predict`. It is the next
+release in the flash line aimock already mocks at 3.5 and 3.6.

--- a/drift-proposals/gemini-gemini-3.7-flash-video-understanding-eap-new-family.md
+++ b/drift-proposals/gemini-gemini-3.7-flash-video-understanding-eap-new-family.md
@@ -1,0 +1,43 @@
+# New / unclassified model family: gemini-3.7-flash-video-understanding-eap
+
+Provider: gemini
+Detected: 2026-08-15
+Status: RESOLVED — decision recorded below and applied to the registry
+
+This model family appeared in a live /models listing but matches no classification rule (include, exclude, -preview, gemma). drift-sync never silently classifies a new family.
+
+## Decision
+
+<!-- drift-sync never auto-classifies a new family. To approve adding it to
+     the registry, change the line below to `Decision: include` — the NEXT
+     drift-sync run will then apply the mechanical registry edit (still
+     zero-LLM: this is a human-authored decision, not generated code). -->
+
+<!-- NOTE: the `Decision: include` marker documented above is drift-sync's
+     AUTOMATED path, and it writes EXCLUSIVELY into `includeFamilies`
+     (scripts/drift-sync.ts: addFamilyLiteralInSource(..., "includeFamilies", ...)).
+     There is no automated exclude path, so an EXCLUDE decision is recorded here
+     in prose and applied by hand — writing `include` would misclassify. -->
+
+Decision: EXCLUDE (applied — excludeFamilies.gemini in
+`src/__tests__/drift/model-registry.ts`, with the `excludeFamilies.gemini`
+re-pin in `src/__tests__/drift/logic-pin.test.ts`).
+
+Rationale: gated PRE-GA surface, not a stable tier. This is the only one of the
+54 entries in the live Gemini /models listing whose provider-declared
+`displayName` AND `description` are "[Confidential] Gemini 3.7 Flash Video
+Understanding EAP" — an Early Access Program model visible only to allowlisted
+keys. aimock does not mock pre-GA surfaces, which is exactly the policy
+PREVIEW_FAMILY applies to every `-preview` tier; this id carries no trailing
+`-preview` token, so that rule cannot reach it and it must be enumerated.
+
+NOT rejected for being "video" by name. It genuinely declares
+`supportedGenerationMethods: [generateContent, countTokens, createCachedContent,
+batchGenerateContent]` — the same method set as its GA sibling
+`gemini-3.7-flash` — so it IS text-capable, and a name-substring rule would have
+been the wrong instrument (compare the native-audio misclassification, where the
+declared capability, not the id, was the deciding evidence: the live
+`gemini-2.5-flash-native-audio-latest` entry declares only `countTokens` and
+`bidiGenerateContent`, and no `generateContent` at all). The disqualifier here is
+access status, and it is provider-declared metadata rather than an inference from
+the id string.

--- a/src/__tests__/agui-mock.test.ts
+++ b/src/__tests__/agui-mock.test.ts
@@ -3,7 +3,7 @@ import * as http from "node:http";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AGUIEvent, AGUIRunAgentInput } from "../agui-types.js";
+import type { AGUIEvent, AGUIRunAgentInput, AGUITokenUsage } from "../agui-types.js";
 import { AGUIMock } from "../agui-mock.js";
 import {
   buildTextResponse,
@@ -1709,6 +1709,68 @@ describe("AGUIMock recorder — structured user content", () => {
 // ---------------------------------------------------------------------------
 // NO_USER_MESSAGE_SENTINEL — wire-format compatibility guard
 // ---------------------------------------------------------------------------
+
+describe("AG-UI token usage on terminal events", () => {
+  const usage: AGUITokenUsage[] = [
+    {
+      provider: "openai",
+      model: "gpt-4o",
+      inputTokens: 12,
+      outputTokens: 34,
+      totalTokens: 46,
+      reasoningTokens: 5,
+      cachedInputTokens: 2,
+    },
+  ];
+
+  it("buildTextResponse attaches usage to RUN_FINISHED when supplied", () => {
+    const events = buildTextResponse("hello", { usage });
+    const finished = events.find((e) => e.type === "RUN_FINISHED") as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(finished.usage).toEqual(usage);
+  });
+
+  it("buildErrorResponse attaches usage to RUN_ERROR when supplied", () => {
+    const events = buildErrorResponse("boom", "ERR_500", { usage });
+    const errored = events.find((e) => e.type === "RUN_ERROR") as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(errored.usage).toEqual(usage);
+  });
+
+  it("never synthesizes usage when the caller does not supply it", () => {
+    // aimock does not estimate token counts from fixture content (same policy
+    // as the Bedrock/Cohere/Gemini usage overrides): absent in, absent out.
+    const finished = buildTextResponse("hello").find(
+      (e) => e.type === "RUN_FINISHED",
+    ) as unknown as Record<string, unknown>;
+    expect("usage" in finished).toBe(false);
+
+    const errored = buildErrorResponse("boom").find(
+      (e) => e.type === "RUN_ERROR",
+    ) as unknown as Record<string, unknown>;
+    expect("usage" in errored).toBe(false);
+  });
+
+  it("emits usage over the wire on the SSE stream", async () => {
+    agui = new AGUIMock({ port: 0 });
+    agui.onRun("usage please", buildTextResponse("ok", { usage }));
+    await agui.start();
+
+    const resp = await post(agui.url, aguiInput("usage please"));
+    expect(resp.status).toBe(200);
+
+    const parsed = parseSSEEvents(resp.body);
+    const finished = parsed.find((e) => e.type === "RUN_FINISHED") as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(finished.usage).toEqual(usage);
+  });
+});
 
 describe("NO_USER_MESSAGE_SENTINEL", () => {
   it("preserves the historical on-disk sentinel string", () => {

--- a/src/__tests__/drift/helpers.ts
+++ b/src/__tests__/drift/helpers.ts
@@ -177,6 +177,38 @@ export const AUDIO_FIXTURE: Fixture = {
 /** The prompt that selects {@link AUDIO_FIXTURE} on both sides of a drift leg. */
 export const AUDIO_PROMPT = "Greet me aloud";
 
+/**
+ * Tool-call fixture for the Gemini Live drift leg.
+ *
+ * A Live session carries exactly ONE response modality and it is `AUDIO`, so a
+ * turn in which the model calls a function is an AUDIO turn that ALSO calls it:
+ * the model speaks (`serverContent`) and then asks for the call (`toolCall`).
+ * The shared {@link TOOL_FIXTURE} describes a text-protocol tool turn — tool
+ * call and nothing else — so driving the Live leg's mock side with it produces
+ * a bare `toolCall` with no model turn at all.
+ *
+ * That mis-drive is what run 31896605497's head report recorded as
+ * `SSE:serverContent … mock:"<absent>"`, and the ORDER in it is not a guess: the
+ * probe collects up to and including the FIRST `toolCall`, the real leg's
+ * `toolCallCount > 0` assertion passed, and a `serverContent` was nonetheless
+ * present in what it collected — so the provider sent `serverContent` strictly
+ * BEFORE the `toolCall`. It is the same class of error as the TEXT-modality
+ * request that mis-drove the REAL side: one side driven into a shape the
+ * session's modality cannot produce.
+ *
+ * NOT PROVEN: the fields of the provider's pre-`toolCall` `serverContent`. The
+ * artifact records the event TYPE only. `AUDIO` being the session's sole
+ * modality, audio parts are the shape reproduced here; confirming the
+ * provider's exact fields needs a live run.
+ */
+export const LIVE_TOOL_FIXTURE: Fixture = {
+  match: { userMessage: "Weather in Paris" },
+  response: {
+    audio: { b64Json: "AAAAAA==", contentType: "audio/pcm;rate=24000" },
+    toolCalls: [{ name: "get_weather", arguments: '{"city":"Paris"}' }],
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Server lifecycle
 // ---------------------------------------------------------------------------
@@ -186,6 +218,22 @@ export async function startDriftServer(): Promise<ServerInstance> {
     port: 0,
     chunkSize: 100,
   });
+}
+
+/**
+ * Drift server for the Gemini Live legs.
+ *
+ * Separate from {@link startDriftServer} because the Live leg's fixtures are
+ * modality-specific: {@link LIVE_TOOL_FIXTURE} answers the same
+ * `"Weather in Paris"` prompt as the shared {@link TOOL_FIXTURE} but with the
+ * AUDIO turn a Live session actually produces. Putting it on the shared server
+ * would mean either shadowing `TOOL_FIXTURE` for every other provider's tool
+ * leg or gating it on a model-name pattern — and a Live model is not
+ * identifiable by its name (see the header of ws-gemini-live.drift.ts). A
+ * dedicated instance needs neither.
+ */
+export async function startGeminiLiveDriftServer(): Promise<ServerInstance> {
+  return createServer([AUDIO_FIXTURE, LIVE_TOOL_FIXTURE], { port: 0, chunkSize: 100 });
 }
 
 export async function stopDriftServer(instance: ServerInstance): Promise<void> {

--- a/src/__tests__/drift/logic-pin.test.ts
+++ b/src/__tests__/drift/logic-pin.test.ts
@@ -429,7 +429,7 @@ const DATA_FROZEN: Record<string, { members: () => string[]; pin: string }> = {
   },
   "includeFamilies.gemini": {
     members: () => [...includeFamilies.gemini].sort(),
-    pin: "c2e2c56b8f8d5fc56152b4633e7d3782e95b7eeb9bc123da71f00e884a54a743",
+    pin: "566fb89af6862badeff1d95ecfa511dcd1fc757feeb60a8ff8fec563952cadbc",
   },
   "excludeFamilies.openai": {
     members: () => [...excludeFamilies.openai].sort(),
@@ -441,7 +441,7 @@ const DATA_FROZEN: Record<string, { members: () => string[]; pin: string }> = {
   },
   "excludeFamilies.gemini": {
     members: () => [...excludeFamilies.gemini].sort(),
-    pin: "c95dedab7588212bbba0bf9ab6434bfd43a449adbe7b35f81f48271ee849a9c2",
+    pin: "3c8fb0b7cee776619467afd34407bde69e30b063ae263da4871096e7a7afca1d",
   },
   // The realtime canary's seed sets, previously pinned NOWHERE. An edit to
   // either one was invisible to every guard in the repo: adding a family to

--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -148,6 +148,7 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     "gemini-3.5-flash",
     "gemini-3.5-flash-lite",
     "gemini-3.6-flash",
+    "gemini-3.7-flash",
   ]),
 };
 
@@ -286,6 +287,21 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     "gemini-2.0-flash-thinking-exp",
     // Live/full-duplex voice — owned by the realtime canary, not this text check
     "gemini-live",
+    // Restricted EARLY-ACCESS (EAP) surface, not a GA tier. Google's own live
+    // /models entry declares `displayName` AND `description` as
+    // "[Confidential] Gemini 3.7 Flash Video Understanding EAP" — the only one
+    // of the 54 live entries carrying either marker. NOT excluded for being
+    // "video" by name: it genuinely declares `generateContent` (same method set
+    // as its GA sibling gemini-3.7-flash), so it IS text-capable. It is excluded
+    // because it is a gated pre-GA surface, which is the same policy
+    // PREVIEW_FAMILY applies to every `-preview` tier — aimock does not mock
+    // pre-GA surfaces. It carries no trailing `-preview` token, so that rule
+    // cannot reach it and it must be enumerated here (mirrors the
+    // `-preview-tts` / `-preview-customtools` entries above).
+    //
+    // Decision: EXCLUDE, recorded in
+    // drift-proposals/gemini-gemini-3.7-flash-video-understanding-eap-new-family.md.
+    "gemini-3.7-flash-video-understanding-eap",
     // NOTE: every `-preview` family (gemini-3.x preview tiers, deep-research
     // previews, antigravity-preview-05, computer-use-preview-10, image/tts/robotics
     // previews, lyria/veo/nano-banana previews, gemini-embedding-2-preview, …) is

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -382,6 +382,9 @@ describe("full live /models wave is fully classified (2026-07-16 drift)", () => 
       "gemini-3.5-flash",
       "gemini-3.5-flash-lite",
       "gemini-3.6-flash",
+      "gemini-3.7-flash",
+      // Restricted EAP surface — explicit exclude (text-capable, but pre-GA)
+      "gemini-3.7-flash-video-understanding-eap",
       // Preview text tiers — auto-excluded by the -preview pattern rule
       "gemini-3-flash-preview",
       "gemini-3-pro-preview",

--- a/src/__tests__/drift/sdk-shapes.ts
+++ b/src/__tests__/drift/sdk-shapes.ts
@@ -1252,6 +1252,32 @@ export function geminiLiveAudioEventShapes(): SSEEventShape[] {
 
 export function geminiLiveToolCallEventShapes(): SSEEventShape[] {
   return [
+    // The model turn that precedes the call. A Live session carries exactly one
+    // response modality and it is AUDIO, so the turn in which the model decides
+    // to call a function is itself an audio turn — `serverContent` and
+    // `toolCall` are alternatives of `LiveServerMessage`'s message union, so
+    // they arrive as two messages, `serverContent` first.
+    //
+    // Listing it here is what lets the leg grade the event's FIELDS and not
+    // merely its presence: `triangulateAt` raises critical drift only for a
+    // field the SDK shape and the real API both have and the mock lacks, so
+    // without a `serverContent` entry a field-level regression on it could
+    // never be critical.
+    //
+    // NOT PROVEN: that the provider's pre-`toolCall` `serverContent` carries
+    // inlineData audio specifically. The drift artifact records the event type
+    // only. A field the real API turns out not to send grades as `SDK EXTRA`
+    // (info), never as a false critical.
+    {
+      type: "serverContent",
+      dataShape: extractShape({
+        serverContent: {
+          modelTurn: {
+            parts: [{ inlineData: { mimeType: "audio/pcm;rate=24000", data: "AAAAAA==" } }],
+          },
+        },
+      }),
+    },
     {
       type: "toolCall",
       dataShape: extractShape({

--- a/src/__tests__/drift/ws-frame-opcodes.test.ts
+++ b/src/__tests__/drift/ws-frame-opcodes.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Regression + guard tests for the drift WS client's FRAME HANDLING.
+ *
+ * THE BUG. `connectTLSWebSocket`'s RFC 6455 reader handled exactly three
+ * opcodes — TEXT (0x1), CLOSE (0x8) and PING (0x9). Every other frame was
+ * consumed off the buffer and then DROPPED ON THE FLOOR: no message recorded,
+ * no counter incremented, no error raised. The FIN bit was never read at all,
+ * so a fragmented message (a first frame with FIN=0 plus CONTINUATION frames,
+ * opcode 0x0) was mis-parsed — the head was JSON.parse'd on its own and the
+ * tail silently discarded.
+ *
+ * Two consequences, both fail-silent:
+ *
+ *   1. A provider that frames its JSON as BINARY (0x2) — which the Live wire
+ *      permits, which `@google/genai` explicitly decodes (`event.data
+ *      instanceof Blob` / `instanceof ArrayBuffer`), and which Google's own
+ *      WebSocket sample reads with `ws.recv(decode=False)` — is observed by
+ *      this client as a socket that upgraded and then said NOTHING.
+ *   2. A provider that fragments a large message (an audio turn's base64
+ *      `inlineData` is exactly the payload that gets fragmented) loses its tail.
+ *
+ * Both surface as the SAME string a genuinely mute server produces:
+ *
+ *   Error: waitUntil timeout after 30000ms. Collected 0 messages: [] bodies=[]
+ *
+ * which is byte-identical to the live Gemini Live drift observation. So "the
+ * surface sent nothing" and "we could not read what the surface sent" were
+ * indistinguishable — the probe reported its own deafness as provider silence.
+ *
+ * THE FIX, in two parts:
+ *   - Read the frames: BINARY is decoded like TEXT, and FIN/CONTINUATION are
+ *     reassembled. An opcode still not understood is COUNTED, never dropped.
+ *   - Say what was seen: every timeout and every server-close now carries the
+ *     per-opcode frame tally and the protocol step that was waiting, so a
+ *     zero-message failure states whether zero FRAMES arrived (the surface
+ *     really is mute) or whether frames arrived and were unreadable.
+ *
+ * These tests drive the REAL exported `connectTLSWebSocket` against a local TLS
+ * server, using the repo's own `computeAcceptKey` for the upgrade. Nothing about
+ * the client's framing is reimplemented here: the server writes raw RFC 6455
+ * bytes and the client under test is the one the live legs run.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as tls from "node:tls";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+import { computeAcceptKey } from "../../ws-framing.js";
+import { connectTLSWebSocket, WSClosedError } from "./ws-providers.js";
+
+// ---------------------------------------------------------------------------
+// Local TLS WebSocket server
+// ---------------------------------------------------------------------------
+
+let certDir: string;
+let key: Buffer;
+let cert: Buffer;
+
+beforeAll(() => {
+  certDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-wsframe-"));
+  const keyPath = path.join(certDir, "key.pem");
+  const certPath = path.join(certDir, "cert.pem");
+  // A throwaway self-signed cert, generated per-run so no private key is ever
+  // committed. Node requires a subjectAltName (a CN alone is rejected).
+  execFileSync(
+    "openssl",
+    [
+      "req",
+      "-x509",
+      "-newkey",
+      "rsa:2048",
+      "-nodes",
+      "-keyout",
+      keyPath,
+      "-out",
+      certPath,
+      "-days",
+      "1",
+      "-subj",
+      "/CN=localhost",
+      "-addext",
+      "subjectAltName=DNS:localhost,IP:127.0.0.1",
+    ],
+    { stdio: "ignore" },
+  );
+  key = fs.readFileSync(keyPath);
+  cert = fs.readFileSync(certPath);
+});
+
+afterAll(() => {
+  if (certDir) fs.rmSync(certDir, { recursive: true, force: true });
+});
+
+/**
+ * Build an unmasked server-to-client frame.
+ *
+ * Written from RFC 6455 §5.2 directly rather than through the repo's own
+ * `WebSocketConnection`, because these tests must be able to emit frame shapes
+ * the repo's sender never produces — a BINARY frame, and an explicitly
+ * fragmented FIN=0 head plus CONTINUATION tail.
+ */
+function serverFrame(opcode: number, payload: Buffer, fin = true): Buffer {
+  const header: Buffer =
+    payload.length < 126
+      ? Buffer.alloc(2)
+      : payload.length <= 0xffff
+        ? Buffer.alloc(4)
+        : Buffer.alloc(10);
+  header[0] = (fin ? 0x80 : 0x00) | opcode;
+  if (payload.length < 126) {
+    header[1] = payload.length;
+  } else if (payload.length <= 0xffff) {
+    header[1] = 126;
+    header.writeUInt16BE(payload.length, 2);
+  } else {
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(payload.length), 2);
+  }
+  return Buffer.concat([header, payload]);
+}
+
+const textFrame = (s: string, fin = true) => serverFrame(0x1, Buffer.from(s, "utf-8"), fin);
+const binaryFrame = (s: string, fin = true) => serverFrame(0x2, Buffer.from(s, "utf-8"), fin);
+const continuationFrame = (s: string, fin = true) => serverFrame(0x0, Buffer.from(s, "utf-8"), fin);
+
+interface LocalServer {
+  port: number;
+  stop: () => void;
+}
+
+function startServer(afterUpgrade: (socket: tls.TLSSocket) => void): Promise<LocalServer> {
+  return new Promise((resolve) => {
+    const live: tls.TLSSocket[] = [];
+    const server = tls.createServer({ key, cert }, (socket) => {
+      live.push(socket);
+      socket.once("data", (data: Buffer) => {
+        const wsKey = /sec-websocket-key:\s*(\S+)/i.exec(data.toString())?.[1] ?? "";
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${computeAcceptKey(wsKey)}\r\n\r\n`,
+        );
+        afterUpgrade(socket);
+      });
+      socket.on("error", () => {
+        /* the client tears sockets down mid-flight; not a test failure */
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as { port: number }).port;
+      resolve({
+        port,
+        stop: () => {
+          for (const s of live) s.destroy();
+          server.close();
+        },
+      });
+    });
+  });
+}
+
+async function withClient<T>(
+  afterUpgrade: (socket: tls.TLSSocket) => void,
+  body: (ws: Awaited<ReturnType<typeof connectTLSWebSocket>>) => Promise<T>,
+): Promise<T> {
+  const server = await startServer(afterUpgrade);
+  try {
+    const ws = await connectTLSWebSocket("localhost", "/probe", undefined, {
+      port: server.port,
+      ca: cert,
+    });
+    return await body(ws);
+  } finally {
+    server.stop();
+  }
+}
+
+/** The predicate `geminiLiveWS` step 2 waits on. */
+const isSetupComplete = (msg: unknown): boolean =>
+  !!msg && typeof msg === "object" && "setupComplete" in msg;
+
+/** Resolve to the error instead of throwing, so it can be asserted on. */
+const captureError = (p: Promise<unknown>): Promise<unknown> =>
+  p.then(
+    () => null,
+    (e: unknown) => e,
+  );
+
+// ---------------------------------------------------------------------------
+// THE READ GAP: frames the client was sent but could not see
+// ---------------------------------------------------------------------------
+
+describe("REGRESSION: a message the provider framed as BINARY is read, not dropped", () => {
+  it("observes a BINARY-framed setupComplete", async () => {
+    // RED (pre-fix): opcode 0x2 fell through every branch of the frame reader,
+    // was sliced off the buffer and discarded, and this wait timed out having
+    // "collected 0 messages" — the exact live Gemini Live observation.
+    const messages = await withClient(
+      (socket) => socket.write(binaryFrame(JSON.stringify({ setupComplete: {} }))),
+      (ws) => ws.waitUntil(isSetupComplete, 2000),
+    );
+
+    expect(messages).toEqual([{ setupComplete: {} }]);
+  });
+
+  it("reads a BINARY-framed audio turn the same way it reads a TEXT one", async () => {
+    // The payload shape the AUDIO leg grades on, delivered over the opcode the
+    // client used to be blind to.
+    const audio = {
+      serverContent: { modelTurn: { parts: [{ inlineData: { data: "AAAA" } }] } },
+    };
+    const messages = await withClient(
+      (socket) => {
+        socket.write(binaryFrame(JSON.stringify({ setupComplete: {} })));
+        socket.write(binaryFrame(JSON.stringify(audio)));
+        socket.write(binaryFrame(JSON.stringify({ serverContent: { turnComplete: true } })));
+      },
+      async (ws) => {
+        await ws.waitUntil(isSetupComplete, 2000);
+        return ws.waitUntil(
+          (m: unknown) =>
+            (m as { serverContent?: { turnComplete?: boolean } })?.serverContent?.turnComplete ===
+            true,
+          2000,
+        );
+      },
+    );
+
+    expect(messages).toEqual([audio, { serverContent: { turnComplete: true } }]);
+  });
+});
+
+describe("REGRESSION: a fragmented message is reassembled, not truncated", () => {
+  it("joins a FIN=0 TEXT head with its CONTINUATION tail into ONE message", async () => {
+    // RED (pre-fix): the head was JSON.parse'd alone (invalid JSON -> pushed as
+    // a raw string, which no predicate matches) and the tail was dropped.
+    const json = JSON.stringify({ setupComplete: { sessionId: "abc" } });
+    const cut = 12;
+    const messages = await withClient(
+      (socket) => {
+        socket.write(textFrame(json.slice(0, cut), false));
+        socket.write(continuationFrame(json.slice(cut), true));
+      },
+      (ws) => ws.waitUntil(isSetupComplete, 2000),
+    );
+
+    expect(messages).toEqual([{ setupComplete: { sessionId: "abc" } }]);
+  });
+
+  it("joins a fragmented BINARY message across MULTIPLE continuation frames", async () => {
+    // An audio turn's base64 payload is precisely the message a provider
+    // fragments, and it arrives on the binary opcode.
+    const json = JSON.stringify({
+      serverContent: { modelTurn: { parts: [{ inlineData: { data: "QUJDREVGR0hJSks=" } }] } },
+    });
+    const third = Math.ceil(json.length / 3);
+    const messages = await withClient(
+      (socket) => {
+        socket.write(binaryFrame(json.slice(0, third), false));
+        socket.write(continuationFrame(json.slice(third, third * 2), false));
+        socket.write(continuationFrame(json.slice(third * 2), true));
+      },
+      (ws) =>
+        ws.waitUntil((m: unknown) => !!m && typeof m === "object" && "serverContent" in m, 2000),
+    );
+
+    expect(messages).toEqual([JSON.parse(json)]);
+  });
+
+  it("does not let an interleaved control frame corrupt a message being reassembled", async () => {
+    // RFC 6455 §5.4: a control frame MAY be injected between fragments. It must
+    // not be spliced into the message body.
+    const json = JSON.stringify({ setupComplete: {} });
+    const messages = await withClient(
+      (socket) => {
+        socket.write(textFrame(json.slice(0, 5), false));
+        socket.write(serverFrame(0x9, Buffer.from("hb"))); // PING mid-message
+        socket.write(continuationFrame(json.slice(5), true));
+      },
+      (ws) => ws.waitUntil(isSetupComplete, 2000),
+    );
+
+    expect(messages).toEqual([{ setupComplete: {} }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THE DIAGNOSTIC: a zero-message failure must say what the transport DID see
+// ---------------------------------------------------------------------------
+
+describe("a zero-message timeout distinguishes a mute surface from an unreadable one", () => {
+  it("reports an all-zero frame tally when the server truly sends nothing", async () => {
+    const err = (await withClient(
+      () => {
+        /* the provider says nothing at all */
+      },
+      (ws) => captureError(ws.waitUntil(isSetupComplete, 600, "setupComplete")),
+    )) as Error;
+
+    // The collector's recognizer parses this prefix; it must stay contiguous.
+    expect(err.message).toContain("waitUntil timeout after 600ms. Collected 0 messages:");
+    expect(err.message).toContain("step=setupComplete");
+    expect(err.message).toContain("frames text=0 binary=0 continuation=0");
+    expect(err.message).toContain("unhandled=0");
+  });
+
+  it("reports the frames it COULD NOT read rather than looking mute", async () => {
+    // An opcode outside the set the client understands must be counted. This is
+    // the assertion that makes "the surface sent nothing" a falsifiable claim:
+    // pre-fix, this case and the one above produced identical text.
+    const err = (await withClient(
+      (socket) => socket.write(serverFrame(0x3, Buffer.from("reserved"))),
+      (ws) => captureError(ws.waitUntil(isSetupComplete, 600, "setupComplete")),
+    )) as Error;
+
+    expect(err.message).toContain("Collected 0 messages:");
+    expect(err.message).toContain("unhandled=1");
+  });
+
+  it("carries the frame tally and the step into a server-initiated CLOSE too", async () => {
+    const err = (await withClient(
+      (socket) => {
+        socket.write(binaryFrame(JSON.stringify({ hello: true })));
+        const payload = Buffer.alloc(2 + 6);
+        payload.writeUInt16BE(1011, 0);
+        payload.write("oops!!", 2);
+        socket.write(serverFrame(0x8, payload));
+      },
+      (ws) => captureError(ws.waitUntil(isSetupComplete, 2000, "setupComplete")),
+    )) as WSClosedError;
+
+    expect(err).toBeInstanceOf(WSClosedError);
+    expect(err.code).toBe(1011);
+    expect(err.message).toContain("step=setupComplete");
+    // One readable binary frame arrived before the close — evidence that the
+    // transport was working and the provider still ended the session.
+    expect(err.message).toContain("binary=1");
+  });
+
+  it("still reports a plain timeout, with a nonzero tally, when frames were read but none matched", async () => {
+    const err = (await withClient(
+      (socket) => {
+        socket.write(textFrame(JSON.stringify({ somethingElse: 1 })));
+        socket.write(textFrame(JSON.stringify({ andAnother: 2 })));
+      },
+      (ws) => captureError(ws.waitUntil(isSetupComplete, 600, "turn")),
+    )) as Error;
+
+    // Gate 2 of the collector's timeout recognizer: a nonzero collected count
+    // must NOT be classified as a silent surface.
+    expect(err.message).toContain("Collected 2 messages:");
+    expect(err.message).toContain("frames text=2");
+    expect(err.message).toContain("step=turn");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GUARDS: the tally cannot manufacture observations
+// ---------------------------------------------------------------------------
+
+describe("GUARD: the frame tally counts what actually arrived", () => {
+  it("counts a PING as ping, not as a message", async () => {
+    const err = (await withClient(
+      (socket) => socket.write(serverFrame(0x9, Buffer.from("hb"))),
+      (ws) => captureError(ws.waitUntil(isSetupComplete, 600, "setupComplete")),
+    )) as Error;
+
+    expect(err.message).toContain("Collected 0 messages:");
+    expect(err.message).toContain("ping=1");
+    expect(err.message).toContain("unhandled=0");
+  });
+
+  it("counts continuation frames separately from the message they complete", async () => {
+    const err = (await withClient(
+      (socket) => {
+        // A fragmented message that never finishes: no message can be emitted.
+        socket.write(textFrame('{"setup', false));
+        socket.write(continuationFrame('Complete":', false));
+      },
+      (ws) => captureError(ws.waitUntil(isSetupComplete, 600, "setupComplete")),
+    )) as Error;
+
+    // An unterminated fragment sequence is NOT a message — it must not be
+    // emitted early, and it must not be invisible either.
+    expect(err.message).toContain("Collected 0 messages:");
+    expect(err.message).toContain("text=1");
+    expect(err.message).toContain("continuation=1");
+  });
+});

--- a/src/__tests__/drift/ws-frame-opcodes.test.ts
+++ b/src/__tests__/drift/ws-frame-opcodes.test.ts
@@ -48,6 +48,7 @@ import * as path from "node:path";
 import { execFileSync } from "node:child_process";
 import { computeAcceptKey } from "../../ws-framing.js";
 import { connectTLSWebSocket, WSClosedError } from "./ws-providers.js";
+import { parseLiveTimeout } from "../../../scripts/drift-report-collector.js";
 
 // ---------------------------------------------------------------------------
 // Local TLS WebSocket server
@@ -353,6 +354,42 @@ describe("a zero-message timeout distinguishes a mute surface from an unreadable
     expect(err.message).toContain("Collected 2 messages:");
     expect(err.message).toContain("frames text=2");
     expect(err.message).toContain("step=turn");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The probe -> collector seam
+// ---------------------------------------------------------------------------
+//
+// The collector routes a silent live leg by REGEX over the probe's own failure
+// text (`parseLiveTimeout`). Appending the transport diagnostic to that text is
+// therefore a cross-module change: if it split the `waitUntil timeout after
+// <n>ms. Collected <n> messages:` prefix the recognizer needs, every silent leg
+// would stop being classified as exit 6 and become an exit-5 manual-triage hard
+// stop on the daily cron — trading a diagnosis for an outage. So the seam is
+// asserted against a message the REAL client produced, not a hand-written one.
+
+describe("the collector still classifies the probe's timeout text", () => {
+  it("routes a REAL zero-message timeout into the live-timeout lane", async () => {
+    const err = (await withClient(
+      () => {
+        /* mute provider */
+      },
+      (ws) => captureError(ws.waitUntil(isSetupComplete, 600, "setupComplete")),
+    )) as Error;
+
+    expect(parseLiveTimeout(err.message)).toEqual({ timeoutMs: 600 });
+  });
+
+  it("still refuses that lane when messages WERE collected", async () => {
+    // Gate 2 of the recognizer. A leg that observed something is not a silent
+    // surface, and the transport suffix must not accidentally satisfy the gate.
+    const err = (await withClient(
+      (socket) => socket.write(textFrame(JSON.stringify({ somethingElse: 1 }))),
+      (ws) => captureError(ws.waitUntil(isSetupComplete, 600, "setupComplete")),
+    )) as Error;
+
+    expect(parseLiveTimeout(err.message)).toBeNull();
   });
 });
 

--- a/src/__tests__/drift/ws-gemini-live-modality.test.ts
+++ b/src/__tests__/drift/ws-gemini-live-modality.test.ts
@@ -126,6 +126,10 @@ interface FakeProviderOptions {
   emitTextInsteadOfAudio?: boolean;
   /** Never end the turn. */
   omitTurnComplete?: boolean;
+  /** Accept the socket and say NOTHING — not even `setupComplete`. */
+  muteFromStart?: boolean;
+  /** Send `setupComplete`, then ignore the client's turn entirely. */
+  muteAfterSetup?: boolean;
 }
 
 /** The client-to-server messages the fake provider understands. */
@@ -194,6 +198,10 @@ function startFakeProvider(options: FakeProviderOptions = {}): Promise<FakeProvi
         let hasTools = false;
 
         conn.on("message", (raw: string) => {
+          // The live failure mode: the session is accepted and nothing comes
+          // back. Handled before parsing so the provider is mute no matter what
+          // the probe sends.
+          if (options.muteFromStart) return;
           let msg: LiveClientMessage;
           try {
             msg = JSON.parse(raw) as LiveClientMessage;
@@ -228,6 +236,9 @@ function startFakeProvider(options: FakeProviderOptions = {}): Promise<FakeProvi
           }
 
           if (msg.clientContent) {
+            // A session that establishes fine and then produces no turn — the
+            // OTHER cause a zero-message live failure can have.
+            if (options.muteAfterSetup) return;
             if (hasTools) {
               conn.send(
                 JSON.stringify({
@@ -295,11 +306,12 @@ async function withProvider<T>(
 }
 
 /** Drive the REAL probe against the fake provider. */
-function probe(provider: FakeProvider, tools?: object[]) {
+function probe(provider: FakeProvider, tools?: object[], waitMs?: number) {
   return geminiLiveWS({ apiKey: "fake-key" }, "Greet me aloud", tools, OBSERVED_MODEL, {
     host: "localhost",
     port: provider.port,
     ca: cert,
+    waitMs,
   });
 }
 
@@ -363,6 +375,58 @@ describe("REPRODUCTION: a TEXT-modality Live session is refused with 1007", () =
     expect(err).toBeInstanceOf(WSClosedError);
     expect((err as WSClosedError).code).toBe(1007);
     expect((err as WSClosedError).reason).toContain("(TEXT, AUDIO)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The CURRENT live failure: accepted, then nothing
+// ---------------------------------------------------------------------------
+//
+// The live legs now fail as a bare zero-message timeout. Two causes produce
+// that, and the drift-report artifact could not tell them apart:
+//
+//   A. the session was never established — no `setupComplete` ever arrived;
+//   B. the session WAS established and the turn produced nothing.
+//
+// The per-call message cursor means B's collected count is also 0 (step 2
+// consumed the `setupComplete`), so both printed `Collected 0 messages: []`.
+// These two tests are the discriminator, driven through the REAL probe: the
+// failure now names the step it was on AND the dynamically-resolved model, so
+// the next live run states which cause it hit instead of repeating the
+// ambiguity.
+
+describe("a zero-message live failure names its cause", () => {
+  it("A: a provider mute from the start fails at step=setupComplete", async () => {
+    const err = (await withProvider({ muteFromStart: true }, (provider) =>
+      probe(provider, undefined, 500).then(
+        () => null,
+        (e: unknown) => e,
+      ),
+    )) as Error;
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("step=setupComplete");
+    expect(err.message).toContain(`model=${OBSERVED_MODEL}`);
+    // Nothing was read because nothing was sent — an all-zero data tally is the
+    // transport stating it was not the deaf party.
+    expect(err.message).toContain("frames text=0 binary=0");
+  });
+
+  it("B: a provider that answers setup but not the turn fails at step=turn", async () => {
+    const err = (await withProvider({ muteAfterSetup: true }, (provider) =>
+      probe(provider, undefined, 500).then(
+        () => null,
+        (e: unknown) => e,
+      ),
+    )) as Error;
+
+    expect(err).toBeInstanceOf(Error);
+    // The distinction the artifact could not previously make.
+    expect(err.message).toContain("step=turn");
+    expect(err.message).toContain(`model=${OBSERVED_MODEL}`);
+    // The session WAS established: one frame was read before the surface went
+    // quiet, which is what separates this from case A.
+    expect(err.message).toContain("frames text=1");
   });
 });
 

--- a/src/__tests__/drift/ws-gemini-live-modality.test.ts
+++ b/src/__tests__/drift/ws-gemini-live-modality.test.ts
@@ -32,6 +32,14 @@
  * NOT PROVEN HERE: that the live endpoint accepts `["AUDIO"]` and emits this
  * exact sequence. That is established from Google's published capabilities guide
  * and can only be confirmed by a live run with a real GOOGLE_API_KEY.
+ *
+ * THE SAME MIS-DRIVE, ON THE OTHER SIDE. Once the real side was asking for a
+ * modality the model serves, the tool-call leg reported that the provider emits
+ * `serverContent` and the mock does not — because the MOCK side was still being
+ * driven by a text-shaped tool fixture into a bare `toolCall` with no model turn.
+ * The final section of this file holds that down end to end, with the fake
+ * provider emitting the tool turn in the order the live artifact proves it used
+ * (`serverContent` strictly before `toolCall`).
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import * as tls from "node:tls";
@@ -50,9 +58,14 @@ import {
   WSClosedError,
 } from "./ws-providers.js";
 import { extractShape, compareSSESequences } from "./schema.js";
-import { geminiLiveSetupCompleteShape, geminiLiveAudioEventShapes } from "./sdk-shapes.js";
+import {
+  geminiLiveSetupCompleteShape,
+  geminiLiveAudioEventShapes,
+  geminiLiveToolCallEventShapes,
+} from "./sdk-shapes.js";
 import {
   startDriftServer,
+  startGeminiLiveDriftServer,
   stopDriftServer,
   collectMockWSMessages,
   GEMINI_WS_PATH,
@@ -240,6 +253,29 @@ function startFakeProvider(options: FakeProviderOptions = {}): Promise<FakeProvi
             // OTHER cause a zero-message live failure can have.
             if (options.muteAfterSetup) return;
             if (hasTools) {
+              // A Live tool turn is an AUDIO turn that ALSO calls the function:
+              // the model speaks, THEN asks for the call, as two messages
+              // (`serverContent` and `toolCall` are alternatives of one union
+              // on `LiveServerMessage`, never combined).
+              //
+              // The ORDER is recovered from the live drift artifact, not
+              // invented: the probe collects up to and including the FIRST
+              // `toolCall`, the leg's `toolCallCount > 0` assertion passed, and
+              // a `serverContent` was present in what it collected — so the
+              // provider sent `serverContent` strictly BEFORE the `toolCall`.
+              // The old fake sent a bare `toolCall`, which modelled the MOCK's
+              // bug rather than the provider, and so could not reproduce it.
+              conn.send(
+                JSON.stringify({
+                  serverContent: {
+                    modelTurn: {
+                      parts: [
+                        { inlineData: { mimeType: "audio/pcm;rate=24000", data: "AAAAAA==" } },
+                      ],
+                    },
+                  },
+                }),
+              );
               conn.send(
                 JSON.stringify({
                   toolCall: {
@@ -306,14 +342,34 @@ async function withProvider<T>(
 }
 
 /** Drive the REAL probe against the fake provider. */
-function probe(provider: FakeProvider, tools?: object[], waitMs?: number) {
-  return geminiLiveWS({ apiKey: "fake-key" }, "Greet me aloud", tools, OBSERVED_MODEL, {
+function probe(provider: FakeProvider, tools?: object[], waitMs?: number, prompt = AUDIO_PROMPT) {
+  return geminiLiveWS({ apiKey: "fake-key" }, prompt, tools, OBSERVED_MODEL, {
     host: "localhost",
     port: provider.port,
     ca: cert,
     waitMs,
   });
 }
+
+/** The `functionDeclarations` the live tool-call leg declares, verbatim. */
+const WEATHER_TOOLS = [
+  {
+    functionDeclarations: [
+      {
+        name: "get_weather",
+        description: "Get weather",
+        parameters: {
+          type: "object",
+          properties: { city: { type: "string" } },
+          required: ["city"],
+        },
+      },
+    ],
+  },
+];
+
+/** The prompt the live tool-call leg sends, verbatim. */
+const TOOL_PROMPT = "Weather in Paris";
 
 // ---------------------------------------------------------------------------
 // The reproduction: what the live endpoint did to a TEXT request
@@ -667,6 +723,183 @@ describe("three-way AUDIO comparison: sdk shapes × provider turn × aimock", ()
       realResult.events,
       textShapedMock,
     );
+
+    const critical = diffs.filter((d) => d.severity === "critical");
+    expect(critical.length).toBeGreaterThan(0);
+    expect(critical.map((d) => d.path).join(" ")).toContain("inlineData");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The TOOL turn, run locally end to end
+// ---------------------------------------------------------------------------
+//
+// Run 31896605497's head drift report carried exactly one Gemini Live diff, on
+// the TOOL-CALL leg (the audio leg graded clean):
+//
+//   severity: critical
+//   path:     SSE:serverContent
+//   issue:    real API emits event type "serverContent" but mock does not
+//   real:     serverContent
+//   mock:     <absent>
+//
+// The provider was NOT emitting an event aimock has never heard of — aimock
+// emits `serverContent` in every other branch of the Live handler. What it
+// could not do was emit one in a TOOL turn, for two compounding reasons:
+//
+//   1. the leg drove the mock with the shared, text-shaped TOOL_FIXTURE, whose
+//      Live rendering is a bare `toolCall` with no model turn at all; and
+//   2. the ONE fixture shape that expresses "the model speaks AND calls a
+//      function" — an AudioResponse carrying the `toolCalls` companion — was
+//      silently dropping that companion in the Live handler's audio branch.
+//
+// So (2) made the correct drive (1) inexpressible. Both are fixed, and the
+// three tests below hold each end of that down: the mis-drive still reproduces
+// the reported critical, the corrected drive grades clean, and a mock that
+// loses the model turn still goes critical.
+describe("three-way TOOL comparison: sdk shapes × provider turn × aimock", () => {
+  let liveInstance: ServerInstance;
+  let sharedInstance: ServerInstance;
+
+  beforeAll(async () => {
+    liveInstance = await startGeminiLiveDriftServer();
+    sharedInstance = await startDriftServer();
+  });
+
+  afterAll(async () => {
+    await stopDriftServer(liveInstance);
+    await stopDriftServer(sharedInstance);
+  });
+
+  /**
+   * Drive aimock exactly as the tool-call drift leg's mock side does, against
+   * whichever fixture set is under test.
+   */
+  async function driveMockTool(instance: ServerInstance): Promise<unknown[]> {
+    const mockWs = await connectWebSocket(instance.url, GEMINI_WS_PATH);
+    mockWs.send(
+      JSON.stringify({
+        setup: {
+          model: OBSERVED_MODEL,
+          tools: WEATHER_TOOLS,
+          generationConfig: { responseModalities: GEMINI_LIVE_RESPONSE_MODALITIES },
+        },
+      }),
+    );
+    const setupMsgs = await mockWs.waitForMessages(1);
+    const raw: unknown[] = [JSON.parse(setupMsgs[0])];
+    mockWs.send(
+      JSON.stringify({
+        clientContent: {
+          turns: [{ role: "user", parts: [{ text: TOOL_PROMPT }] }],
+          turnComplete: true,
+        },
+      }),
+    );
+    const content = await collectMockWSMessages(
+      mockWs,
+      (msg) => !!msg && typeof msg === "object" && "toolCall" in msg,
+      15000,
+      1,
+    );
+    raw.push(...content.rawMessages);
+    mockWs.close();
+    return raw;
+  }
+
+  function toEvents(raw: unknown[]) {
+    return raw.map((msg) => ({
+      type: classifyGeminiMessage(msg as Record<string, unknown>),
+      dataShape: extractShape(msg),
+    }));
+  }
+
+  const toolSdkShapes = () => [geminiLiveSetupCompleteShape(), ...geminiLiveToolCallEventShapes()];
+
+  it("REPRODUCTION: the text-shaped tool fixture still reports SSE:serverContent as <absent>", async () => {
+    // The mis-drive, kept alive on purpose. This is the reported failure, not a
+    // paraphrase of it: the shared TOOL_FIXTURE renders as a bare `toolCall`,
+    // and grading that against a provider turn that speaks first produces the
+    // artifact's diff verbatim. If a future change made this pass, the leg
+    // would have stopped being able to see the bug it was built for.
+    const realResult = await withProvider({}, (provider) =>
+      probe(provider, WEATHER_TOOLS, undefined, TOOL_PROMPT),
+    );
+    const mockRaw = await driveMockTool(sharedInstance);
+
+    // The mock's own turn: a tool call and nothing before it.
+    expect(summarizeGeminiLiveTurn(mockRaw)).toMatchObject({
+      toolCallCount: 1,
+      audioPartCount: 0,
+      textPartCount: 0,
+    });
+
+    const diffs = compareSSESequences(toolSdkShapes(), realResult.events, toEvents(mockRaw));
+    expect(diffs).toContainEqual(
+      expect.objectContaining({
+        path: "SSE:serverContent",
+        severity: "critical",
+        expected: "serverContent",
+        real: "serverContent",
+        mock: "<absent>",
+      }),
+    );
+  });
+
+  it("aimock streams the model turn BEFORE the tool call for the Live tool fixture", async () => {
+    const raw = await driveMockTool(liveInstance);
+
+    // Ordering is the whole point, so it is asserted on the SEQUENCE, not on
+    // counts: counts alone would pass a mock that spoke after calling, which is
+    // what the handler used to do (its `turnComplete` trailed the `toolCall`
+    // and the probe therefore never saw it).
+    expect(toEvents(raw).map((e) => e.type)).toEqual([
+      "setupComplete",
+      "serverContent",
+      "toolCall",
+    ]);
+
+    const turn = summarizeGeminiLiveTurn(raw);
+    expect(turn.setupCompleteCount).toBe(1);
+    expect(turn.audioPartCount).toBeGreaterThan(0);
+    expect(turn.toolCallCount).toBe(1);
+    // AUDIO modality: the turn speaks, it does not write.
+    expect(turn.textPartCount).toBe(0);
+  });
+
+  it("reports NO critical drift between the sdk tool shapes, the provider turn, and aimock", async () => {
+    const realResult = await withProvider({}, (provider) =>
+      probe(provider, WEATHER_TOOLS, undefined, TOOL_PROMPT),
+    );
+    const mockRaw = await driveMockTool(liveInstance);
+
+    const diffs = compareSSESequences(toolSdkShapes(), realResult.events, toEvents(mockRaw));
+
+    expect(diffs.filter((d) => d.severity === "critical")).toEqual([]);
+  });
+
+  it("GUARD: a mock whose model turn lost its audio IS reported as critical drift", async () => {
+    // Non-vacuity of the test above. The mock side here keeps the correct EVENT
+    // SEQUENCE — serverContent then toolCall — and only empties the model turn,
+    // so a comparison that graded event types alone would call this clean.
+    const realResult = await withProvider({}, (provider) =>
+      probe(provider, WEATHER_TOOLS, undefined, TOOL_PROMPT),
+    );
+    const hollowMock = [
+      { type: "setupComplete", dataShape: extractShape({ setupComplete: {} }) },
+      {
+        type: "serverContent",
+        dataShape: extractShape({ serverContent: { modelTurn: { parts: [{ text: "" }] } } }),
+      },
+      {
+        type: "toolCall",
+        dataShape: extractShape({
+          toolCall: { functionCalls: [{ name: "get_weather", args: {}, id: "x" }] },
+        }),
+      },
+    ];
+
+    const diffs = compareSSESequences(toolSdkShapes(), realResult.events, hollowMock);
 
     const critical = diffs.filter((d) => d.severity === "critical");
     expect(critical.length).toBeGreaterThan(0);

--- a/src/__tests__/drift/ws-gemini-live-modality.test.ts
+++ b/src/__tests__/drift/ws-gemini-live-modality.test.ts
@@ -796,10 +796,14 @@ describe("three-way TOOL comparison: sdk shapes × provider turn × aimock", () 
         },
       }),
     );
+    // A short budget on purpose: a mock that never emits the `toolCall` must
+    // fail as the collector's own "timed out … Collected N messages" — which
+    // names the defect — rather than as vitest's bare per-test timeout, which
+    // names nothing. Everything here is local and answers in milliseconds.
     const content = await collectMockWSMessages(
       mockWs,
       (msg) => !!msg && typeof msg === "object" && "toolCall" in msg,
-      15000,
+      3000,
       1,
     );
     raw.push(...content.rawMessages);

--- a/src/__tests__/drift/ws-gemini-live.drift.ts
+++ b/src/__tests__/drift/ws-gemini-live.drift.ts
@@ -64,7 +64,7 @@ import {
   type LiveModelEntry,
 } from "./providers.js";
 import {
-  startDriftServer,
+  startGeminiLiveDriftServer,
   stopDriftServer,
   collectMockWSMessages,
   classifyGeminiMessage,
@@ -81,7 +81,7 @@ let instance: ServerInstance;
 const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY;
 
 beforeAll(async () => {
-  instance = await startDriftServer();
+  instance = await startGeminiLiveDriftServer();
 });
 
 afterAll(async () => {
@@ -375,6 +375,21 @@ describe.skipIf(!GOOGLE_API_KEY)("Gemini Live WS drift", () => {
     expect(
       mockTurn.toolCallCount,
       `Mock emitted no toolCall: ${JSON.stringify(mockTurn)}`,
+    ).toBeGreaterThan(0);
+    // The mock must SPEAK before it calls. A Live tool turn is an AUDIO turn
+    // that also calls a function, and the mock driven by a text-shaped
+    // tool-only fixture issued a bare `toolCall` with no model turn at all —
+    // reported as `SSE:serverContent … mock:"<absent>"`. Graded here on the mock
+    // side directly, because `compareSSESequences` can only see the absence
+    // while the REAL side happens to send the event, and a provider that
+    // stopped sending it would silently retire the check.
+    //
+    // Deliberately NOT asserted on the real side: what the provider puts in its
+    // pre-`toolCall` `serverContent` is unproven, so requiring audio parts
+    // there would red the leg on an unverified assumption rather than on drift.
+    expect(
+      mockTurn.audioPartCount,
+      `Mock issued a toolCall with no model turn before it: ${JSON.stringify(mockTurn)}`,
     ).toBeGreaterThan(0);
 
     const diffs = compareSSESequences(sdkEvents, realResult.events, mockEvents);

--- a/src/__tests__/drift/ws-providers.ts
+++ b/src/__tests__/drift/ws-providers.ts
@@ -28,7 +28,17 @@ interface WSResult {
 
 interface TLSWSClient {
   send(data: string): void;
-  waitUntil(predicate: (msg: unknown) => boolean, timeoutMs?: number): Promise<unknown[]>;
+  /**
+   * `step` names the protocol step being awaited (e.g. `"setupComplete"`), and
+   * is carried into the failure text. Without it, every stage of a multi-step
+   * handshake fails with the same sentence, so a probe that never got past
+   * setup and one whose turn produced nothing are indistinguishable in CI.
+   */
+  waitUntil(
+    predicate: (msg: unknown) => boolean,
+    timeoutMs?: number,
+    step?: string,
+  ): Promise<unknown[]>;
   close(): void;
 }
 
@@ -115,6 +125,53 @@ export function parseCloseFrame(payload: Buffer): { code: number; reason: string
   const code = payload.length >= 2 ? payload.readUInt16BE(0) : 1005;
   const reason = payload.length > 2 ? payload.subarray(2).toString("utf-8") : "";
   return { code, reason };
+}
+
+/**
+ * Per-opcode count of the RFC 6455 frames a connection has received.
+ *
+ * The point is that NOTHING the transport is handed can be invisible. A
+ * zero-message failure used to be a single, ambiguous sentence — "Collected 0
+ * messages" — that a mute provider and a provider whose frames this client
+ * could not decode produced identically. With the tally attached, `text=0
+ * binary=0 unhandled=0` says the surface really sent nothing, while any nonzero
+ * count says bytes arrived and the fault is on this side of the wire.
+ */
+export interface WSFrameTally {
+  /** Data frames with opcode 0x1. */
+  text: number;
+  /** Data frames with opcode 0x2 — read exactly like text (both carry JSON). */
+  binary: number;
+  /** Continuation frames (opcode 0x0) folded into a fragmented message. */
+  continuation: number;
+  /** Control frames: ping (0x9), pong (0xA), close (0x8). */
+  ping: number;
+  pong: number;
+  close: number;
+  /**
+   * Frames whose opcode this client does not implement. Counted rather than
+   * dropped: an unhandled frame is the one thing that must never be silent,
+   * because silence is what it would otherwise be mistaken for.
+   */
+  unhandled: number;
+}
+
+function emptyFrameTally(): WSFrameTally {
+  return { text: 0, binary: 0, continuation: 0, ping: 0, pong: 0, close: 0, unhandled: 0 };
+}
+
+/**
+ * Render a connection's frame tally, plus the protocol step that was waiting,
+ * for a failure message. Appended AFTER {@link describeCollected} so the
+ * collector's `waitUntil timeout after <n>ms. Collected <n> messages:`
+ * recognizer keeps matching an uninterrupted prefix.
+ */
+export function describeTransport(tally: WSFrameTally, step?: string): string {
+  return (
+    `Transport: ${step ? `step=${step} ` : ""}frames text=${tally.text} ` +
+    `binary=${tally.binary} continuation=${tally.continuation} ping=${tally.ping} ` +
+    `pong=${tally.pong} close=${tally.close} unhandled=${tally.unhandled}.`
+  );
 }
 
 /**
@@ -320,6 +377,24 @@ export function connectTLSWebSocket(
       let closeInfo: { code: number; reason: string } | null = null;
       // Connection-scoped cursor so successive waitUntil calls resume where the last left off
       let checkedUpTo = 0;
+      // Every frame this connection has received, by opcode. Read by the
+      // failure paths so a zero-message outcome states what DID arrive.
+      const tally = emptyFrameTally();
+      // Fragment reassembly buffer (RFC 6455 §5.4). A data frame with FIN=0
+      // starts a message that continuation frames extend; only the final
+      // fragment emits. Non-empty means a message is mid-flight.
+      let fragments: Buffer[] = [];
+
+      /** Decode a completed message payload and wake every pending waiter. */
+      const emitMessage = (payload: Buffer) => {
+        const text = payload.toString("utf-8");
+        try {
+          messages.push(JSON.parse(text));
+        } catch {
+          messages.push(text);
+        }
+        for (const r of messageResolvers) r();
+      };
 
       socket.on("data", (data: Buffer) => {
         buffer = Buffer.concat([buffer, data]);
@@ -357,7 +432,11 @@ export function connectTLSWebSocket(
               socket.write(buildMaskedTextFrame(Buffer.from(data, "utf-8")));
             },
 
-            waitUntil(predicate: (msg: unknown) => boolean, timeoutMs = 30000): Promise<unknown[]> {
+            waitUntil(
+              predicate: (msg: unknown) => boolean,
+              timeoutMs = 30000,
+              step?: string,
+            ): Promise<unknown[]> {
               return new Promise((resolve, reject) => {
                 const collected: unknown[] = [];
                 let settled = false;
@@ -376,7 +455,8 @@ export function connectTLSWebSocket(
                   reject(
                     new WSClosedError(
                       `WebSocket closed by server during waitUntil: code=${info.code} ` +
-                        `reason=${JSON.stringify(info.reason)}. ${describeCollected(collected)}`,
+                        `reason=${JSON.stringify(info.reason)}. ${describeCollected(collected)} ` +
+                        `${describeTransport(tally, step)}`,
                       info.code,
                       info.reason,
                     ),
@@ -410,7 +490,8 @@ export function connectTLSWebSocket(
                     removeResolver();
                     reject(
                       new Error(
-                        `waitUntil timeout after ${timeoutMs}ms. ${describeCollected(collected)}`,
+                        `waitUntil timeout after ${timeoutMs}ms. ${describeCollected(collected)} ` +
+                          `${describeTransport(tally, step)}`,
                       ),
                     );
                   }
@@ -426,7 +507,8 @@ export function connectTLSWebSocket(
                     reject(
                       new Error(
                         `WebSocket error during waitUntil: ${socketError.message}. ` +
-                          `Collected ${collected.length} messages.`,
+                          `Collected ${collected.length} messages. ` +
+                          `${describeTransport(tally, step)}`,
                       ),
                     );
                     return;
@@ -486,6 +568,7 @@ export function connectTLSWebSocket(
         while (buffer.length >= 2) {
           const byte0 = buffer[0];
           const byte1 = buffer[1];
+          const fin = (byte0 & 0x80) !== 0;
           const opcode = byte0 & 0x0f;
           let payloadLength = byte1 & 0x7f;
           let offset = 2;
@@ -506,26 +589,52 @@ export function connectTLSWebSocket(
           const framePayload = buffer.subarray(offset, offset + payloadLength);
           buffer = buffer.subarray(offset + payloadLength);
 
-          if (opcode === 0x1) {
-            // text frame
-            const text = framePayload.toString("utf-8");
-            try {
-              const parsed = JSON.parse(text);
-              messages.push(parsed);
-            } catch {
-              messages.push(text);
+          if (opcode === 0x1 || opcode === 0x2) {
+            // A data frame. TEXT and BINARY are decoded IDENTICALLY: this
+            // protocol's payload is UTF-8 JSON either way, and which opcode a
+            // provider picks is its own choice — `@google/genai` decodes an
+            // inbound Blob/ArrayBuffer for exactly that reason. Treating 0x2 as
+            // unreadable is what made a talking provider look mute.
+            if (opcode === 0x1) tally.text++;
+            else tally.binary++;
+            if (fin) {
+              emitMessage(framePayload);
+            } else {
+              // Copy: `framePayload` is a view onto the receive buffer, which
+              // is replaced on the next socket "data" event.
+              fragments = [Buffer.from(framePayload)];
             }
-            for (const r of messageResolvers) r();
+          } else if (opcode === 0x0) {
+            // Continuation of a fragmented message. Emit only on FIN — a
+            // partial message must NOT be surfaced as if it were complete.
+            tally.continuation++;
+            if (fragments.length > 0) {
+              fragments.push(Buffer.from(framePayload));
+              if (fin) {
+                const complete = Buffer.concat(fragments);
+                fragments = [];
+                emitMessage(complete);
+              }
+            }
           } else if (opcode === 0x8) {
             // close frame — keep the code/reason before ending the socket, then
             // wake any pending waitUntil so it can report the stated reason.
             // Socket lifecycle is deliberately unchanged: still a plain end().
+            tally.close++;
             closeInfo = parseCloseFrame(framePayload);
             socket.end();
             for (const r of messageResolvers) r();
           } else if (opcode === 0x9) {
-            // ping — respond with pong per RFC 6455
+            // ping — respond with pong per RFC 6455. Control frames may be
+            // interleaved between fragments, so this must not touch `fragments`.
+            tally.ping++;
             socket.write(buildMaskedPongFrame(framePayload));
+          } else if (opcode === 0xa) {
+            tally.pong++;
+          } else {
+            // An opcode this client does not implement. Counted, never dropped
+            // silently — see WSFrameTally.
+            tally.unhandled++;
           }
         }
       });
@@ -559,7 +668,7 @@ export async function openaiResponsesWS(
   // Terminal: a completion event ("response.completed"/"response.done", both
   // observed in the wild) OR a request-level error frame — see
   // isResponsesWSTerminal for why the error frame must be terminal too.
-  const rawMessages = await ws.waitUntil(isResponsesWSTerminal);
+  const rawMessages = await ws.waitUntil(isResponsesWSTerminal, undefined, "response");
 
   ws.close();
 
@@ -597,7 +706,11 @@ export async function openaiRealtimeWS(
   );
 
   // Step 1: Wait for session.created
-  const sessionCreated = await ws.waitUntil((msg: any) => msg?.type === "session.created");
+  const sessionCreated = await ws.waitUntil(
+    (msg: any) => msg?.type === "session.created",
+    undefined,
+    "session.created",
+  );
 
   // Step 2: Send session.update.
   // GA requires session.type:"realtime" and renames the legacy `modalities`
@@ -612,7 +725,11 @@ export async function openaiRealtimeWS(
   ws.send(JSON.stringify({ type: "session.update", session }));
 
   // Step 3: Wait for session.updated
-  const sessionUpdated = await ws.waitUntil((msg: any) => msg?.type === "session.updated");
+  const sessionUpdated = await ws.waitUntil(
+    (msg: any) => msg?.type === "session.updated",
+    undefined,
+    "session.updated",
+  );
 
   // Step 4: Send conversation.item.create
   ws.send(
@@ -627,13 +744,21 @@ export async function openaiRealtimeWS(
   );
 
   // Step 5: Wait for conversation.item.added (GA)
-  const itemCreated = await ws.waitUntil((msg: any) => msg?.type === "conversation.item.added");
+  const itemCreated = await ws.waitUntil(
+    (msg: any) => msg?.type === "conversation.item.added",
+    undefined,
+    "conversation.item.added",
+  );
 
   // Step 6: Send response.create
   ws.send(JSON.stringify({ type: "response.create" }));
 
   // Step 7: Collect until response.done
-  const responseMessages = await ws.waitUntil((msg: any) => msg?.type === "response.done");
+  const responseMessages = await ws.waitUntil(
+    (msg: any) => msg?.type === "response.done",
+    undefined,
+    "response.done",
+  );
 
   ws.close();
 
@@ -757,9 +882,14 @@ export async function geminiLiveWS(
   if (tools) setup.tools = tools;
   ws.send(JSON.stringify({ setup }));
 
-  // Step 2: Wait for setupComplete
+  // Step 2: Wait for setupComplete. The step LABEL is what makes a silent run
+  // diagnosable: `step=setupComplete` means the session was never established,
+  // `step=turn` below means it was and the turn produced nothing — two very
+  // different causes that previously failed with identical text.
   const setupComplete = await ws.waitUntil(
     (msg: any) => msg && typeof msg === "object" && "setupComplete" in msg,
+    undefined,
+    "setupComplete",
   );
 
   // Step 3: Send client content
@@ -773,14 +903,18 @@ export async function geminiLiveWS(
   );
 
   // Step 4: Collect until turnComplete or toolCall
-  const responseMessages = await ws.waitUntil((msg: any) => {
-    if (!msg || typeof msg !== "object") return false;
-    if ("toolCall" in msg) return true;
-    if ("serverContent" in msg) {
-      return (msg as any).serverContent?.turnComplete === true;
-    }
-    return false;
-  });
+  const responseMessages = await ws.waitUntil(
+    (msg: any) => {
+      if (!msg || typeof msg !== "object") return false;
+      if ("toolCall" in msg) return true;
+      if ("serverContent" in msg) {
+        return (msg as any).serverContent?.turnComplete === true;
+      }
+      return false;
+    },
+    undefined,
+    "turn",
+  );
 
   ws.close();
 

--- a/src/__tests__/drift/ws-providers.ts
+++ b/src/__tests__/drift/ws-providers.ts
@@ -808,6 +808,12 @@ export const GEMINI_LIVE_HOST = "generativelanguage.googleapis.com";
 export interface GeminiLiveTransportOptions extends TLSWSConnectOptions {
   /** Host override. Defaults to {@link GEMINI_LIVE_HOST}. */
   host?: string;
+  /**
+   * Per-step wait budget in ms. Defaults to the client's 30s, which is what the
+   * live leg uses. Exists so a test can drive the REAL probe against a provider
+   * that goes mute — the live failure mode — without waiting out 30 seconds.
+   */
+  waitMs?: number;
 }
 
 /**
@@ -885,11 +891,13 @@ export async function geminiLiveWS(
   // Step 2: Wait for setupComplete. The step LABEL is what makes a silent run
   // diagnosable: `step=setupComplete` means the session was never established,
   // `step=turn` below means it was and the turn produced nothing — two very
-  // different causes that previously failed with identical text.
+  // different causes that previously failed with identical text. The MODEL rides
+  // along because it is resolved dynamically from the live listing, so a failure
+  // that does not name it cannot be attributed to a model at all.
   const setupComplete = await ws.waitUntil(
     (msg: any) => msg && typeof msg === "object" && "setupComplete" in msg,
-    undefined,
-    "setupComplete",
+    transport?.waitMs,
+    `setupComplete model=${model}`,
   );
 
   // Step 3: Send client content
@@ -912,8 +920,8 @@ export async function geminiLiveWS(
       }
       return false;
     },
-    undefined,
-    "turn",
+    transport?.waitMs,
+    `turn model=${model}`,
   );
 
   ws.close();

--- a/src/__tests__/fix-drift-workflow.test.ts
+++ b/src/__tests__/fix-drift-workflow.test.ts
@@ -2694,10 +2694,19 @@ describe("fix-drift.yml — needs-human notes are PERSISTED (pushed + PR'd), not
     );
   });
 
-  it("the needs-human persist step's PR body tells a human to set Decision: include and merge (closing the two-run loop), never auto-merged", () => {
+  it("the needs-human persist step's PR body states the procedure that ACTUALLY applies a family, and never auto-merges", () => {
     const body = codeOf(persistStep());
-    expect(body).toContain("Decision: include");
-    // No `gh pr merge` anywhere (asserted globally too) — human merges.
+    // The body used to instruct `Decision: include` + merge, promising a
+    // two-run hand-off. That path cannot work: `includeFamilies` is
+    // checksum-pinned, adding a family moves the pin and reds the freeze test
+    // gate-2 re-runs, and gate-1's allowlist bars drift-sync from re-pinning —
+    // a follow-up run reports `gate-failed`, never `ok-applied`. Every
+    // classification in this repo's history landed BY HAND (72f85f8, 936b59c).
+    // This pins the corrected instruction so the false one cannot come back.
+    expect(body).not.toContain("Decision: include");
+    expect(body).toContain("re-pin BOTH checksums");
+    expect(body).toMatch(/by hand/i);
+    // No `gh pr merge` anywhere (asserted globally too) — a human merges.
     expect(body).not.toMatch(/gh pr merge/);
   });
 

--- a/src/__tests__/ws-gemini-live.test.ts
+++ b/src/__tests__/ws-gemini-live.test.ts
@@ -30,7 +30,45 @@ const toolResultFixture: Fixture = {
   response: { content: "Weather in NYC is sunny, 72F" },
 };
 
-const allFixtures: Fixture[] = [textFixture, toolResultFixture, toolFixture, errorFixture];
+/** Audio-only turn: no companion modalities. */
+const audioFixture: Fixture = {
+  match: { userMessage: "sing" },
+  response: { audio: { b64Json: "QUJD", contentType: "audio/pcm;rate=24000" } },
+};
+
+/**
+ * Audio turn that ALSO calls a function and speaks text — the companion
+ * modalities `AudioResponse` documents as preserved (types.ts). Over the Live
+ * protocol `serverContent` and `toolCall` are alternatives of one message
+ * union, so this must arrive as `serverContent` then `toolCall`, not as a
+ * functionCall part (which is how the HTTP generateContent path carries it).
+ */
+const audioToolFixture: Fixture = {
+  match: { userMessage: "forecast" },
+  response: {
+    audio: { b64Json: "REVG", contentType: "audio/pcm;rate=24000" },
+    content: "Let me check.",
+    toolCalls: [{ name: "get_weather", arguments: '{"city":"Paris"}', id: "call_fixed_0" }],
+  },
+};
+
+const audioToolResultFixture: Fixture = {
+  match: { toolCallId: "call_fixed_0" },
+  response: { content: "Sunny." },
+};
+
+// Tool-result fixtures precede the fixtures whose turn produced them: the
+// router takes the FIRST match, and the user message that triggered the tool
+// call is still in the conversation on the follow-up turn.
+const allFixtures: Fixture[] = [
+  textFixture,
+  toolResultFixture,
+  audioToolResultFixture,
+  toolFixture,
+  errorFixture,
+  audioFixture,
+  audioToolFixture,
+];
 
 // --- helpers ---
 
@@ -1104,6 +1142,80 @@ describe("WebSocket Gemini Live BidiGenerateContent", () => {
     expect(msg.error.code).toBe(13); // gRPC INTERNAL
     expect(msg.error.message).toBe("Fixture response did not match any known type");
     expect(msg.error.status).toBe("INTERNAL");
+
+    ws.close();
+  });
+
+  it("streams an audio-only turn as one serverContent carrying inlineData and turnComplete", async () => {
+    instance = await createServer(allFixtures);
+    const ws = await connectWebSocket(instance.url, GEMINI_WS_PATH);
+
+    ws.send(setupMsg());
+    await ws.waitForMessages(1);
+    ws.send(clientContentMsg("sing"));
+
+    const raw = await ws.waitForMessages(2);
+    expect(JSON.parse(raw[1])).toEqual({
+      serverContent: {
+        modelTurn: { parts: [{ inlineData: { mimeType: "audio/pcm;rate=24000", data: "QUJD" } }] },
+        turnComplete: true,
+      },
+    });
+
+    ws.close();
+  });
+
+  it("streams an audio turn WITH companions as serverContent, then toolCall, then turnComplete", async () => {
+    // The companions used to be dropped: the handler emitted the audio and
+    // returned, so a recorded turn that spoke AND called a function replayed as
+    // audio alone. `toolCall` is a separate message here because the Live
+    // protocol unions it with `serverContent` — it is not a part.
+    instance = await createServer(allFixtures);
+    const ws = await connectWebSocket(instance.url, GEMINI_WS_PATH);
+
+    ws.send(setupMsg());
+    await ws.waitForMessages(1);
+    ws.send(clientContentMsg("forecast"));
+
+    const raw = await ws.waitForMessages(4);
+    expect(JSON.parse(raw[1])).toEqual({
+      serverContent: {
+        modelTurn: {
+          parts: [
+            { inlineData: { mimeType: "audio/pcm;rate=24000", data: "REVG" } },
+            { text: "Let me check." },
+          ],
+        },
+      },
+    });
+    expect(JSON.parse(raw[2])).toEqual({
+      toolCall: {
+        functionCalls: [{ name: "get_weather", args: { city: "Paris" }, id: "call_fixed_0" }],
+      },
+    });
+    expect(JSON.parse(raw[3])).toEqual({ serverContent: { turnComplete: true } });
+
+    ws.close();
+  });
+
+  it("carries the audio turn's companions into conversation history", async () => {
+    // The wire message is only half the fix: a dropped tool call also left the
+    // session unable to answer the client's toolResponse, because history held
+    // "[audio]" and no tool_calls at all. Answering the follow-up proves the
+    // emitted id and the recorded id are the same id.
+    instance = await createServer(allFixtures);
+    const ws = await connectWebSocket(instance.url, GEMINI_WS_PATH);
+
+    ws.send(setupMsg());
+    await ws.waitForMessages(1);
+    ws.send(clientContentMsg("forecast"));
+    await ws.waitForMessages(4);
+
+    ws.send(toolResponseMsg("get_weather", { temp: 20 }, "call_fixed_0"));
+
+    const raw = await ws.waitForMessages(6);
+    expect(JSON.parse(raw[4]).serverContent.modelTurn.parts[0].text).toBe("Sunny.");
+    expect(JSON.parse(raw[5])).toEqual({ serverContent: { turnComplete: true } });
 
     ws.close();
   });

--- a/src/__tests__/ws-gemini-live.test.ts
+++ b/src/__tests__/ws-gemini-live.test.ts
@@ -52,8 +52,26 @@ const audioToolFixture: Fixture = {
   },
 };
 
-const audioToolResultFixture: Fixture = {
-  match: { toolCallId: "call_fixed_0" },
+/**
+ * Answers the follow-up turn ONLY if the session recorded the audio turn's
+ * companions in its own conversation history.
+ *
+ * Matching on `toolCallId` would NOT do: that reads the id off the client's
+ * incoming toolResponse, so it matches whether or not the handler ever recorded
+ * the assistant turn — a guard that cannot fail. The predicate reads the
+ * ASSISTANT message the handler pushed, which is the thing under test.
+ */
+const audioHistoryFixture: Fixture = {
+  match: {
+    predicate: (req) => {
+      const assistant = req.messages.find((m) => m.role === "assistant");
+      return (
+        assistant?.content === "Let me check." &&
+        assistant?.tool_calls?.[0]?.id === "call_fixed_0" &&
+        assistant?.tool_calls?.[0]?.function.name === "get_weather"
+      );
+    },
+  },
   response: { content: "Sunny." },
 };
 
@@ -63,7 +81,7 @@ const audioToolResultFixture: Fixture = {
 const allFixtures: Fixture[] = [
   textFixture,
   toolResultFixture,
-  audioToolResultFixture,
+  audioHistoryFixture,
   toolFixture,
   errorFixture,
   audioFixture,
@@ -1200,9 +1218,10 @@ describe("WebSocket Gemini Live BidiGenerateContent", () => {
 
   it("carries the audio turn's companions into conversation history", async () => {
     // The wire message is only half the fix: a dropped tool call also left the
-    // session unable to answer the client's toolResponse, because history held
-    // "[audio]" and no tool_calls at all. Answering the follow-up proves the
-    // emitted id and the recorded id are the same id.
+    // session's history holding "[audio]" and no tool_calls at all. The
+    // follow-up fixture matches on that history (see `audioHistoryFixture`), so
+    // answering it proves the companions were recorded AND that the id on the
+    // wire is the id in history.
     instance = await createServer(allFixtures);
     const ws = await connectWebSocket(instance.url, GEMINI_WS_PATH);
 

--- a/src/agui-handler.ts
+++ b/src/agui-handler.ts
@@ -15,6 +15,7 @@ import type {
   AGUIRunStartedEvent,
   AGUIRunFinishedEvent,
   AGUIRunFinishedOutcome,
+  AGUITokenUsage,
   AGUIRunErrorEvent,
   AGUITextMessageStartEvent,
   AGUITextMessageContentEvent,
@@ -154,6 +155,13 @@ export interface AGUIBuildOpts {
   parentRunId?: string;
   /** For tool call builder: include a result event */
   result?: string;
+  /**
+   * Token usage to attach to the terminal RUN_FINISHED / RUN_ERROR event.
+   * Optional and never synthesized: aimock does not estimate token counts
+   * from fixture content, so `usage` is emitted only when a caller supplies
+   * it explicitly (same policy as the Bedrock/Cohere/Gemini usage overrides).
+   */
+  usage?: AGUITokenUsage[];
 }
 
 // ─── Event builders ──────────────────────────────────────────────────────────
@@ -169,7 +177,7 @@ function makeRunStarted(opts?: AGUIBuildOpts): AGUIRunStartedEvent {
 
 function makeRunFinished(
   started: AGUIRunStartedEvent,
-  finishOpts?: { outcome?: AGUIRunFinishedOutcome; result?: unknown },
+  finishOpts?: { outcome?: AGUIRunFinishedOutcome; result?: unknown; usage?: AGUITokenUsage[] },
 ): AGUIRunFinishedEvent {
   return {
     type: "RUN_FINISHED",
@@ -177,6 +185,7 @@ function makeRunFinished(
     runId: started.runId,
     ...(finishOpts?.result !== undefined ? { result: finishOpts.result } : {}),
     ...(finishOpts?.outcome !== undefined ? { outcome: finishOpts.outcome } : {}),
+    ...(finishOpts?.usage !== undefined ? { usage: finishOpts.usage } : {}),
   };
 }
 
@@ -203,7 +212,7 @@ export function buildTextResponse(text: string, opts?: AGUIBuildOpts): AGUIEvent
       type: "TEXT_MESSAGE_END",
       messageId,
     } as AGUITextMessageEndEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -221,7 +230,7 @@ export function buildTextChunkResponse(text: string, opts?: AGUIBuildOpts): AGUI
       role: "assistant",
       delta: text,
     } as AGUITextMessageChunkEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -264,7 +273,7 @@ export function buildToolCallResponse(
     } as AGUIToolCallResultEvent);
   }
 
-  events.push(makeRunFinished(started));
+  events.push(makeRunFinished(started, { usage: opts?.usage }));
   return events;
 }
 
@@ -280,7 +289,7 @@ export function buildStateUpdate(snapshot: unknown, opts?: AGUIBuildOpts): AGUIE
       type: "STATE_SNAPSHOT",
       snapshot,
     } as AGUIStateSnapshotEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -296,7 +305,7 @@ export function buildStateDelta(patches: unknown[], opts?: AGUIBuildOpts): AGUIE
       type: "STATE_DELTA",
       delta: patches,
     } as AGUIStateDeltaEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -312,7 +321,7 @@ export function buildMessagesSnapshot(messages: AGUIMessage[], opts?: AGUIBuildO
       type: "MESSAGES_SNAPSHOT",
       messages,
     } as AGUIMessagesSnapshotEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -348,7 +357,7 @@ export function buildReasoningResponse(text: string, opts?: AGUIBuildOpts): AGUI
       type: "REASONING_END",
       messageId,
     } as AGUIReasoningEndEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -372,7 +381,7 @@ export function buildActivityResponse(
       content,
       replace: true,
     } as AGUIActivitySnapshotEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -392,6 +401,7 @@ export function buildErrorResponse(
       type: "RUN_ERROR",
       message,
       ...(code !== undefined ? { code } : {}),
+      ...(opts?.usage !== undefined ? { usage: opts.usage } : {}),
     } as AGUIRunErrorEvent,
   ];
 }
@@ -432,7 +442,7 @@ export function buildStepWithText(
       type: "STEP_FINISHED",
       stepName,
     } as AGUIStepFinishedEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -457,7 +467,11 @@ export function buildCompositeResponse(
   }
 
   const hasError = inner.some((e) => e.type === "RUN_ERROR");
-  return [started, ...inner, ...(hasError ? [] : [makeRunFinished(started)])];
+  return [
+    started,
+    ...inner,
+    ...(hasError ? [] : [makeRunFinished(started, { usage: opts?.usage })]),
+  ];
 }
 
 // ─── Convenience event builders ─────────────────────────────────────────────
@@ -481,7 +495,7 @@ export function buildActivityDelta(
       activityType,
       patch,
     } as AGUIActivityDeltaEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -507,7 +521,7 @@ export function buildToolCallChunk(
       ...(opts?.parentMessageId !== undefined ? { parentMessageId: opts.parentMessageId } : {}),
       delta,
     } as AGUIToolCallChunkEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -524,7 +538,7 @@ export function buildRawEvent(event: unknown, source?: string, opts?: AGUIBuildO
       event,
       ...(source !== undefined ? { source } : {}),
     } as AGUIRawEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -541,7 +555,7 @@ export function buildCustomEvent(name: string, value: unknown, opts?: AGUIBuildO
       name,
       value,
     } as AGUICustomEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -561,7 +575,7 @@ export function buildReasoningChunk(
       ...(opts?.messageId !== undefined ? { messageId: opts.messageId } : {}),
       delta,
     } as AGUIReasoningMessageChunkEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 
@@ -584,7 +598,7 @@ export function buildReasoningEncryptedValue(
       entityId,
       encryptedValue,
     } as AGUIReasoningEncryptedValueEvent,
-    makeRunFinished(started),
+    makeRunFinished(started, { usage: opts?.usage }),
   ];
 }
 

--- a/src/agui-stub.ts
+++ b/src/agui-stub.ts
@@ -47,6 +47,7 @@ export type {
   AGUIInterrupt,
   AGUIResumeEntry,
   AGUIRunFinishedOutcome,
+  AGUITokenUsage,
   AGUIFixtureMatch,
   AGUIFixture,
   AGUIMockOptions,

--- a/src/agui-types.ts
+++ b/src/agui-types.ts
@@ -74,12 +74,14 @@ export interface AGUIRunFinishedEvent extends AGUIBaseEvent {
   runId: string;
   result?: unknown;
   outcome?: AGUIRunFinishedOutcome;
+  usage?: AGUITokenUsage[];
 }
 
 export interface AGUIRunErrorEvent extends AGUIBaseEvent {
   type: "RUN_ERROR";
   message: string;
   code?: string;
+  usage?: AGUITokenUsage[];
 }
 
 export interface AGUIStepStartedEvent extends AGUIBaseEvent {
@@ -341,6 +343,23 @@ export interface AGUIResumeEntry {
 export type AGUIRunFinishedOutcome =
   | { type: "success" }
   | { type: "interrupt"; interrupts: AGUIInterrupt[] };
+
+/**
+ * Numeric-only token usage summary, mirroring `TokenUsageSchema` in
+ * `@ag-ui/core`. Deliberately carries no content-bearing or identifying
+ * fields — only provider/model labels and non-negative integer token counts.
+ * Carried as an array on RUN_FINISHED / RUN_ERROR so a run that invokes
+ * multiple models keeps them separate.
+ */
+export interface AGUITokenUsage {
+  provider?: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+}
 
 // ─── Request types ───────────────────────────────────────────────────────────
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,6 +294,7 @@ export type {
   AGUIInterrupt,
   AGUIResumeEntry,
   AGUIRunFinishedOutcome,
+  AGUITokenUsage,
 } from "./agui-types.js";
 export type { AGUIBuildOpts } from "./agui-handler.js";
 export { matchesFixture as matchesAGUIFixture } from "./agui-handler.js";

--- a/src/ws-gemini-live.ts
+++ b/src/ws-gemini-live.ts
@@ -464,7 +464,33 @@ async function processMessage(
     return;
   }
 
-  // Audio response — single frame with inlineData and turnComplete: true
+  // Audio response — an AUDIO-modality model turn, plus the companion
+  // modalities `AudioResponse` documents (types.ts) as preserved alongside it.
+  //
+  // COMPANION PLACEMENT is protocol-specific, and the Live protocol does NOT
+  // place a tool call where the HTTP protocol does. On `generateContent` a
+  // functionCall is a PART, so gemini.ts's `buildGeminiAudioParts` appends it to
+  // the same `content.parts` array as the audio. On Live, `serverContent` and
+  // `toolCall` are alternatives of ONE union: `@google/genai`'s
+  // `LiveServerMessage` declares them as sibling optional fields and the
+  // BidiGenerateContent reference states the response's `messageType` union
+  // "can be only one of the following". A turn that both speaks and calls a
+  // function is therefore TWO messages, not one part list —
+  //
+  //   serverContent{modelTurn.parts} → toolCall{functionCalls} → serverContent{turnComplete}
+  //
+  // — which is also the order every other branch of this handler already emits
+  // and the order the live provider was observed to use (its tool turn sent a
+  // `serverContent` strictly before the `toolCall`).
+  //
+  // Emitting only the audio and returning — the previous behavior — silently
+  // discarded the tool call and the text content of a recorded audio turn, the
+  // exact loss types.ts's AudioResponse companions exist to prevent.
+  //
+  // NOT handled here: `AudioResponse.reasoning`. This handler has no thought
+  // channel in ANY branch (nothing in it emits `thought: true`), so replaying
+  // reasoning from the audio branch alone would invent a Live-wide capability
+  // out of one fixture field. That gap is real but separate.
   if (isAudioResponse(response)) {
     journal.add({
       method: "WS",
@@ -486,20 +512,62 @@ async function processMessage(
       data = audioResp.audio.b64Json;
     }
 
-    ws.send(
-      JSON.stringify({
-        serverContent: {
-          modelTurn: {
-            parts: [{ inlineData: { mimeType, data } }],
-          },
-          turnComplete: true,
-        },
-      }),
-    );
+    // Part order mirrors gemini.ts's `buildGeminiAudioParts`: audio first, then
+    // the text companion.
+    const parts: GeminiLivePart[] = [{ inlineData: { mimeType, data } }];
+    if (audioResp.content) {
+      parts.push({ text: audioResp.content });
+    }
+
+    // Stable IDs resolved once, so the wire message and conversation history
+    // agree (same contract as the tool-call branches below).
+    const resolvedToolCalls = (audioResp.toolCalls ?? []).map((tc) => ({
+      ...tc,
+      resolvedId: tc.id ?? generateToolCallId(),
+    }));
+
+    if (resolvedToolCalls.length === 0) {
+      ws.send(
+        JSON.stringify({
+          serverContent: { modelTurn: { parts }, turnComplete: true },
+        }),
+      );
+    } else {
+      ws.send(JSON.stringify({ serverContent: { modelTurn: { parts } } }));
+
+      if (!ws.isClosed) {
+        const functionCalls = resolvedToolCalls.map((tc) => {
+          let argsObj: Record<string, unknown>;
+          try {
+            argsObj = JSON.parse(tc.arguments || "{}") as Record<string, unknown>;
+          } catch {
+            defaults.logger.warn(
+              `Malformed JSON in fixture tool call arguments for "${tc.name}": ${tc.arguments}`,
+            );
+            argsObj = {};
+          }
+          return { name: tc.name, args: argsObj, id: tc.resolvedId };
+        });
+        ws.send(JSON.stringify({ toolCall: { functionCalls } }));
+      }
+
+      if (!ws.isClosed) {
+        ws.send(JSON.stringify({ serverContent: { turnComplete: true } }));
+      }
+    }
 
     session.conversationHistory.push({
       role: "assistant",
-      content: "[audio]",
+      content: audioResp.content ?? "[audio]",
+      ...(resolvedToolCalls.length > 0
+        ? {
+            tool_calls: resolvedToolCalls.map((tc) => ({
+              id: tc.resolvedId,
+              type: "function" as const,
+              function: { name: tc.name, arguments: tc.arguments },
+            })),
+          }
+        : {}),
     });
     return;
   }


### PR DESCRIPTION
`Fix Drift` failed 2026-08-14 and 2026-08-15 with `reason=needs-human`: Google shipped model families aimock had never seen. That is the workflow working — an unclassified family is the one case that is supposed to reach a human.

This classifies them, and corrects the instructions the bot gives for doing so, which described a procedure that cannot work.

## The classification

Decided from the live `GET /v1beta/models` listing (54 entries) on **declared capabilities**, not on substrings of the model name. That distinction matters here: a recent defect selected Live-capable models with `!name.includes("native-audio")`, which silently misclassified a native-audio model as text-capable and produced four days of unexplained failures.

**`gemini-3.7-flash` → include.** `supportedGenerationMethods` is `[generateContent, countTokens, createCachedContent, batchGenerateContent]`, byte-identical to the already-included `gemini-3.6-flash`, `gemini-3.5-flash` and `gemini-2.5-pro`. No `bidiGenerateContent`, no `embedContent`, no `predict`. It is the next release in a flash line already mocked at 3.5 and 3.6.

**`gemini-3.7-flash-video-understanding-eap` → exclude.** It is genuinely text-capable, so it is not rejected on capability. It is the sole entry of the 54 whose declared `displayName` *and* `description` are marked `[Confidential] … EAP` — gated pre-GA access. That is the same policy `PREVIEW_FAMILY` applies to `-preview` suffixes, but this name carries no such suffix, so it has to be enumerated explicitly.

Both notes are resolved, both checksum pins re-frozen, and the offline `/models` wave updated. A live re-run afterwards reports zero unclassified gemini families.

## The instructions were wrong

The bot's needs-human PR body told humans to set `Decision: include` and merge, promising that the next drift-sync run would read the approved note and apply the registry edit — "that two-run hand-off is how the loop closes."

**That path cannot work.** `includeFamilies` is checksum-pinned; adding a family moves the pin (`c2e2c56b` → `566fb89a`) and reds the freeze test that gate-2 re-runs. Gate-1's allowlist permits drift-sync to touch only `model-registry.ts` and `drift-proposals/`, so it cannot re-pin. A follow-up run reports `gate-failed`, not `ok-applied`.

No commit in this repo's history carries drift-sync's `approved via drift-proposals` marker. Every classification has landed by hand — `72f85f8`, `936b59c`, and now this one. The documented path has never been exercised.

The PR body and the step's rationale comment now state the procedure that actually applies a family: one commit adding to `includeFamilies` (or `excludeFamilies` to reject), re-pinning **both** checksums, resolving the note, and updating the offline `/models` wave — with those two prior commits named as worked examples.

## A test was holding the false claim in place

`fix-drift-workflow.test.ts` asserted the PR body must contain `Decision: include`, pinning the instruction that fails its own gate. It now pins the corrected procedure instead, and keeps the non-auto-merge assertion, which is true and load-bearing.

The new assertion is mutation-proven: restoring the old `Decision: include` text reds it, and restoring the correction greens it again. The false instruction cannot come back silently.

## Verification

Full suite 5288 passing across 177 files, `test:drift` clean, build, lint, `format:check`, `actionlint` and commitlint all clean. Tests-inclusive typecheck at the 115 baseline — re-measured empirically on `origin/main` with the same standalone config rather than assumed — with zero errors in the added lines and the harness mutation-tested. The pin-freeze assertion is itself mutation-tested against a bogus family.

Version-neutral: `package.json`, `CHANGELOG.md`, `charts/**` and `.claude-plugin/**` untouched; still 1.38.0.

## Unproven

That the next scheduled run goes quiet. It is inferred from a local live re-run showing no unclassified gemini families, not observed in CI.

Separately and not addressed here: the Gemini Live drift legs still observe zero messages within 30s even on a modality the model accepts. The collector reports that correctly as a silent surface rather than as drift or a fault, so it does not fail the cron — but that surface is not being graded.


## Also folded in: the WS reader was deaf to two opcodes

While diagnosing why the Gemini Live legs observe zero messages, the probe's TLS client turned out to handle only opcodes `0x1` (text), `0x8` (close) and `0x9` (ping). **Binary (`0x2`) and continuation (`0x0`) frames were consumed and silently dropped, and the FIN bit was never read**, so a fragmented message emitted only a truncated head — observed as `bodies=["{\"setup"]`.

That produces output byte-identical to the live symptom. Whether Gemini Live actually frames binary is **unproven here** — there are no Google credentials in this environment — but `@google/genai` decodes inbound `Blob`/`ArrayBuffer` and Google's own sample reads with `recv(decode=False)`, so it is a live candidate rather than a theoretical one.

The reader now decodes binary and reassembles fragments, and counts frames it does not handle rather than discarding them.

### The next live run is now decisive

Every timeout and close carries `step=`, `model=`, and a per-opcode frame tally. From `drift-report.json` `timeouts[].message`:

- `step=setupComplete` → the session was never established.
- `step=turn` → it was established and the turn came back empty; suspect the text-turn shape or the model choice, since selection still takes the *first* model declaring `bidiGenerateContent`, which is coarser than "conversational Live".
- any nonzero `binary=` or `unhandled=` → it was our deafness all along.
- an all-zero tally → the surface is genuinely mute.

`model=` names the resolved model in every case.

11 tests red before the fix, 27 green after. 11 mutations, all red — including dropping binary, ignoring FIN, dropping continuation, misclassifying ping, and collapsing the two step labels.

### Why the silence itself is still unproven

The old cursor was per-call, so a stall waiting for `setupComplete` and a stall on an empty turn produced *identical* text. That is why four days of artifacts could not distinguish them, and why this change adds the discriminator rather than guessing which one it was.

One candidate is weakened: Google is demonstrably loud about a bad setup — the observed `1007` modality refusal and a `1008` `Requested model is not supported for BidiGenerateContent` — rather than mute.

## Correction to this PR's own earlier claim

An earlier version of this description said the 2026-08-14 and 08-15 `Drift Tests` failures were the Live silence. They were not. Both failed on **exit 2, critical drift**: 08-14 on the unclassified `gemini-3.7-flash`; 08-15 on four criticals — the two Gemini families plus AG-UI `RUN_FINISHED.usage` and `RUN_ERROR.usage` missing from aimock. The Live silence was a non-fatal warning in both, and in the passing 08-13 run as well.

That AG-UI schema drift is real, unrelated to Gemini, and **not fixed here**.


## Also folded in: the two drift findings the frame fix exposed

Reading binary frames turned the Gemini Live legs from `timeouts=2` to `timeouts=0`. The surface was never mute — the client was deaf. With it audible, the probe immediately reported real drift, and the AG-UI leg was already reporting its own.

### `Gemini Live SSE:serverContent` — tool turns only

aimock emits `serverContent` in every branch of the Live handler. The gap was narrower than the report's `mock: <absent>` suggests: it could not emit `serverContent` during a **tool** turn.

`serverContent` is not the wrapper a tool call sits inside. `@google/genai@1.50.1` declares `serverContent` and `toolCall` as sibling fields of `LiveServerMessage`, and the API's response `messageType` union "can be only one of the following" — so a speaking-and-calling turn is two messages, not one nested. The ordering is taken from the artifact rather than assumed: the probe collects up to and including the first `toolCall`, the real leg's `toolCallCount > 0` assertion passed, and a `serverContent` was among what it collected, so the real API sent `serverContent` strictly before `toolCall`.

The audio branch now emits `serverContent{modelTurn.parts}` → `toolCall` → `serverContent{turnComplete}`, keeps the `content` companion, and records both in history with stable ids. An audio-only turn is byte-identical to before. `reasoning` is deliberately not emitted — this handler has no thought channel in any branch.

This subsumes half of the previously-reported `ws-gemini-live.ts:468-505` defect: that code made the correct fixture inexpressible, so the leg fell back to a text-shaped tool-only fixture and the mock answered with a bare `toolCall`. Fixing either alone does not clear the drift.

### AG-UI `RUN_FINISHED.usage` / `RUN_ERROR.usage`

Canonical is `usage: z.array(TokenUsageSchema).optional()`, where `TokenUsage` carries all-optional `provider`, `model`, `inputTokens`, `outputTokens`, `totalTokens`, `reasoningTokens`, `cachedInputTokens`.

Added as types **and** emission — threaded through every builder's terminal `RUN_FINISHED` and through `RUN_ERROR`, never synthesized, matching the repo's existing bedrock/cohere/gemini usage policy. A type declaring a field the server never populates would satisfy the schema check and still be wrong for users.

**The `outcome` optionality warning is deliberately not "fixed".** Canonical is `.nullable().optional()` — genuinely optional. The mismatch is an artifact of the harness's field regex being line-scoped, so a multi-line definition loses its `.optional()`; the same artifact produces the `parentMessageId` warnings. Aligning would contradict canonical and break every construction site.

## Verification

Full suite 5314 passing across 178 files; `test:drift`, build, lint, `format:check`, `actionlint` and commitlint all clean. Tests-inclusive typecheck at 115 on both base and head, error sets diff-identical, zero `TS2688`, zero errors in every touched file, harness mutation-tested in both a source and a test file.

Mutation coverage on the new work: 12 on the Live tool turn, 4 on AG-UI emission, 11 on the frame reader, plus the corrected-instruction guard. Two guards were found unfailable during the work and repaired rather than kept — one matched the client's incoming id instead of the recorded assistant turn; the other pinned the old instruction text.

## Known and not fixed

Two defects in the drift harness itself, both found while doing this:

`ensureAgUiRepo()` clones the canonical AG-UI repo only when `../ag-ui` is **absent**, and never freshens it. A stale local clone therefore produces a **false green** — the schema comparison passes because its own reference is out of date. This was live: the local clone predated the `usage` field entirely.

The field-extraction regex is line-scoped, so any multi-line canonical definition loses trailing modifiers like `.optional()`, manufacturing optionality warnings that are not real drift.

Unproven and live-only: the exact field set Google puts in that leading `serverContent` — AUDIO is the session's only modality, so audio parts are reproduced, but only a live run confirms Google's payload. Google's documentation does not state the tool-turn sequence; the Live reference, capabilities and tools guides were all checked.
