### PR TITLE
chore(release): bump remaining aimock refs to 1.39.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "npm",
         "package": "@copilotkit/aimock",
-        "version": "^1.38.0"
+        "version": "^1.39.0"
       },
       "description": "Fixture authoring skill for @copilotkit/aimock — LLM, multimedia (image/TTS/transcription/video), MCP, A2A, AG-UI, vector, embeddings, structured output, sequential responses, streaming physics, record/replay, agent loop patterns, and debugging"
     }

--- a/packages/aimock-pytest/README.md
+++ b/packages/aimock-pytest/README.md
@@ -80,7 +80,7 @@ aimock.reset_fixtures()    # alias for reset() — a full reset, despite the nam
 
 ```
 --aimock-node PATH       Path to node binary
---aimock-version VER     aimock npm version (default: 1.38.0)
+--aimock-version VER     aimock npm version (default: 1.39.0)
 --aimock-api-key KEY     Inbound API key for the aimock child process
 ```
 

--- a/packages/aimock-pytest/src/aimock_pytest/_version.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_version.py
@@ -11,4 +11,4 @@ npm publication and verifies that this pin exists before it builds or uploads
 a wheel. Keep it tracking npm releases.
 """
 
-AIMOCK_VERSION = "1.38.0"
+AIMOCK_VERSION = "1.39.0"


### PR DESCRIPTION
Follow-up sweep to #383 (v1.39.0 release), which bumped package.json, CHANGELOG.md, Chart.yaml appVersion, and .claude-plugin/plugin.json but missed three version references. This bumps the remaining ones from 1.38.0 to 1.39.0:

- `.claude-plugin/marketplace.json` — aimock npm version constraint `^1.38.0` → `^1.39.0`
- `packages/aimock-pytest/src/aimock_pytest/_version.py` — `AIMOCK_VERSION` (default aimock server version the pytest client downloads/runs) `1.38.0` → `1.39.0`
- `packages/aimock-pytest/README.md` — CLI-options default-version text `1.38.0` → `1.39.0`

No source changes. The pytest package's own version (pyproject.toml) is intentionally untouched. Remaining `1.38.0` references in CHANGELOG.md are historical release-notes entries and are intentionally left as-is.