### PR TITLE
fix(agui): mirror the canonical subagent lifecycle events and subagentRunId

### DIFF
--- a/src/__tests__/drift/agui-schema.drift.ts
+++ b/src/__tests__/drift/agui-schema.drift.ts
@@ -129,8 +129,14 @@ function splitTopLevelEntries(body: string): string[] {
  * Extract field definitions from a Zod `.extend({...})` block body.
  */
 function extractExtendFields(extendBody: string, aliases: SchemaAliases): FieldInfo[] {
-  // Strip comment lines so they don't match as field definitions
-  const cleanBody = extendBody.replace(/^\s*\/\/.*$/gm, "");
+  // Strip comments so they don't match as field definitions. Trailing comments
+  // must go too, not just whole-line ones: `delta: z.array(z.any()), // JSON
+  // Patch (RFC 6902)` splits on its top-level comma, and the comment then
+  // leads the NEXT entry, so the field-name match fails and that field is
+  // dropped silently. That is how canonical STATE_DELTA.subagentRunId read as
+  // absent. Safe to strip unconditionally here: no canonical schema literal
+  // contains `//`.
+  const cleanBody = extendBody.replace(/\/\/[^\n]*/g, "");
   const fields: FieldInfo[] = [];
   for (const entry of splitTopLevelEntries(cleanBody)) {
     const fieldMatch = entry.match(/^\s*(\w+)\s*:\s*([\s\S]+)$/);
@@ -592,6 +598,20 @@ describe("canonical field optionality", () => {
     const fields = extractExtendFields('  role: z.enum(["user", "assistant"]),', new Map());
 
     expect(fields.map((f) => f.name)).toEqual(["role"]);
+  });
+
+  it("reads a field that follows a trailing comment", () => {
+    // Upstream's STATE_DELTA. The comment trails the previous field, so after
+    // the top-level comma split it heads the `subagentRunId` entry and hid the
+    // field entirely — reported as aimock-only rather than canonical.
+    const body = [
+      "  delta: z.array(z.any()), // JSON Patch (RFC 6902)",
+      "  subagentRunId: z.string().optional(),",
+    ].join("\n");
+    const fields = extractExtendFields(body, new Map());
+
+    expect(fields.map((f) => f.name)).toEqual(["delta", "subagentRunId"]);
+    expect(fields.find((f) => f.name === "subagentRunId")!.optional).toBe(true);
   });
 
   it("still reads inline optionality with no aliases in play", () => {

--- a/src/agui-types.ts
+++ b/src/agui-types.ts
@@ -38,6 +38,10 @@ export type AGUIEventType =
   | "REASONING_MESSAGE_CHUNK"
   | "REASONING_END"
   | "REASONING_ENCRYPTED_VALUE"
+  // Subagents
+  | "SUBAGENT_STARTED"
+  | "SUBAGENT_FINISHED"
+  | "SUBAGENT_ERROR"
   // Special
   | "RAW"
   | "CUSTOM"
@@ -90,11 +94,13 @@ export interface AGUIRunErrorEvent extends AGUIBaseEvent {
 export interface AGUIStepStartedEvent extends AGUIBaseEvent {
   type: "STEP_STARTED";
   stepName: string;
+  subagentRunId?: string;
 }
 
 export interface AGUIStepFinishedEvent extends AGUIBaseEvent {
   type: "STEP_FINISHED";
   stepName: string;
+  subagentRunId?: string;
 }
 
 // Text messages
@@ -115,17 +121,20 @@ export interface AGUITextMessageStartEvent extends AGUIBaseEvent {
   messageId: string;
   role: AGUITextMessageRole;
   name?: string;
+  subagentRunId?: string;
 }
 
 export interface AGUITextMessageContentEvent extends AGUIBaseEvent {
   type: "TEXT_MESSAGE_CONTENT";
   messageId: string;
   delta: string;
+  subagentRunId?: string;
 }
 
 export interface AGUITextMessageEndEvent extends AGUIBaseEvent {
   type: "TEXT_MESSAGE_END";
   messageId: string;
+  subagentRunId?: string;
 }
 
 export interface AGUITextMessageChunkEvent extends AGUIBaseEvent {
@@ -134,6 +143,7 @@ export interface AGUITextMessageChunkEvent extends AGUIBaseEvent {
   role?: AGUITextMessageRole;
   delta?: string;
   name?: string;
+  subagentRunId?: string;
 }
 
 // Tool calls
@@ -143,17 +153,20 @@ export interface AGUIToolCallStartEvent extends AGUIBaseEvent {
   toolCallId: string;
   toolCallName: string;
   parentMessageId?: string;
+  subagentRunId?: string;
 }
 
 export interface AGUIToolCallArgsEvent extends AGUIBaseEvent {
   type: "TOOL_CALL_ARGS";
   toolCallId: string;
   delta: string;
+  subagentRunId?: string;
 }
 
 export interface AGUIToolCallEndEvent extends AGUIBaseEvent {
   type: "TOOL_CALL_END";
   toolCallId: string;
+  subagentRunId?: string;
 }
 
 export interface AGUIToolCallChunkEvent extends AGUIBaseEvent {
@@ -162,6 +175,7 @@ export interface AGUIToolCallChunkEvent extends AGUIBaseEvent {
   toolCallName?: string;
   parentMessageId?: string;
   delta?: string;
+  subagentRunId?: string;
 }
 
 export interface AGUIToolCallResultEvent extends AGUIBaseEvent {
@@ -170,6 +184,7 @@ export interface AGUIToolCallResultEvent extends AGUIBaseEvent {
   toolCallId: string;
   content: string;
   role?: "tool";
+  subagentRunId?: string;
 }
 
 // State
@@ -177,11 +192,13 @@ export interface AGUIToolCallResultEvent extends AGUIBaseEvent {
 export interface AGUIStateSnapshotEvent extends AGUIBaseEvent {
   type: "STATE_SNAPSHOT";
   snapshot: unknown;
+  subagentRunId?: string;
 }
 
 export interface AGUIStateDeltaEvent extends AGUIBaseEvent {
   type: "STATE_DELTA";
   delta: unknown[]; // JSON Patch (RFC 6902)
+  subagentRunId?: string;
 }
 
 export interface AGUIMessagesSnapshotEvent extends AGUIBaseEvent {
@@ -197,6 +214,7 @@ export interface AGUIActivitySnapshotEvent extends AGUIBaseEvent {
   activityType: string;
   content: Record<string, unknown>;
   replace?: boolean;
+  subagentRunId?: string;
 }
 
 export interface AGUIActivityDeltaEvent extends AGUIBaseEvent {
@@ -204,6 +222,7 @@ export interface AGUIActivityDeltaEvent extends AGUIBaseEvent {
   messageId: string;
   activityType: string;
   patch: unknown[];
+  subagentRunId?: string;
 }
 
 // Reasoning
@@ -211,34 +230,40 @@ export interface AGUIActivityDeltaEvent extends AGUIBaseEvent {
 export interface AGUIReasoningStartEvent extends AGUIBaseEvent {
   type: "REASONING_START";
   messageId: string;
+  subagentRunId?: string;
 }
 
 export interface AGUIReasoningMessageStartEvent extends AGUIBaseEvent {
   type: "REASONING_MESSAGE_START";
   messageId: string;
   role: "reasoning";
+  subagentRunId?: string;
 }
 
 export interface AGUIReasoningMessageContentEvent extends AGUIBaseEvent {
   type: "REASONING_MESSAGE_CONTENT";
   messageId: string;
   delta: string;
+  subagentRunId?: string;
 }
 
 export interface AGUIReasoningMessageEndEvent extends AGUIBaseEvent {
   type: "REASONING_MESSAGE_END";
   messageId: string;
+  subagentRunId?: string;
 }
 
 export interface AGUIReasoningMessageChunkEvent extends AGUIBaseEvent {
   type: "REASONING_MESSAGE_CHUNK";
   messageId?: string;
   delta?: string;
+  subagentRunId?: string;
 }
 
 export interface AGUIReasoningEndEvent extends AGUIBaseEvent {
   type: "REASONING_END";
   messageId: string;
+  subagentRunId?: string;
 }
 
 export type AGUIReasoningEncryptedValueSubtype = "tool-call" | "message";
@@ -248,6 +273,38 @@ export interface AGUIReasoningEncryptedValueEvent extends AGUIBaseEvent {
   subtype: AGUIReasoningEncryptedValueSubtype;
   entityId: string;
   encryptedValue: string;
+  subagentRunId?: string;
+}
+
+// Subagents
+
+export interface AGUISubagentStartedEvent extends AGUIBaseEvent {
+  type: "SUBAGENT_STARTED";
+  subagentRunId: string;
+  name: string;
+  description?: string;
+  parentSubagentRunId?: string;
+  // Link back to the tool call (and the message that held it) that spawned this
+  // subagent, for the agents-as-tools pattern. Lets a consumer correlate the
+  // subagent to its spawning call without inspecting rawEvent.metadata.
+  parentToolCallId?: string;
+  parentMessageId?: string;
+}
+
+export interface AGUISubagentFinishedEvent extends AGUIBaseEvent {
+  type: "SUBAGENT_FINISHED";
+  subagentRunId: string;
+  result?: unknown;
+  // Absent means success (the legacy reading). Unlike RUN_FINISHED.outcome this
+  // field postdates the valueless-field cleanup, so it never tolerates null.
+  outcome?: AGUISubagentFinishedOutcome;
+}
+
+export interface AGUISubagentErrorEvent extends AGUIBaseEvent {
+  type: "SUBAGENT_ERROR";
+  subagentRunId: string;
+  message: string;
+  code?: string;
 }
 
 // Special
@@ -256,12 +313,14 @@ export interface AGUIRawEvent extends AGUIBaseEvent {
   type: "RAW";
   event: unknown;
   source?: string;
+  subagentRunId?: string;
 }
 
 export interface AGUICustomEvent extends AGUIBaseEvent {
   type: "CUSTOM";
   name: string;
   value: unknown;
+  subagentRunId?: string;
 }
 
 // Deprecated
@@ -317,6 +376,9 @@ export type AGUIEvent =
   | AGUIReasoningMessageChunkEvent
   | AGUIReasoningEndEvent
   | AGUIReasoningEncryptedValueEvent
+  | AGUISubagentStartedEvent
+  | AGUISubagentFinishedEvent
+  | AGUISubagentErrorEvent
   | AGUIRawEvent
   | AGUICustomEvent
   | AGUIThinkingStartEvent
@@ -346,6 +408,19 @@ export interface AGUIResumeEntry {
 export type AGUIRunFinishedOutcome =
   | { type: "success" }
   | { type: "interrupt"; interrupts: AGUIInterrupt[] };
+
+/**
+ * Mirrors `AGUIRunFinishedOutcome` one level down: a subagent's terminal closes
+ * its stream segment for this run either because the work completed
+ * ("success") or because the workflow is paused awaiting outside input
+ * ("suspended" — on resume the same `subagentRunId` is re-announced as a
+ * continuation). `interruptIds` names the run-level interrupts this subagent
+ * directly owns, and may be absent: an ancestor that suspended because a
+ * descendant interrupted owns no interrupt itself.
+ */
+export type AGUISubagentFinishedOutcome =
+  | { type: "success" }
+  | { type: "suspended"; interruptIds?: string[] };
 
 /**
  * Numeric-only token usage summary, mirroring `TokenUsageSchema` in


### PR DESCRIPTION
`Drift Tests` has been red on `main` since Aug 26. Of the criticals, **26 are AG-UI schema drift** — upstream ag-ui added the subagent lifecycle and aimock's types never followed. (The Gemini model-family criticals in the same run are a separate concern and are not touched here.)

## What upstream added

Three new members on `EventType` — `SUBAGENT_STARTED`, `SUBAGENT_FINISHED`, `SUBAGENT_ERROR` — plus a `subagentRunId` correlation field threaded through every event a subagent can emit.

## `subagentRunId` is per-event, not a base field

Worth stating explicitly, because the cheap fix is wrong. The drift report lists `subagentRunId` against 23 event types, which reads like a base-event field — and declaring it once on `AGUIBaseEvent` would have cleared all 23 at once, the way `metadata` was cleared in #387.

But canonical does not put it on `BaseEventSchema`. Reading `events.ts` schema by schema:

- **24 events** declare `subagentRunId: z.string().optional()`
- **3 subagent events** declare it required, `z.string()`
- **7 events deliberately omit it**: `RUN_STARTED`, `RUN_FINISHED`, `RUN_ERROR`, `MESSAGES_SNAPSHOT`, and the four deprecated `THINKING_*` events

A base-event declaration would have gone green while putting the field on seven events canonical does not give it. So it is mirrored per event.

(24 optional, not the 23 reported — `STATE_DELTA` was missing from the report for a separate reason, below.)

## Changes

- **`src/agui-types.ts`** — `subagentRunId?: string` on the 24 events canonical marks optional; three new event interfaces (`AGUISubagentStartedEvent` / `Finished` / `Error`) with it required; `AGUISubagentFinishedOutcome` mirroring `AGUIRunFinishedOutcome` one level down; union and `AGUIEventType` members.
- **`src/__tests__/drift/agui-schema.drift.ts`** — strip trailing comments in the canonical parser, plus a regression test.

## The parser bug this surfaced

The canonical parser stripped whole-line comments only. A trailing comment survives, and since entries are cut on top-level commas it then *leads the next entry*, whose field-name match fails — the field is dropped silently.

Upstream writes exactly that on `STATE_DELTA`:

```ts
delta: z.array(z.any()), // JSON Patch (RFC 6902)
subagentRunId: z.string().optional(),
```

So canonical `STATE_DELTA.subagentRunId` was invisible: it never appeared in the 23 criticals, and once declared it flipped to a false `exists in aimock but not in canonical` warning. Same class as the two parser mis-readings fixed in #387. Stripping is safe here — no canonical schema literal contains `//`.

## Red-green proof

⚠️ **The local `../ag-ui` sibling this test resolves was stale (Aug 22, no subagent events at all), and against it the suite passes 15/15 — a false green.** Both runs below use an isolated, freshly-cloned canonical checkout, the same thing CI clones.

- aimock: `5e3b500` (red) → `6ecdcce` (green)
- **ag-ui: `363d3878e30887e88c1fd5ca1916ec3a5962b6be`**
- Positive control: `grep -c SUBAGENT` on the fresh clone's `events.ts` = 9; on the stale sibling = **0**.

Command, identical for both:

```
npx vitest run --config vitest.config.drift.ts
```

**RED** — at `5e3b500`, unmodified:

```
EXIT=1
 Test Files  1 failed | 18 passed | 7 skipped (26)
      Tests  2 failed | 132 passed | 57 skipped (191)

[CRITICAL] Event type "SUBAGENT_STARTED" exists in canonical @ag-ui/core but is missing from aimock AGUIEventType
[CRITICAL] Event type "SUBAGENT_FINISHED" ...
[CRITICAL] Event type "SUBAGENT_ERROR" ...
[CRITICAL] TEXT_MESSAGE_START: field "subagentRunId" (optional) exists in canonical but missing from aimock
  ... × 23 event types
```

26 criticals: 3 event types + `subagentRunId` × 23.

**GREEN** — this branch:

```
EXIT=0
 Test Files  19 passed | 7 skipped (26)
      Tests  135 passed | 57 skipped (192)
```

0 criticals. One warning remains and is pre-existing and genuine — canonical `TEXT_MESSAGE_START.role` is `.default("assistant")` where aimock requires it, same one #387 left as-is. The false `STATE_DELTA` warning is gone.

## Guards mutation-tested

| Mutation | Result |
| --- | --- |
| Drop `subagentRunId` from `agui-types.ts` | EXIT=1, criticals return |
| Drop the 3 `SUBAGENT_*` members from `AGUIEventType` | EXIT=1, all 3 event-type criticals return |
| Revert the trailing-comment strip | EXIT=1, the new regression test fails |

## Other checks

`tsc --noEmit` clean · `eslint .` clean · `prettier --check` clean · `tsdown` build clean · full unit suite **5280 passed | 46 skipped (5326)**, EXIT=0.

## Note on CI

The `drift` job is gated `if: github.event_name != 'pull_request'`, so **a green PR here does not exercise it** — hence the local proof above. `agui-schema-drift` does run on PRs and covers the change in this PR.
