### PR TITLE
fix(docs): repair the homepage's no-JS blank render, JS-animated motion, table semantics and mobile nav

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -77,6 +77,12 @@
         --font-features-mono: "liga" 0, "calt" 0;
         --font-sans: "Instrument Sans", -apple-system, system-ui, sans-serif;
         --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+        /* Rendered height of the fixed nav. Anything that sticks below the nav
+           offsets from this instead of re-guessing the number. The value here is
+           the desktop/mobile fallback for a no-JS render; the nav measures itself
+           on load and on resize and overwrites it, so a change to nav padding,
+           brand font-size or link wrapping can no longer silently desync. */
+        --nav-h: 70px;
       }
 
       html {
@@ -144,7 +150,12 @@
       nav .container {
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        gap: 2rem;
+      }
+      /* Pushes both link groups to the right, so splitting them into two lists
+         leaves the desktop bar looking exactly as it did with one. */
+      .nav-brand {
+        margin-right: auto;
       }
       .nav-brand {
         display: flex;
@@ -162,13 +173,6 @@
       }
       .nav-brand .prompt {
         color: var(--accent);
-      }
-      .nav-brand .powered-by {
-        font-size: 0.6rem;
-        font-weight: 400;
-        color: var(--text-dim);
-        padding-left: 1.5rem;
-        margin-top: -2px;
       }
       .nav-links {
         display: flex;
@@ -611,9 +615,6 @@
         box-shadow: 0 0 10px var(--error);
         animation: pulse 1.5s infinite;
       }
-      .record-left h2 {
-        display: none; /* moved above grid */
-      }
       .steps {
         display: flex;
         flex-direction: column;
@@ -696,18 +697,6 @@
         text-decoration: none;
       }
 
-      /* ─── Section: Transition ─────────────────────────────────────── */
-      .section-transition {
-        padding: 6rem 0;
-        text-align: center;
-      }
-      .transition-text {
-        font-size: clamp(1.4rem, 3vw, 2rem);
-        font-weight: 600;
-        color: var(--text-secondary);
-        letter-spacing: -0.02em;
-        margin-bottom: 3rem;
-      }
       .service-strip {
         display: flex;
         gap: 1rem;
@@ -1204,7 +1193,7 @@
       }
       .comparison-table thead th {
         position: sticky;
-        top: 57px;
+        top: var(--nav-h);
         z-index: 10;
         padding: 1rem;
         background: var(--bg-deep);
@@ -1231,7 +1220,9 @@
         text-align: center;
         color: var(--text-secondary);
       }
-      .comparison-table tbody td:first-child {
+      .comparison-table tbody th {
+        padding: 0.75rem 1rem;
+        border: 1px solid var(--border);
         text-align: left;
         color: var(--text-primary);
         font-weight: 500;
@@ -1359,11 +1350,35 @@
 
       /* ─── Mobile ──────────────────────────────────────────────────── */
       @media (max-width: 768px) {
-        .nav-links {
+        /* The five section anchors used to be display:none below 768px, which
+           left phones with no way to reach any section at all. They now take
+           their own full-width row under the brand and scroll horizontally —
+           Docs and the GitHub button keep their place on the first row — so
+           every anchor stays reachable without a JS-dependent menu. The mask
+           fades the right edge to advertise that the row scrolls. */
+        nav .container {
+          flex-wrap: wrap;
           gap: 1rem;
+          row-gap: 0.6rem;
         }
-        .nav-links .nav-hide-mobile {
+        .nav-sections {
+          order: 3;
+          width: 100%;
+          gap: 1.4rem;
+          overflow-x: auto;
+          scrollbar-width: none;
+          -webkit-overflow-scrolling: touch;
+          -webkit-mask-image: linear-gradient(to right, #000 85%, transparent 100%);
+          mask-image: linear-gradient(to right, #000 85%, transparent 100%);
+        }
+        .nav-sections::-webkit-scrollbar {
           display: none;
+        }
+        .nav-sections li {
+          flex: 0 0 auto;
+        }
+        .nav-sections a {
+          font-size: 0.8rem;
         }
         .demo-grid {
           grid-template-columns: 1fr;
@@ -1416,14 +1431,23 @@
         .hero h1 {
           font-size: 2rem;
         }
-        .nav-brand .powered-by {
-          display: none;
-        }
         .cn-label {
           display: none;
         }
       }
     </style>
+    <!-- .fade-in rests hidden and is revealed by an IntersectionObserver. With
+         scripting off there is no observer, so everything below the hero would
+         render permanently blank. Restore the revealed state as the resting
+         state. (The observer-threw case is handled in the script itself.) -->
+    <noscript>
+      <style>
+        .fade-in {
+          opacity: 1;
+          transform: none;
+        }
+      </style>
+    </noscript>
     <script src="/pixels.js" defer></script>
   </head>
 
@@ -1434,12 +1458,14 @@
         <div class="nav-brand">
           <div class="brand-main"><span class="prompt">$</span> aimock</div>
         </div>
-        <ul class="nav-links">
-          <li><a href="#record" class="nav-hide-mobile">Record & Replay</a></li>
-          <li><a href="#suite" class="nav-hide-mobile">Suite</a></li>
-          <li><a href="#features" class="nav-hide-mobile">Features</a></li>
-          <li><a href="#comparison" class="nav-hide-mobile">Comparison</a></li>
-          <li><a href="#switch" class="nav-hide-mobile">Switch</a></li>
+        <ul class="nav-links nav-sections">
+          <li><a href="#record">Record &amp; Replay</a></li>
+          <li><a href="#suite">Suite</a></li>
+          <li><a href="#features">Features</a></li>
+          <li><a href="#comparison">Comparison</a></li>
+          <li><a href="#switch">Switch</a></li>
+        </ul>
+        <ul class="nav-links nav-actions">
           <li><a href="/docs">Docs</a></li>
           <li>
             <a
@@ -2560,7 +2586,7 @@
             <div class="demo-body">
               <pre><span class="t-green">$</span> npx @copilotkit/aimock --config aimock.json
 
-<span class="t-blue">&#9889;</span> aimock v1.16.0
+<span class="t-blue">&#9889;</span> aimock v1.39.0
 
 <span class="t-green">&#10003;</span> LLM    <span class="t-dim">mounted at</span>  /v1/chat/completions
 <span class="t-green">&#10003;</span> LLM    <span class="t-dim">mounted at</span>  /v1/messages
@@ -2714,65 +2740,69 @@
           <table class="comparison-table">
             <thead>
               <tr>
-                <th>Capability</th>
-                <th class="col-aimock">
+                <th scope="col">Capability</th>
+                <th scope="col" class="col-aimock">
                   <a href="https://github.com/CopilotKit/aimock">aimock</a>
                 </th>
-                <th><a href="https://github.com/mswjs/msw">MSW</a></th>
-                <th><a href="https://github.com/vidaiUK/VidaiMock">VidaiMock</a></th>
-                <th><a href="https://github.com/dwmkerr/mock-llm">mock-llm</a></th>
-                <th><a href="https://github.com/piyook/llm-mock">piyook/llm-mock</a></th>
-                <th><a href="https://github.com/mokksy/ai-mocks">mokksy/ai-mocks</a></th>
+                <th scope="col"><a href="https://github.com/mswjs/msw">MSW</a></th>
+                <th scope="col"><a href="https://github.com/vidaiUK/VidaiMock">VidaiMock</a></th>
+                <th scope="col"><a href="https://github.com/dwmkerr/mock-llm">mock-llm</a></th>
+                <th scope="col">
+                  <a href="https://github.com/piyook/llm-mock">piyook/llm-mock</a>
+                </th>
+                <th scope="col">
+                  <a href="https://github.com/mokksy/ai-mocks">mokksy/ai-mocks</a>
+                </th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td>Cross-process interception</td>
+                <th scope="row">Cross-process interception</th>
                 <td class="col-aimock"><span class="yes">Real server &#10003;</span></td>
                 <td>In-process only</td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span> (Docker)</td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span> (Ktor)</td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span> (Docker)</td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span> (Ktor)</td>
               </tr>
               <tr>
-                <td>Chat Completions SSE</td>
+                <th scope="row">Chat Completions SSE</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
                 <td><span class="manual">manual</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
               </tr>
               <tr>
-                <td>Responses API SSE</td>
+                <th scope="row">Responses API SSE</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
                 <td><span class="manual">manual</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
               </tr>
               <tr>
-                <td>Claude Messages API</td>
+                <th scope="row">Claude Messages API</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
                 <td><span class="manual">manual</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
               </tr>
               <tr>
-                <td>Gemini streaming</td>
+                <th scope="row">Gemini streaming</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
                 <td><span class="manual">manual</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
               </tr>
               <tr>
-                <td>Multi-provider support</td>
+                <th scope="row">Multi-provider support</th>
                 <td class="col-aimock">
                   <span class="yes">13 providers (15 API surfaces) &#10003;</span>
                 </td>
@@ -2783,286 +2813,296 @@
                 <td>5 providers</td>
               </tr>
               <tr>
-                <td>OpenRouter router / fallback simulation</td>
+                <th scope="row">OpenRouter router / fallback simulation</th>
                 <td class="col-aimock"><span class="yes">Deterministic &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>WebSocket APIs</td>
+                <th scope="row">WebSocket APIs</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Embeddings API</td>
+                <th scope="row">Embeddings API</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
               </tr>
               <tr>
-                <td>Image generation</td>
+                <th scope="row">Image generation</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Image editing</td>
+                <th scope="row">Image editing</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Text-to-Speech</td>
+                <th scope="row">Text-to-Speech</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Audio transcription</td>
+                <th scope="row">Audio transcription</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Audio translation</td>
+                <th scope="row">Audio translation</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Non-speech audio</td>
+                <th scope="row">Non-speech audio</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Video generation</td>
+                <th scope="row">Video generation</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>AG-UI event mocking</td>
+                <th scope="row">AG-UI event mocking</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>MCP tool mocking</td>
+                <th scope="row">MCP tool mocking</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>A2A agent mocking</td>
+                <th scope="row">A2A agent mocking</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
               </tr>
               <tr>
-                <td>Vector DB mocking</td>
+                <th scope="row">Vector DB mocking</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Search &amp; rerank</td>
+                <th scope="row">Search &amp; rerank</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Record &amp; replay</td>
+                <th scope="row">Record &amp; replay</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Drift detection</td>
-                <td class="col-aimock"><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <th scope="row">Drift detection</th>
+                <td class="col-aimock">
+                  <span class="yes" role="img" aria-label="Yes">&#10003;</span>
+                </td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Sequential / stateful responses</td>
+                <th scope="row">Sequential / stateful responses</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
                 <td><span class="manual">manual</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Request journal</td>
-                <td class="col-aimock"><span class="yes">&#10003;</span></td>
+                <th scope="row">Request journal</th>
+                <td class="col-aimock">
+                  <span class="yes" role="img" aria-label="Yes">&#10003;</span>
+                </td>
                 <td><span class="manual">manual</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Error injection</td>
-                <td class="col-aimock"><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
+                <th scope="row">Error injection</th>
+                <td class="col-aimock">
+                  <span class="yes" role="img" aria-label="Yes">&#10003;</span>
+                </td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
                 <td><span class="partial">partial</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Chaos testing</td>
+                <th scope="row">Chaos testing</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Streaming physics</td>
+                <th scope="row">Streaming physics</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Structured output / JSON mode</td>
+                <th scope="row">Structured output / JSON mode</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
                 <td><span class="manual">manual</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Programmatic API</td>
-                <td class="col-aimock"><span class="yes">&#10003;</span> (TypeScript/JS)</td>
-                <td><span class="yes">&#10003;</span> (TypeScript/JS)</td>
+                <th scope="row">Programmatic API</th>
+                <td class="col-aimock">
+                  <span class="yes" role="img" aria-label="Yes">&#10003;</span> (TypeScript/JS)
+                </td>
+                <td>
+                  <span class="yes" role="img" aria-label="Yes">&#10003;</span> (TypeScript/JS)
+                </td>
                 <td>No (binary only)</td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span> (Kotlin/JVM)</td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span> (Kotlin/JVM)</td>
               </tr>
               <tr>
-                <td>Fixture files</td>
+                <th scope="row">Fixture files</th>
                 <td class="col-aimock"><span class="yes">JSON &#10003;</span></td>
                 <td>Code-only</td>
                 <td>Tera templates</td>
                 <td>YAML config</td>
                 <td>JSON templates</td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>GitHub Action</td>
+                <th scope="row">GitHub Action</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
               </tr>
               <tr>
-                <td>Vitest / Jest plugins</td>
+                <th scope="row">Vitest / Jest plugins</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Docker + Helm</td>
+                <th scope="row">Docker + Helm</th>
                 <td class="col-aimock"><span class="yes">Both &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
                 <td>Docker only</td>
-                <td><span class="yes">&#10003;</span> (Both)</td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span> (Both)</td>
                 <td>Docker only</td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Prometheus metrics</td>
+                <th scope="row">Prometheus metrics</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Streaming usage chunks</td>
+                <th scope="row">Streaming usage chunks</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="yes">&#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="yes" role="img" aria-label="Yes">&#10003;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Rate limiting headers</td>
+                <th scope="row">Rate limiting headers</th>
                 <td class="col-aimock"><span class="yes">Built-in &#10003;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
-                <td><span class="no">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
+                <td><span class="no" role="img" aria-label="No">&#10007;</span></td>
               </tr>
               <tr>
-                <td>Dependencies</td>
+                <th scope="row">Dependencies</th>
                 <td class="col-aimock"><span class="yes">Zero &#10003;</span></td>
                 <td>~300KB</td>
                 <td>Zero (Rust)</td>
@@ -3090,29 +3130,33 @@
           class="fade-in"
           style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap"
         >
-          <a href="/migrate-from-msw" class="btn btn-secondary"
+          <a href="/migrate-from-msw" class="btn-secondary"
             ><img
               src="https://mswjs.io/icon.svg"
+              loading="lazy"
+              referrerpolicy="no-referrer"
               alt=""
               width="16"
               height="16"
               style="vertical-align: -2px; margin-right: 6px; filter: grayscale(1) brightness(2)"
             />MSW</a
           >
-          <a href="/migrate-from-vidaimock" class="btn btn-secondary">VidaiMock</a>
-          <a href="/migrate-from-mock-llm" class="btn btn-secondary">mock-llm</a>
-          <a href="/migrate-from-piyook" class="btn btn-secondary">piyook</a>
-          <a href="/migrate-from-python-mocks" class="btn btn-secondary"
+          <a href="/migrate-from-vidaimock" class="btn-secondary">VidaiMock</a>
+          <a href="/migrate-from-mock-llm" class="btn-secondary">mock-llm</a>
+          <a href="/migrate-from-piyook" class="btn-secondary">piyook</a>
+          <a href="/migrate-from-python-mocks" class="btn-secondary"
             ><img
               src="https://www.python.org/static/favicon.ico"
+              loading="lazy"
+              referrerpolicy="no-referrer"
               alt=""
               width="16"
               height="16"
               style="vertical-align: -2px; margin-right: 6px"
             />Python</a
           >
-          <a href="/migrate-from-mokksy" class="btn btn-secondary">Mokksy</a>
-          <a href="/migrate-from-openai-responses" class="btn btn-secondary">openai-responses</a>
+          <a href="/migrate-from-mokksy" class="btn-secondary">Mokksy</a>
+          <a href="/migrate-from-openai-responses" class="btn-secondary">openai-responses</a>
         </div>
       </div>
     </section>
@@ -3203,23 +3247,61 @@
         });
       }
 
-      // Scroll-triggered fade-in via IntersectionObserver
+      // Publish the nav's rendered height as --nav-h so anything sticking below
+      // it (the comparison table's sticky header) offsets from the real number
+      // rather than a hard-coded guess that silently rots when the nav changes.
       (function () {
-        var observer = new IntersectionObserver(
-          function (entries) {
-            entries.forEach(function (entry) {
-              if (entry.isIntersecting) {
-                entry.target.classList.add("visible");
-                observer.unobserve(entry.target);
-              }
-            });
-          },
-          { threshold: 0.1, rootMargin: "0px 0px -40px 0px" },
-        );
+        try {
+          var nav = document.querySelector("nav");
+          if (!nav) return;
+          var apply = function () {
+            document.documentElement.style.setProperty(
+              "--nav-h",
+              Math.round(nav.getBoundingClientRect().height) + "px",
+            );
+          };
+          apply();
+          window.addEventListener("resize", apply);
+        } catch (e) {
+          /* the CSS fallback value stands */
+        }
+      })();
 
-        document.querySelectorAll(".fade-in").forEach(function (el) {
-          observer.observe(el);
-        });
+      // Scroll-triggered fade-in via IntersectionObserver.
+      // .fade-in rests at opacity 0, so if this never runs the whole page below
+      // the hero is blank. Every failure path — no IntersectionObserver, a
+      // constructor that throws — must therefore end with the content revealed.
+      // The try/catch also keeps a throw here from aborting the rest of this
+      // <script>, which is what animates the hero terminal.
+      (function () {
+        var revealAll = function () {
+          document.querySelectorAll(".fade-in").forEach(function (el) {
+            el.classList.add("visible");
+          });
+        };
+        try {
+          if (typeof IntersectionObserver !== "function") {
+            revealAll();
+            return;
+          }
+          var observer = new IntersectionObserver(
+            function (entries) {
+              entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+                  entry.target.classList.add("visible");
+                  observer.unobserve(entry.target);
+                }
+              });
+            },
+            { threshold: 0.1, rootMargin: "0px 0px -40px 0px" },
+          );
+
+          document.querySelectorAll(".fade-in").forEach(function (el) {
+            observer.observe(el);
+          });
+        } catch (e) {
+          revealAll();
+        }
       })();
 
       // ── Terminal demo animation ──────────────────────────────────────
@@ -3279,8 +3361,61 @@
         },
       ];
 
+      // The page-wide prefers-reduced-motion CSS block cannot reach a demo that
+      // is animated in JS, so the terminal has to opt out itself: under reduced
+      // motion it paints the finished transcript once and never loops.
+      var termReduceMotion = !!(
+        window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      );
+      var termVisible = false;
+      var termRunning = false;
+      var termStaticDone = false;
+      var termRestartTimer = null;
+
+      // The end state of termSteps, with no typing and no timers.
+      function renderTermStatic(term) {
+        term.innerHTML = "";
+        termSteps.forEach(function (step) {
+          if (step.type === "stream") {
+            var target = document.getElementById(step.target);
+            if (target) target.textContent = step.text;
+            return;
+          }
+          var line = document.createElement("div");
+          line.className = "line visible";
+          if (step.type === "prompt") {
+            line.innerHTML = '<span class="prompt-sym">$ </span><span class="cmd"></span>';
+            line.querySelector(".cmd").textContent = step.text;
+          } else {
+            line.innerHTML = step.html === "" ? "&nbsp;" : step.html;
+          }
+          term.appendChild(line);
+        });
+      }
+
+      // Only loop while the demo is actually on screen and the tab is visible;
+      // re-entering the viewport restarts it.
+      function scheduleTermRestart() {
+        clearTimeout(termRestartTimer);
+        termRestartTimer = setTimeout(function () {
+          if (termReduceMotion || !termVisible || document.hidden) return;
+          runTermDemo();
+        }, 4000);
+      }
+
       function runTermDemo() {
         var term = document.getElementById("demo-term");
+        if (!term) return;
+        if (termReduceMotion) {
+          if (!termStaticDone) {
+            renderTermStatic(term);
+            termStaticDone = true;
+          }
+          termRunning = false;
+          return;
+        }
+        clearTimeout(termRestartTimer);
+        termRunning = true;
         term.innerHTML = "";
         var stepIdx = 0;
 
@@ -3291,7 +3426,8 @@
             cursorLine.innerHTML = '<span class="prompt-sym">$ </span><span class="cursor"></span>';
             cursorLine.style.opacity = "1";
             term.appendChild(cursorLine);
-            setTimeout(runTermDemo, 4000);
+            termRunning = false;
+            scheduleTermRestart();
             return;
           }
 
@@ -3375,22 +3511,33 @@
         nextStep();
       }
 
-      // Start when demo scrolls into view
+      // Start when demo scrolls into view. It stays observed so the loop can be
+      // stopped when it scrolls away and picked up again when it comes back.
       (function () {
         var demoTerm = document.getElementById("demo-term");
         if (!demoTerm) return;
-        var demoObserver = new IntersectionObserver(
-          function (entries) {
-            entries.forEach(function (e) {
-              if (e.isIntersecting) {
-                runTermDemo();
-                demoObserver.unobserve(e.target);
-              }
-            });
-          },
-          { threshold: 0.1 },
-        );
-        demoObserver.observe(demoTerm);
+        try {
+          if (typeof IntersectionObserver !== "function") {
+            runTermDemo();
+            return;
+          }
+          var demoObserver = new IntersectionObserver(
+            function (entries) {
+              entries.forEach(function (e) {
+                termVisible = e.isIntersecting;
+                if (termVisible && !termRunning) runTermDemo();
+              });
+            },
+            { threshold: 0.1 },
+          );
+          demoObserver.observe(demoTerm);
+          document.addEventListener("visibilitychange", function () {
+            if (!document.hidden && termVisible && !termRunning) runTermDemo();
+          });
+        } catch (e) {
+          renderTermStatic(demoTerm);
+          termStaticDone = true;
+        }
       })();
     </script>
   </body>


### PR DESCRIPTION
Eight of the nine page findings from the adoption-wall review were re-verified against
`origin/main` (`0a47901`) — the version serving at https://aimock.copilotkit.dev — and all
eight reproduced. This fixes those eight. **P-03 is not addressed and must not be:** it
concerns a marquee pause/play toggle that main deliberately does not ship.

Every defect below was reproduced in a real browser (Playwright + Chromium) against
`docs/index.html` served over HTTP, **before** any change, and re-run unchanged **after**.
`RED` = pristine `origin/main` on :8792. `GREEN` = this branch on :8791. Probe script and
all screenshots were run locally; the raw lines are pasted verbatim.

---

## P-01 — everything below the hero renders blank without JS (Critical)

`.fade-in` rests at `opacity: 0; transform: translateY(30px)` and is only revealed by an
IntersectionObserver. No `<noscript>`. All four IIFEs share one `<script>`, so a throw in
the observer also kills the hero terminal demo.

**RED** (scripting disabled, and separately with the `IntersectionObserver` constructor throwing):
```
[RED][P-01 js-disabled] { "noscriptCount": 0, "fadeInTotal": 31, "visibleCount": 0,
 "opacities": [[".adopter-marquee","0","matrix(1, 0, 0, 1, 0, 30)"],
               ["#record .record-left","0","matrix(1, 0, 0, 1, 0, 30)"],
               ["#suite h2","0","matrix(1, 0, 0, 1, 0, 30)"],
               ["#features h2","0","matrix(1, 0, 0, 1, 0, 30)"],
               ["#comparison h2","0","matrix(1, 0, 0, 1, 0, 30)"],
               ["#switch h2","0","matrix(1, 0, 0, 1, 0, 30)"]] }
[RED][P-01b observer-throws] {"visibleCount":0,"fadeInTotal":31,"marqueeOpacity":"0",
                              "termHtmlLen":0,"copyFnDefined":"function"} pageerrors: ["boom"]
```
`termHtmlLen: 0` is the collateral damage: the throw aborted the rest of the `<script>`, so
the hero terminal never ran either.

**GREEN**:
```
[GREEN][P-01 js-disabled] { "noscriptCount": 1, "fadeInTotal": 31, "visibleCount": 0,
 "opacities": [[".adopter-marquee","1","none"], ["#record .record-left","1","none"],
               ["#suite h2","1","none"], ["#features h2","1","none"],
               ["#comparison h2","1","none"], ["#switch h2","1","none"]] }
[GREEN][P-01b observer-throws] {"visibleCount":31,"fadeInTotal":31,"marqueeOpacity":"1",
                                "termHtmlLen":1029,"copyFnDefined":"function"} pageerrors: []
```

Fix: a `<noscript>` style making the revealed state the resting state, plus a `try/catch`
around both observers that reveals everything on any failure — which also contains the
throw so the rest of the script still runs (`termHtmlLen` 0 → 1029, `pageerrors` now empty).

---

## P-02 — the hero terminal types forever under `prefers-reduced-motion` (Critical)

The demo is animated in JS, so the page-wide reduced-motion CSS block cannot reach it.
Snapshot of `#demo-term.innerHTML` length at ~1.5s / 4s / 8s / 14s, in a context with
`reducedMotion: "reduce"`:

**RED**
```
[RED][P-02 reduced-motion-terminal] lens=167,459,876,1122 settled=false
```
**GREEN**
```
[GREEN][P-02 reduced-motion-terminal] lens=1029,1029,1029,1029 settled=true
[GREEN][P-02] final-frame-has-200OK=true snapshot-tail="ine visible\">&nbsp;</div><div class=\"line visible\"><span class=\"ok\">  ✓ 200 OK</span> <span class=\"info\">— 3 chunks, 1s latency</span></div>"
```
The finished transcript is painted once and never mutates again. Outside reduced motion the
demo still animates, but now only loops while it is on screen and the tab is visible instead
of holding a timer chain forever.

---

## P-04 — the suite panel advertises a version 23 minors old (Important)

**RED** `"P04_versionText": ["aimock v1.16.0"]` — `package.json` is `1.39.0`.
**GREEN** `"P04_versionText": ["aimock v1.39.0"]`

---

## P-05 — the 7×38 comparison matrix has no table semantics (Important)

**RED**
```
"P05_theadThTotal": 7, "P05_theadScopeCol": 0, "P05_rowHeaderTh": 0, "P05_rowCount": 38,
"P05_firstCellTag": "TD", "P05_bareGlyphCount": 168, "P05_labelledGlyphCount": 0
```
**GREEN**
```
"P05_theadThTotal": 7, "P05_theadScopeCol": 7, "P05_rowHeaderTh": 38, "P05_rowCount": 38,
"P05_firstCellTag": "TH", "P05_bareGlyphCount": 168, "P05_labelledGlyphCount": 168
```
Every column header carries `scope="col"`, each row's leading cell is now `<th scope="row">`
(styled with a rule that reproduces the old `td:first-child` presentation exactly — see the
desktop screenshots, which are pixel-identical apart from the sticky offset), and all 168
bare ✓/✗ glyphs carry `role="img"` + an accessible name.

---

## P-06 — the sticky table header hides 13px behind the nav (Minor)

`top: 57px` was the nav's height at some earlier point; the nav renders at 70.17px.
Measured with the table scrolled far enough that the sticky header is engaged:

**RED**
```
[RED][P-06 sticky-vs-nav iphonese]   {"engaged":true,"navBottom":70.17,"thTop":57.35,"overlapPx":12.82}
[RED][P-06 sticky-vs-nav iphone14pm] {"engaged":true,"navBottom":70.17,"thTop":57.35,"overlapPx":12.82}
[RED][P-06 sticky-vs-nav desktop]    {"engaged":true,"navBottom":70.17,"thTop":57.35,"overlapPx":12.82}
```
**GREEN**
```
[GREEN][P-06 sticky-vs-nav iphonese]   {"engaged":true,"navBottom":105.36,"thTop":105.31,"overlapPx":0.05}
[GREEN][P-06 sticky-vs-nav iphone14pm] {"engaged":true,"navBottom":105.36,"thTop":105.31,"overlapPx":0.04}
[GREEN][P-06 sticky-vs-nav desktop]    {"engaged":true,"navBottom":70.17,"thTop":70.32,"overlapPx":-0.14}
```
`--nav-h` is a `:root` token with a `70px` fallback for a no-JS render; the nav measures
itself on load and on resize and overwrites it, which is why the mobile figure tracks the
now-taller two-row nav from P-08 automatically (`"navHVar":"105px"` / `"70px"`).

---

## P-07 — hotlinked third-party icons leak a Referer and load eagerly (Minor)

**RED**
```
"P07_externalImgs": [["https://mswjs.io/icon.svg", null, null],
                     ["https://www.python.org/static/favicon.ico", null, null]],
"P07_adopterImgAttrs": ["no-referrer","lazy"]
```
**GREEN**
```
"P07_externalImgs": [["https://mswjs.io/icon.svg","no-referrer","lazy"],
                     ["https://www.python.org/static/favicon.ico","no-referrer","lazy"]]
```
They now match what every adopter logo in the same document already did.

---

## P-08 — no in-page navigation at all on a phone (Minor)

All five section anchors were `display: none` at ≤768px with no hamburger and no alternative.

**RED**
```
[RED][P-06/P-08 iphonese 375x667]   {"navLinksTotal":7,"navLinksVisible":2,"visibleHrefs":["/docs","https://github.com/CopilotKit/aimock"],"hasHamburger":false}
[RED][P-06/P-08 iphone14pm 430x932] {"navLinksTotal":7,"navLinksVisible":2,"visibleHrefs":["/docs","https://github.com/CopilotKit/aimock"],"hasHamburger":false}
[RED][P-06/P-08 desktop 1440x900]   {"navLinksTotal":7,"navLinksVisible":7,...}
```
**GREEN**
```
[GREEN][P-06/P-08 iphonese 375x667]   {"navLinksVisible":7,"visibleHrefs":["#record","#suite","#features","#comparison","#switch","/docs","https://github.com/CopilotKit/aimock"]}
[GREEN][P-06/P-08 iphone14pm 430x932] {"navLinksVisible":7,"visibleHrefs":["#record","#suite","#features","#comparison","#switch","/docs","https://github.com/CopilotKit/aimock"]}
[GREEN][P-06/P-08 desktop 1440x900]   {"navLinksVisible":7,...}
```
The section anchors take their own full-width row under the brand and scroll horizontally,
with a mask fading the right edge to advertise it. Docs and the GitHub button keep their
place on the first row, so nothing loses prominence. **Desktop is unchanged** — the two
lists sit in the same flex row with the same 2rem gaps; compare the desktop screenshots.
No JS is involved, so this survives P-01's no-script case.

---

## P-09 — dead CSS (Minor)

Rules for markup that does not exist, plus a `.btn` class used 7× with no rule anywhere.

**RED**
```
"P09_recordLeftH2": 0, "P09_sectionTransition": 0, "P09_poweredBy": 0,
"P09_btnClassUses": 7, "P09_hasBtnRule": null,
"P09_deadCssRules": [".nav-brand .powered-by", ".record-left h2",
                     ".section-transition", ".transition-text"]
```
**GREEN**
```
"P09_recordLeftH2": 0, "P09_sectionTransition": 0, "P09_poweredBy": 0,
"P09_btnClassUses": 0, "P09_hasBtnRule": null, "P09_deadCssRules": []
```

---

## Not changed: P-03

P-03 describes an `aria-pressed`/accessible-name conflict in `toggleAdopterMarquee`. That
control does not exist on `main` — `grep` for `toggleAdopterMarquee`, `data-paused` and
`adopter-marquee-toggle` in `origin/main:docs/index.html` returns zero hits, and the repo
owner rejected the button. Nothing to fix on the page, and the button is deliberately not
re-added here.

## Reduced-motion marquee — regression check

The marquee must stay static and horizontally scrollable under reduced motion. Identical
before and after, at all three viewports:
```
[RED(main)][rm-marquee 375]   {"rowAnimation":"none","vpOverflowX":"auto","scrollable":true,"scrollW":2728,"clientW":311,"tiles":22,"static":true}
[GREEN(fix)][rm-marquee 375]  {"rowAnimation":"none","vpOverflowX":"auto","scrollable":true,"scrollW":2728,"clientW":311,"tiles":22,"static":true}
[RED(main)][rm-marquee 430]   {"rowAnimation":"none","vpOverflowX":"auto","scrollable":true,"scrollW":2728,"clientW":366,"tiles":22,"static":true}
[GREEN(fix)][rm-marquee 430]  {"rowAnimation":"none","vpOverflowX":"auto","scrollable":true,"scrollW":2728,"clientW":366,"tiles":22,"static":true}
[RED(main)][rm-marquee 1440]  {"rowAnimation":"none","vpOverflowX":"auto","scrollable":true,"scrollW":3256,"clientW":1056,"tiles":22,"static":true}
[GREEN(fix)][rm-marquee 1440] {"rowAnimation":"none","vpOverflowX":"auto","scrollable":true,"scrollW":3256,"clientW":1056,"tiles":22,"static":true}
```
The marquee's appearance is untouched by this PR.

## Visual verification

Screenshots taken and inspected at 375×667, 430×932 and 1440×900 (nav/hero, adopter
marquee, and the comparison table with its sticky header engaged), before and after.
Desktop is visually identical apart from the sticky header now sitting flush under the nav.
The blank green `aimock` column header visible in the comparison screenshots is pre-existing
on `main` and unchanged — it is not one of the findings and was deliberately left alone.

## Gates (raw exit codes)

```
prettier --check .   exit=0
eslint .             exit=0
tsc --noEmit         exit=0
vitest run           exit=0   (178 files passed, 1 skipped; 5321 tests passed, 46 skipped)
```
`docs/index.html` was prettier-clean before this branch and is prettier-clean after; the
diff is confined to the regions touched (no whole-page reformat).
