### PR TITLE
chore(release): aimock-pytest v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `aimock-pytest` 0.5.3 now defaults to `@copilotkit/aimock` 1.39.0.
+
 ## [1.39.0] - 2026-08-18
 
 ### Added

--- a/packages/aimock-pytest/pyproject.toml
+++ b/packages/aimock-pytest/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aimock-pytest"
-version = "0.5.2"
+version = "0.5.3"
 description = "pytest fixtures for aimock — mock LLM APIs, multimedia, MCP, A2A, AG-UI, vector DBs, and more"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps the `aimock-pytest` Python package from 0.5.2 to 0.5.3. This is the Python package's own version series and is unrelated to the `@copilotkit/aimock` npm server version (1.39.0).

## Changes
- `packages/aimock-pytest/pyproject.toml`: `[project]` version 0.5.2 to 0.5.3 (dependencies and the `AIMOCK_VERSION` pin untouched).
- `CHANGELOG.md` (root, where prior 0.5.x aimock-pytest notes live): adds a `### Changed` note under `[Unreleased]` — `aimock-pytest` 0.5.3 now defaults to `@copilotkit/aimock` 1.39.0.

## Ordering
The "defaults to 1.39.0" claim already holds on `main`: `_version.py` pins `AIMOCK_VERSION = "1.39.0"` (from #384, merged). No ordering dependency.