### PR TITLE
fix: collapse OpenAI Responses-API function-call streams into toolCalls

### DIFF
--- a/src/__tests__/stream-collapse.test.ts
+++ b/src/__tests__/stream-collapse.test.ts
@@ -1773,6 +1773,158 @@ describe("collapseOpenAISSE with reasoning", () => {
   });
 });
 
+describe("collapseOpenAISSE Responses API function calls", () => {
+  it("collapses a tool-call-only Responses stream into toolCalls (not empty content)", () => {
+    // The exact event sequence the OpenAI Responses API (and aimock's own
+    // replay path) emits for a function call: output_item.added(function_call)
+    // → function_call_arguments.delta* → function_call_arguments.done →
+    // output_item.done(function_call). Before the fix, all of these were
+    // dropped by the `response.*` catch-all, yielding empty content and no
+    // toolCalls.
+    const body = [
+      `data: ${JSON.stringify({ type: "response.created", response: {} })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_123",
+          call_id: "call_abc",
+          name: "get_weather",
+          arguments: "",
+          status: "in_progress",
+        },
+      })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: "response.function_call_arguments.delta",
+        item_id: "fc_123",
+        output_index: 0,
+        delta: '{"ci',
+      })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: "response.function_call_arguments.delta",
+        item_id: "fc_123",
+        output_index: 0,
+        delta: 'ty":"Paris"}',
+      })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: "response.function_call_arguments.done",
+        item_id: "fc_123",
+        output_index: 0,
+        arguments: '{"city":"Paris"}',
+      })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_123",
+          call_id: "call_abc",
+          name: "get_weather",
+          arguments: '{"city":"Paris"}',
+          status: "completed",
+        },
+      })}`,
+      "",
+      `data: ${JSON.stringify({ type: "response.completed", response: {} })}`,
+      "",
+    ].join("\n");
+
+    const result = collapseOpenAISSE(body);
+    expect(result.toolCalls).toBeDefined();
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].name).toBe("get_weather");
+    expect(result.toolCalls![0].arguments).toBe('{"city":"Paris"}');
+    expect(JSON.parse(result.toolCalls![0].arguments)).toEqual({ city: "Paris" });
+    // The tool-call id is the Responses API `call_id` (what a tool result
+    // references), not the internal `fc_…` item id.
+    expect(result.toolCalls![0].id).toBe("call_abc");
+    expect(result.content).toBeUndefined();
+  });
+
+  it("collapses multiple Responses function calls keyed by output_index", () => {
+    const body = [
+      `data: ${JSON.stringify({
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_0",
+          call_id: "call_0",
+          name: "lookup",
+          arguments: "",
+        },
+      })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: "response.function_call_arguments.delta",
+        item_id: "fc_0",
+        output_index: 0,
+        delta: '{"q":"a"}',
+      })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: "response.output_item.added",
+        output_index: 1,
+        item: {
+          type: "function_call",
+          id: "fc_1",
+          call_id: "call_1",
+          name: "search",
+          arguments: "",
+        },
+      })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: "response.function_call_arguments.delta",
+        item_id: "fc_1",
+        output_index: 1,
+        delta: '{"q":"b"}',
+      })}`,
+      "",
+      `data: ${JSON.stringify({
+        type: "response.function_call_arguments.done",
+        item_id: "fc_1",
+        output_index: 1,
+        arguments: '{"q":"b"}',
+      })}`,
+      "",
+    ].join("\n");
+
+    const result = collapseOpenAISSE(body);
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls![0]).toMatchObject({
+      name: "lookup",
+      arguments: '{"q":"a"}',
+      id: "call_0",
+    });
+    expect(result.toolCalls![1]).toMatchObject({
+      name: "search",
+      arguments: '{"q":"b"}',
+      id: "call_1",
+    });
+    expect(result.content).toBeUndefined();
+  });
+
+  it("does not regress: Responses text-only stream still collapses to content", () => {
+    const body = [
+      `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Hello" })}`,
+      "",
+      `data: ${JSON.stringify({ type: "response.completed", response: {} })}`,
+      "",
+    ].join("\n");
+
+    const result = collapseOpenAISSE(body);
+    expect(result.content).toBe("Hello");
+    expect(result.toolCalls).toBeUndefined();
+  });
+});
+
 describe("collapseAnthropicSSE with thinking", () => {
   it("extracts reasoning from thinking_delta events", () => {
     const body = [

--- a/src/stream-collapse.ts
+++ b/src/stream-collapse.ts
@@ -442,7 +442,7 @@ export function collapseOpenAISSE(rawBody: string): CollapseResult {
       continue;
     }
 
-    // Responses API web search events
+    // Responses API web search + function-call completion events
     if (parsed.type === "response.output_item.done") {
       const item = parsed.item as Record<string, unknown> | undefined;
       if (item?.type === "web_search_call") {
@@ -452,6 +452,90 @@ export function collapseOpenAISSE(rawBody: string): CollapseResult {
           continue;
         }
       }
+      if (item?.type === "function_call" && typeof parsed.output_index === "number") {
+        // Finalize the accumulated tool call. Fill id/name when the opening
+        // `.added` event was absent, and adopt the full `arguments` ONLY when
+        // the delta stream produced none — never re-append, since the deltas
+        // already carry the complete string.
+        const entry = toolCallMap.get(parsed.output_index);
+        if (entry) {
+          if (!entry.id && typeof item.call_id === "string") entry.id = item.call_id;
+          if (!entry.name && typeof item.name === "string") entry.name = item.name;
+          if (entry.arguments === "" && typeof item.arguments === "string") {
+            entry.arguments = item.arguments;
+          }
+        } else {
+          const created = {
+            id: typeof item.call_id === "string" ? item.call_id : "",
+            name: typeof item.name === "string" ? item.name : "",
+            arguments: typeof item.arguments === "string" ? item.arguments : "",
+          };
+          toolCallMap.set(parsed.output_index, created);
+          orderAtoms.push({ kind: "toolCall", ref: created });
+        }
+        continue;
+      }
+    }
+
+    // Responses API function-call streaming events. A tool call arrives as
+    // `response.output_item.added` (a `function_call` item) → one or more
+    // `response.function_call_arguments.delta` → `response.function_call_arguments.done`
+    // (plus the closing `response.output_item.done` handled above). Mirror the
+    // Chat-Completions tool-call accumulation below so a tool-call-only turn
+    // collapses to `toolCalls` instead of being silently dropped by the
+    // `response.*` catch-all. Key by `output_index` (present on every one of
+    // these events); its integer space is disjoint from the Chat-Completions
+    // `tool_calls[].index` space because a single stream is never both shapes.
+    if (parsed.type === "response.output_item.added") {
+      const item = parsed.item as Record<string, unknown> | undefined;
+      if (item?.type === "function_call" && typeof parsed.output_index === "number") {
+        if (!toolCallMap.has(parsed.output_index)) {
+          const created = {
+            // The Responses API `call_id` is what a tool result references, so
+            // capture THAT (not the internal `fc_…` item id) as the tool-call
+            // id — matching what the replay path treats as `toolCall.id`.
+            id: typeof item.call_id === "string" ? item.call_id : "",
+            name: typeof item.name === "string" ? item.name : "",
+            arguments: "",
+          };
+          toolCallMap.set(parsed.output_index, created);
+          orderAtoms.push({ kind: "toolCall", ref: created });
+        }
+        continue;
+      }
+    }
+    if (
+      parsed.type === "response.function_call_arguments.delta" &&
+      typeof parsed.delta === "string" &&
+      typeof parsed.output_index === "number"
+    ) {
+      let entry = toolCallMap.get(parsed.output_index);
+      if (!entry) {
+        entry = { id: "", name: "", arguments: "" };
+        toolCallMap.set(parsed.output_index, entry);
+        orderAtoms.push({ kind: "toolCall", ref: entry });
+      }
+      entry.arguments += parsed.delta;
+      continue;
+    }
+    if (
+      parsed.type === "response.function_call_arguments.done" &&
+      typeof parsed.output_index === "number"
+    ) {
+      // The `.done` event repeats the fully-assembled `arguments`; adopt it only
+      // when the deltas produced nothing (a delta-less stream) so we never
+      // double-append.
+      const entry = toolCallMap.get(parsed.output_index);
+      if (entry) {
+        if (entry.arguments === "" && typeof parsed.arguments === "string") {
+          entry.arguments = parsed.arguments;
+        }
+      } else if (typeof parsed.arguments === "string") {
+        const created = { id: "", name: "", arguments: parsed.arguments };
+        toolCallMap.set(parsed.output_index, created);
+        orderAtoms.push({ kind: "toolCall", ref: created });
+      }
+      continue;
     }
 
     // Responses API text content events


### PR DESCRIPTION
## Problem

`collapseOpenAISSE()` handles OpenAI **Responses API** text deltas, reasoning, and web-search output items, then a catch-all (`if (parsed.type?.startsWith("response.")) continue;`) silently skips **every other** `response.*` event — including the entire function-call sequence (`response.output_item.added` with a `function_call` item, `response.function_call_arguments.delta`/`.done`, and `response.output_item.done` for a `function_call`). Recording a tool-call-only turn therefore collapses to empty `content` with no `toolCalls` (logged: `Stream collapse produced empty content — fixture may be incomplete`), and replaying that fixture yields an empty assistant turn / no tool invocation.

The older **Chat-Completions** path already handles tool calls (`choices[0].delta.tool_calls`), which is why pre-existing fixtures work and only fresh Responses-API recordings break.

This surfaced downstream: the CopilotKit 1.68.1 showcase deploy shifted integrations onto the Responses-API tool-call shape, and any attempt to re-record D4 chat-smoke fixtures produced empty fixtures → whole-column "empty assistant response" flap across staging integrations.

## Fix

Add a Responses-API function-call handler in `collapseOpenAISSE` (before the `response.*` catch-all), mirroring the Chat-Completions accumulation:
- `response.output_item.added` (`item.type === "function_call"`) → start a tool-call accumulator keyed by `output_index`, capturing `call_id` as the tool-call `id` (the id a tool result references, **not** the internal `fc_…` item id) and `name`.
- `response.function_call_arguments.delta` → append `delta` to `arguments` (get-or-create, robust to delta-before-added).
- `response.function_call_arguments.done` → adopt full args only if deltas produced none.
- `response.output_item.done` (function_call) → finalize (fill id/name if `.added` was missed; adopt args only if empty).

Reuses the existing `toolCallMap` + `orderAtoms` and the existing emit path, so output is `{ id, name, arguments }` (arguments normalized to valid JSON) — identical to the Chat-Completions shape and the checked-in fixtures. `output_index` keyspace is disjoint from Chat-Completions `tool_calls[].index` (a stream is never both shapes).

## Proof — local red→green (unit)

New `describe("collapseOpenAISSE Responses API function calls")` in `src/__tests__/stream-collapse.test.ts` feeds a synthetic Responses-API function-call SSE (single tool, multiple tools keyed by `output_index`, and a text-only no-regression case) using the exact wire shape aimock emits.

- **RED** (src reverted to `origin/main`, new tests present): the two tool-call tests fail — `result.toolCalls` undefined. `2 failed | 1 passed`.
- **GREEN** (fix applied): `3 passed`.

## Proof — live record → replay (independent, real OpenAI)

Validated independently by @Mark against a real OpenAI key, aimock image built from this exact commit, on the built-in-agent D4 weather flow:

- **Record** (`--record`, `Loaded 0 fixture(s)`): D4 L3 greeting green, L4 "What's the weather in San Francisco?" green. Journal held exactly 3 correlated 200s (greeting, tool-call turn, post-tool-result turn). The initial weather fixture now contains real `toolCalls` (no empty-content fallback):
  ```json
  { "toolCalls": [ { "name": "get_weather", "arguments": "{\"location\":\"San Francisco\"}", "id": "call_WTiZY5LQCFpwqkbDm6CdMGhN" } ] }
  ```
  The post-tool-result entry had `turnIndex: 1`, `hasToolResult: true`, and a non-empty final assistant response.
- **Fresh replay** (new process, no `--record`/`--proxy-only`, `Loaded 3 fixture(s)`): D4 L3+L4 green; replay journal shows the full tool chain; DOM assertions verified the weather card, tool result values (`68`, `55%`, `10 mph`), and the final assistant text in `[data-testid="copilot-assistant-message"]`.

## Checks

- `stream-collapse.test.ts`: 205 passed.
- Full suite: 5,271 passed / 46 skipped / 0 failed.
- `pnpm build`, `pnpm format:check`, `pnpm lint`: all clean.

## Scope / follow-up

This PR fixes the **stream collapser only**. It does **not** address the fixture-capture race (a post-tool-result turn can still be draining after the probe exits, landing a fixture in the next run's dir). That belongs in a separate PR that makes the capture workflow wait for the request journal to drain before moving fixtures / restarting aimock. Per @Mark's live findings, a replay drain barrier should key on `response.status === 200 && response.fixture != null` (on ordinary replay `response.source` is left unset; record-mode upstream completion is `response.source === "proxy"`).

**D4 fixture re-recording stays paused** until that capture-workflow barrier lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5dSyNeU6xH9ofPf9ZLaNQ
