### PR TITLE
fix(adoption-wall): write adopter state back to the orphan branch so lastScan can advance

### DIFF
--- a/.github/workflows/update-adoption-wall.yml
+++ b/.github/workflows/update-adoption-wall.yml
@@ -6,14 +6,18 @@ name: Update Adoption Wall
 
 on:
   schedule:
-    # Mondays 17:00 UTC. The weekly adoption scan pushes adopters.json to the
-    # adoption-data branch on Mondays at 16:03 UTC, so this is NOMINALLY 57
-    # minutes behind it. That is ordering by convention, not a guarantee: a
-    # scheduled GitHub run is routinely delayed, the producer can slip or stop,
-    # and this job cannot tell either from the file it reads. Nothing here makes
-    # the state file fresh. What actually catches a stale one is the generator's
-    # own check of the file's `lastScan` against MAX_STATE_AGE_DAYS; if that
-    # ever goes away, this job goes back to reporting a frozen wall as healthy.
+    # Mondays 17:00 UTC. THIS JOB IS THE PRODUCER of adopters.json as well as its
+    # consumer: the generator resolves the whole adopter list against the GitHub
+    # API and, when that resolution was conclusive, writes the refreshed state
+    # back, which the "Persist adopter state" step below commits to the orphan
+    # adoption-data branch. There is no separate upstream routine to be behind.
+    #
+    # That is what keeps MAX_STATE_AGE_DAYS honest rather than decorative. The
+    # stamp is withheld whenever the run could not resolve the list, so a state
+    # file that stops advancing means the scan stopped working — which is
+    # exactly what the generator's staleness check is there to catch. It is
+    # still the thing that catches a frozen wall; if it ever goes away, this job
+    # goes back to reporting a frozen wall as healthy.
     - cron: "0 17 * * 1"
   workflow_dispatch:
 
@@ -83,6 +87,10 @@ jobs:
           echo "Branch name '${STATE_BRANCH}' agrees across workflow, script and .gitignore."
 
       # The adopter state, from the ORPHAN `adoption-data` branch of this repo.
+      # This checkout is ALSO where the refreshed state is committed from — see
+      # "Persist adopter state to the orphan branch" below. It stays a checkout
+      # of the orphan branch in its own directory, so committing into it can
+      # never mix repo history or repo files into that branch.
       #
       # ORPHAN MEANS ORPHAN: that branch shares no history with main, holds
       # nothing but adopters.json, and MUST NEVER BE MERGED INTO main. If a
@@ -211,12 +219,69 @@ jobs:
               | grep -v '^ADOPTION_WALL_REASON_EOF$' || true
             echo "ADOPTION_WALL_REASON_EOF"
           } >> "$GITHUB_OUTPUT"
+          # Whether the generator rewrote the state file. It is a property of the
+          # SCAN, not of the verdict — a NEEDS-REVIEW run that resolved the whole
+          # list still refreshes state — so it is read separately from $CODE.
+          if grep -qx 'ADOPTION_STATE_WRITTEN=true' "${RUNNER_TEMP}/adoption-wall.log"; then
+            echo "state_written=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "state_written=false" >> "$GITHUB_OUTPUT"
+          fi
           case "$CODE" in
             0)  echo "status=clean" >> "$GITHUB_OUTPUT" ;;
             10) echo "status=safe" >> "$GITHUB_OUTPUT" ;;
             20) echo "status=needs-review" >> "$GITHUB_OUTPUT" ;;
             *)  echo "Adoption wall script failed with exit ${CODE}"; exit "$CODE" ;;
           esac
+
+      # THE PRODUCER'S OTHER HALF. The generator rewrote adoption-data/adopters.json
+      # in place; this lands it on the orphan branch. Without it `lastScan` never
+      # moves, and MAX_STATE_AGE_DAYS turns from a guard into a fuse: three weeks
+      # after the branch was seeded EVERY run would report NEEDS-REVIEW and open a
+      # PR, weekly and forever, over a wall nothing had changed.
+      #
+      # Deliberately placed BEFORE the docs/ steps, and gated on the generator's
+      # own state_written flag rather than on the verdict. If this push fails the
+      # job stops here: the wall is not refreshed either, so nothing lands
+      # half-done, and the next run simply retries with three weeks of
+      # MAX_STATE_AGE_DAYS budget still in hand.
+      #
+      # This pushes to refs/heads/adoption-data and NOTHING ELSE. It cannot reach
+      # the default branch: it runs inside the orphan-branch checkout, stages one
+      # named file, and names the destination ref in full.
+      - name: Persist adopter state to the orphan branch
+        if: >-
+          steps.state_branch.outputs.exists == 'true' &&
+          steps.wall.outputs.state_written == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          AUTH=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::${AUTH}"
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+          export GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${AUTH}"
+          cd "${STATE_BRANCH}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # ONE NAMED FILE, never `git add -A`. The orphan branch holds nothing
+          # but adopters.json, and an `-A` here would push whatever else ever
+          # appeared in this directory onto it — which is the single thing the
+          # orphan-branch design exists to prevent.
+          git add -- "${STATE_FILE}"
+          if git diff --cached --quiet; then
+            echo "Refreshed state is byte-identical to what the branch holds; nothing to commit."
+            exit 0
+          fi
+          # --no-verify: see the HUSKY note in the workflow env block.
+          git commit --no-verify -m "chore(adoption): refresh adopter state"
+          # NO retry, NO rebase, NO force. This job is the branch's only writer
+          # and `concurrency` serialises it against itself, so a rejected push
+          # means something else wrote to adoption-data — and re-applying our
+          # file over it would delete whatever that was. Fail loudly instead:
+          # lastScan simply does not advance this week, which is the safe
+          # direction and is exactly what the staleness guard is for.
+          git push origin "HEAD:refs/heads/${STATE_BRANCH}"
 
       - name: Check for changes
         id: changes
@@ -424,6 +489,7 @@ jobs:
           CHANGED: ${{ steps.changes.outputs.changed }}
           CONFINED: ${{ steps.confine.outputs.confined }}
           EXISTS: ${{ steps.state_branch.outputs.exists }}
+          STATE_WRITTEN: ${{ steps.wall.outputs.state_written }}
           REASON: ${{ steps.wall.outputs.reason }}
           JOB_STATUS: ${{ job.status }}
           RUN_ID: ${{ github.run_id }}
@@ -487,6 +553,13 @@ jobs:
               EMOJI="⚠️"
               MSG="*No \`${STATE_BRANCH}\` branch on the remote, yet this run did not report a clean, unchanged wall. Nothing was committed, pushed or opened as a PR — the mutating steps are gated on the branch existing. Treat the rest as unverified.* ${MSG}"
             fi
+          fi
+          # A run that could not vouch for its own scan does not refresh the state,
+          # and that is otherwise invisible: the verdict, the diff and the logo
+          # count can all look ordinary while `lastScan` quietly stops moving. Say
+          # so, because three weeks of this is a weekly review PR nobody asked for.
+          if [ "$JOB_STATUS" = "success" ] && [ "$EXISTS" = "true" ] && [ "$STATE_WRITTEN" != "true" ]; then
+            MSG="${MSG} _Adopter state was NOT refreshed — the scan reached no verdict, so \`lastScan\` did not advance._"
           fi
           PAYLOAD=$(jq -n --arg text "${EMOJI} ${MSG}" '{text: $text}')
           # --fail-with-body + timeouts: a revoked or dead webhook returns 403

--- a/scripts/update-adoption-wall.ts
+++ b/scripts/update-adoption-wall.ts
@@ -1520,6 +1520,13 @@ export function buildSummary(opts: {
   malformedRepos?: string[];
   /** Why no adopter data was read this run, when that is the case. */
   stateNote?: string | null;
+  /**
+   * What this run did to the state file on the orphan branch, and why. Rendered
+   * because a reviewer reading a NEEDS-REVIEW PR needs to know whether the run
+   * also refreshed `lastScan` — a run that did NOT is on a clock, and that fact
+   * is invisible anywhere else in this document.
+   */
+  stateWriteNote?: string | null;
 }): string {
   const lines: string[] = [];
   lines.push("## Adoption wall");
@@ -1544,6 +1551,11 @@ export function buildSummary(opts: {
     `Logo health: ${opts.checks.length - failed.length}/${opts.checks.length} avatar URLs resolved.`,
   );
   lines.push("");
+
+  if (opts.stateWriteNote) {
+    lines.push(opts.stateWriteNote);
+    lines.push("");
+  }
 
   const notes = opts.notes ?? [];
   if (notes.length > 0) {
@@ -1840,6 +1852,164 @@ export function loadAdopterState(path: string): StateLoad {
   return parseAdopterState(raw, path);
 }
 
+// ── State write-back ─────────────────────────────────────────────────────────
+//
+// THIS SCRIPT IS THE PRODUCER OF `adopters.json`, not only its reader. It used
+// to be only the reader, and there was no writer anywhere: `lastScan` was
+// stamped once by hand when the orphan branch was seeded and then never moved
+// again, so MAX_STATE_AGE_DAYS was a fuse rather than a guard — every run stayed
+// green until the seed aged out, and every run after that reported NEEDS-REVIEW
+// forever over a wall nothing had actually changed. The functions below are the
+// missing producer.
+//
+// THE ONE PROPERTY THAT MATTERS: a fresh `lastScan` is a CLAIM that this run
+// resolved the whole adopter list. If a run that could not resolve it stamps one
+// anyway, the staleness guard becomes decorative — it would then be measuring
+// how recently the job RAN, which it can already tell, instead of how recently
+// the data was actually confirmed. So the stamp is gated on scanIsConclusive and
+// on nothing else, and every "we could not tell" answer anywhere in the run
+// withholds it.
+
+/**
+ * The scan's universe: everything the incoming state file lists, PLUS every
+ * repo with a curated `ADOPTER_DISPLAY` entry that the file does not mention.
+ *
+ * The orphan branch was seeded by PARSING THE LIVE WALL, which can only ever
+ * contain repos that were already rendering. `cacheplane/dawnai` is a real,
+ * curated adopter sitting below the wall's cut, so the parse could not see it
+ * and the seeded file did not list it — and because the file is also the
+ * candidate list, a repo missing from it can never climb back onto the wall. The
+ * gap was reported by missingFromState every week and nothing could close it.
+ *
+ * Seeding the curated names into the scan closes it: they are resolved from the
+ * API like every other candidate, ranked on their real numbers, and written back
+ * with whatever the scan actually found. `missedRuns: 0` here is an INPUT, not
+ * an assertion — it only means "ask about this one"; buildNextState overwrites
+ * it with the scan's answer before anything is persisted, and if the scan was
+ * not conclusive nothing is persisted at all.
+ */
+export function withKnownAdopters(
+  adopters: readonly AdopterState[],
+  now: string,
+  mapping: Record<string, AdopterDisplay> = ADOPTER_DISPLAY,
+): AdopterState[] {
+  const seen = new Set(adopters.map((a) => a.repo.toLowerCase()));
+  const added = Object.keys(mapping)
+    .filter((repo) => !seen.has(repo.toLowerCase()))
+    .sort((x, y) => x.localeCompare(y))
+    .map((repo) => ({ repo, channels: ["adopter-display"], missedRuns: 0, firstSeen: now }));
+  return [...adopters, ...added];
+}
+
+/**
+ * Whether this run is allowed to claim it scanned the adopter list.
+ *
+ * Two ways to fail, both meaning "no verdict was reached", never "the answer was
+ * no":
+ *
+ *   · a repo the API was asked about came back unusable (see MetaResolution); or
+ *   · a logo probe was INCONCLUSIVE — a timeout, a 429, a 5xx. That check runs
+ *     against the same GitHub estate over the same network in the same seconds,
+ *     so it is the run's own report that its answers this minute cannot be
+ *     trusted. A dead logo (`http`) or a wrong-account logo (`identity`) is the
+ *     opposite: a definite finding, and a run that established one scanned fine.
+ *
+ * A rate-limited or throttled METADATA pass does not reach here at all — both
+ * fetch paths throw on 403/429/5xx, main() exits EXIT_ERROR, and nothing is
+ * written. That is the loudest form of the same rule.
+ */
+export function scanIsConclusive(opts: {
+  indeterminate: readonly string[];
+  checks: readonly CheckResult[];
+}): { ok: true } | { ok: false; detail: string } {
+  if (opts.indeterminate.length > 0) {
+    const shown = [...opts.indeterminate].sort((x, y) => x.localeCompare(y)).slice(0, 5);
+    return {
+      ok: false,
+      detail:
+        `${opts.indeterminate.length} repo(s) returned no usable metadata, so this run did not ` +
+        `resolve the whole adopter list: ${shown.join(", ")}` +
+        (opts.indeterminate.length > shown.length
+          ? `, and ${opts.indeterminate.length - shown.length} more`
+          : ""),
+    };
+  }
+  const unverified = opts.checks.filter((c) => c.kind === "inconclusive");
+  if (unverified.length > 0) {
+    return {
+      ok: false,
+      detail:
+        `${unverified.length} avatar probe(s) reached no verdict (timeout, 429 or 5xx), so this ` +
+        `run cannot vouch for what it saw: ${unverified[0].repo || unverified[0].url}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * The state file this run should leave behind, given what it resolved.
+ *
+ * `lastScan` is the caller's `scannedAt` — the caller only gets here after
+ * scanIsConclusive said yes, so the field means what it has always claimed to
+ * mean.
+ *
+ * `missedRuns` keeps the semantics the reader already relies on (`> 0` means the
+ * latest scan did not see the repo, and the repo is not a wall candidate):
+ *
+ *   resolved by this scan   -> 0, unconditionally. A repo that comes back is
+ *                              back; carrying an old count forward would keep it
+ *                              off the wall after it returned.
+ *   definitively absent     -> previous + 1. One scan's silence is not a
+ *                              removal, and the counter is what makes that
+ *                              distinction possible.
+ *   NEITHER                 -> carried through UNCHANGED. Two populations land
+ *                              here and both must be left alone: entries already
+ *                              at missedRuns > 0, which are filtered out before
+ *                              the API is asked and so were never looked at this
+ *                              run; and entries whose `repo` is not `owner/name`
+ *                              and cannot be asked about at all. Incrementing a
+ *                              repo nobody looked at manufactures evidence.
+ *
+ * NOTHING IS EVER DELETED. An adopter that drops out of the scan keeps its row,
+ * its `firstSeen` and its rising counter, so a repo that reappears is recognised
+ * as the same repo rather than as a brand-new discovery — and the record that it
+ * was ever an adopter survives the week it went quiet.
+ *
+ * `isFork`, `channels` and `firstSeen` are carried through VERBATIM. `isFork`
+ * especially: the TRUST MODEL note at the top of this file says the reader uses
+ * the file's fork claim for nothing and reports every disagreement with the API,
+ * and overwriting the claim with the API's answer would make that report
+ * self-cancelling — the producer would erase the evidence the reader exists to
+ * surface.
+ *
+ * Entries are sorted by repo so the orphan branch's diff each week is the delta
+ * and not a reshuffle.
+ */
+export function buildNextState(opts: {
+  adopters: readonly AdopterState[];
+  resolved: ReadonlySet<string>;
+  absent: ReadonlySet<string>;
+  scannedAt: string;
+}): AdoptersState {
+  const adopters = [...opts.adopters]
+    .sort(
+      (x, y) =>
+        x.repo.toLowerCase().localeCompare(y.repo.toLowerCase()) || x.repo.localeCompare(y.repo),
+    )
+    .map((a) => {
+      const next: AdopterState = { ...a };
+      if (opts.resolved.has(a.repo)) next.missedRuns = 0;
+      else if (opts.absent.has(a.repo)) next.missedRuns = (a.missedRuns ?? 0) + 1;
+      return next;
+    });
+  return { lastScan: opts.scannedAt, adopters };
+}
+
+/** Exactly the on-disk form the seeded branch already uses: 2-space JSON, trailing newline. */
+export function serializeState(state: AdoptersState): string {
+  return JSON.stringify(state, null, 2) + "\n";
+}
+
 /**
  * One REST call per repo. Correct, but 182 calls for a 182-entry state file, so
  * it is the fallback rather than the default.
@@ -1847,6 +2017,7 @@ export function loadAdopterState(path: string): StateLoad {
 export async function fetchRepoMetaRest(
   repos: string[],
   meta: Map<string, RepoMeta>,
+  indeterminate?: Set<string>,
 ): Promise<void> {
   for (const repo of repos) {
     const res = await fetch(`https://api.github.com/repos/${repo}`, { headers: HEADERS });
@@ -1856,6 +2027,9 @@ export async function fetchRepoMetaRest(
     // once: ~170 repos reading as a mass disappearance and gutting the wall.
     // The GraphQL path throws here for exactly this reason; so does this one.
     if (res.status === 404 || res.status === 451) {
+      // A DEFINITIVE answer: the repo is gone, private or taken down. It yields
+      // no meta, and it is not added to `indeterminate` — the scan learned
+      // something here, and buildNextState is entitled to count it as a miss.
       console.warn(`  ⚠ Skipping ${repo}: ${res.status} ${res.statusText}`);
       continue;
     }
@@ -1877,7 +2051,11 @@ export async function fetchRepoMetaRest(
       typeof json.owner?.id !== "number" ||
       typeof json.fork !== "boolean"
     ) {
+      // NOT a definitive answer: the API replied, but not with the three facts
+      // this script needs. "We could not tell" must never be recorded as "the
+      // scan did not see it" — see buildNextState and scanIsConclusive.
       console.warn(`  ⚠ Skipping ${repo}: incomplete repo metadata`);
+      indeterminate?.add(repo);
       continue;
     }
     meta.set(repo, { stars: json.stargazers_count, ownerId: json.owner.id, isFork: json.fork });
@@ -1925,6 +2103,7 @@ export function buildRepoMetaQuery(repos: string[]): string {
 export async function fetchRepoMetaGraphQL(
   repos: string[],
   meta: Map<string, RepoMeta>,
+  indeterminate?: Set<string>,
 ): Promise<number> {
   let requests = 0;
   for (let i = 0; i < repos.length; i += GRAPHQL_BATCH) {
@@ -1972,7 +2151,11 @@ export async function fetchRepoMetaGraphQL(
         typeof node.isFork !== "boolean" ||
         typeof node.owner?.databaseId !== "number"
       ) {
+        // The node came back but is missing a field this script needs. That is
+        // "we could not tell", NOT "the repo is gone" — a null node (NOT_FOUND)
+        // is the definitive case and is skipped above without landing here.
         console.warn(`  ⚠ Skipping ${requested ?? alias}: incomplete repo metadata`);
+        if (requested !== undefined) indeterminate?.add(requested);
         continue;
       }
       meta.set(requested, {
@@ -1985,8 +2168,30 @@ export async function fetchRepoMetaGraphQL(
   return requests;
 }
 
-async function fetchRepoMeta(repos: string[]): Promise<Map<string, RepoMeta>> {
+/**
+ * What one resolution pass learned, split into the two answers that are NOT
+ * interchangeable.
+ *
+ * `meta` is what resolved. `indeterminate` is every repo the API was asked
+ * about and gave no usable answer for — the reply arrived but was missing a
+ * field. It is deliberately NOT the same set as "asked about and not in
+ * `meta`": a GraphQL NOT_FOUND, a REST 404 and a REST 451 are DEFINITIVE
+ * answers ("this repo is gone or private") and belong to neither set, because
+ * the scan genuinely learned something about those repos.
+ *
+ * The distinction exists for exactly one consumer: the state write-back. A repo
+ * we could not resolve must never be recorded as a repo the scan did not see —
+ * that is how a flaky API turns into a fabricated `missedRuns` and, one run
+ * later, into an adopter silently dropped off a public page.
+ */
+interface MetaResolution {
+  meta: Map<string, RepoMeta>;
+  indeterminate: Set<string>;
+}
+
+async function fetchRepoMeta(repos: string[]): Promise<MetaResolution> {
   const meta = new Map<string, RepoMeta>();
+  const indeterminate = new Set<string>();
 
   const local = argValue("--meta-file");
   if (local) {
@@ -1996,17 +2201,17 @@ async function fetchRepoMeta(repos: string[]): Promise<Map<string, RepoMeta>> {
   }
 
   const missing = repos.filter((r) => !meta.has(r) && r.split("/").length === 2);
-  if (missing.length === 0) return meta;
+  if (missing.length === 0) return { meta, indeterminate };
 
   if (GITHUB_TOKEN) {
-    const requests = await fetchRepoMetaGraphQL(missing, meta);
+    const requests = await fetchRepoMetaGraphQL(missing, meta, indeterminate);
     console.log(resolutionLine(missing, meta, requests));
   } else {
     console.log(`  No GITHUB_TOKEN; falling back to ${missing.length} REST request(s).`);
-    await fetchRepoMetaRest(missing, meta);
+    await fetchRepoMetaRest(missing, meta, indeterminate);
     console.log(resolutionLine(missing, meta, missing.length));
   }
-  return meta;
+  return { meta, indeterminate };
 }
 
 /** Formats through the repo's own prettier config so `format:check` stays green. */
@@ -2117,6 +2322,9 @@ async function main(): Promise<number> {
   const verifyOnly = process.argv.includes("--verify-only");
   const summaryPath = argValue("--summary");
   const statePath = resolve(argValue("--state") ?? DEFAULT_STATE_PATH);
+  // Taken ONCE, at the top, and used for both `lastScan` and any `firstSeen`
+  // this run mints, so every timestamp the run writes names the same run.
+  const scannedAt = new Date().toISOString();
 
   console.log("=== Adoption Wall Updater ===\n");
   if (dryRun) console.log("  [DRY RUN] No files will be modified.\n");
@@ -2139,6 +2347,18 @@ async function main(): Promise<number> {
   let malformed: string[] = [];
   let stateNote: string | null = null;
   const extraReasons: string[] = [];
+  /**
+   * What the scan resolved, kept for the write-back below. Null until a state
+   * file has actually been read and scanned, which is what makes "there is
+   * nothing honest to write" and "the scan said nothing changed" different
+   * things rather than the same silence.
+   */
+  let scan: {
+    list: AdopterState[];
+    resolved: Set<string>;
+    absent: Set<string>;
+    indeterminate: Set<string>;
+  } | null = null;
 
   // Job 2: refresh the list, if there is anything to refresh it from.
   const load = verifyOnly ? null : loadAdopterState(statePath);
@@ -2170,7 +2390,17 @@ async function main(): Promise<number> {
 
   if (load?.kind === "ok") {
     const state = load.state;
-    const adopters = state.adopters ?? [];
+    const incoming = state.adopters ?? [];
+    // The curated names the incoming file does not mention are scanned too, so a
+    // real adopter that never made it into the file can climb onto the wall
+    // instead of being reported as missing forever. See withKnownAdopters.
+    const adopters = withKnownAdopters(incoming, scannedAt);
+    if (adopters.length > incoming.length) {
+      console.log(
+        `\n  ${adopters.length - incoming.length} curated adopter(s) absent from the state file ` +
+          "were added to this scan; they are resolved and ranked like any other candidate.",
+      );
+    }
 
     // Before anything is ranked: is this file still being written? A frozen
     // producer looks exactly like a quiet week from every other angle.
@@ -2209,7 +2439,17 @@ async function main(): Promise<number> {
       for (const repo of malformed) console.warn(`    ${repo}`);
     }
 
-    const meta = await fetchRepoMeta(candidates.map((a) => a.repo));
+    const asked = candidates.map((a) => a.repo).filter((r) => r.split("/").length === 2);
+    const { meta, indeterminate } = await fetchRepoMeta(candidates.map((a) => a.repo));
+    // Three populations, and the middle one is the whole point: resolved,
+    // DEFINITIVELY absent (404 / 451 / NOT_FOUND), and "we could not tell".
+    // Only the first two are facts the write-back may act on.
+    scan = {
+      list: adopters,
+      resolved: new Set(asked.filter((r) => meta.has(r))),
+      absent: new Set(asked.filter((r) => !meta.has(r) && !indeterminate.has(r))),
+      indeterminate,
+    };
 
     disagreements = forkDisagreements(adopters, meta);
     if (disagreements.length > 0) {
@@ -2223,7 +2463,10 @@ async function main(): Promise<number> {
       }
     }
 
-    missing = missingFromState(adopters);
+    // The INCOMING file, deliberately: this line reports what the producer that
+    // wrote the file failed to discover. Running it over the seeded list would
+    // answer "none" every time and report the gap out of existence.
+    missing = missingFromState(incoming);
     if (missing.length > 0) {
       console.warn(`\n⚠ ${missing.length} known adopter(s) absent from the incoming state file:`);
       for (const repo of missing) console.warn(`    ${repo}`);
@@ -2337,6 +2580,64 @@ async function main(): Promise<number> {
   // keeps the run log greppable for a human.
   console.log(`\nADOPTION_WALL_STATUS=${status}`);
 
+  // ── State write-back ──────────────────────────────────────────────────────
+  //
+  // ON ALL THREE VERDICTS, gated on the SCAN and never on the status. `lastScan`
+  // records that the adopter list was resolved, which is a different question
+  // from whether a human needs to look at the result: a dead avatar, an adopter
+  // that genuinely vanished, or a wall below its floor are all things this run
+  // FOUND OUT, and a run that found something out scanned fine. Withholding the
+  // stamp on NEEDS-REVIEW would be actively harmful — the first dead logo would
+  // freeze `lastScan`, and three weeks later every run would carry a SECOND,
+  // invented staleness reason on top of the real one, displacing it from the
+  // three reasons that reach Slack. The failures that must not stamp are the
+  // ones where the run did not learn the answer, and those are exactly what
+  // scanIsConclusive tests.
+  //
+  // A corrupt or missing state file never reaches here: `scan` is still null,
+  // so there is no scanned list to write and last week's file is left alone.
+  let stateWritten = false;
+  let stateWriteNote: string | null = null;
+  if (scan !== null) {
+    const verdict = scanIsConclusive({ indeterminate: [...scan.indeterminate], checks });
+    if (!verdict.ok) {
+      stateWriteNote =
+        `Adopter state was NOT refreshed and \`lastScan\` did not advance: ${verdict.detail}. ` +
+        "A run that could not resolve the list must not stamp it fresh, or the staleness guard " +
+        "stops measuring anything.";
+      console.warn(`\n⚠ ${stateWriteNote}`);
+    } else if (dryRun || verifyOnly) {
+      stateWriteNote = `[DRY RUN] Adopter state would have been refreshed at \`${statePath}\`.`;
+      console.log(`\n[DRY RUN] Would refresh adopter state at ${statePath}.`);
+    } else {
+      const nextState = buildNextState({
+        adopters: scan.list,
+        resolved: scan.resolved,
+        absent: scan.absent,
+        scannedAt,
+      });
+      writeFileSync(statePath, serializeState(nextState), "utf-8");
+      stateWritten = true;
+      const missed = (nextState.adopters ?? []).filter(
+        (a) => typeof a.missedRuns === "number" && a.missedRuns > 0,
+      ).length;
+      stateWriteNote =
+        `Adopter state refreshed: \`lastScan\` is now ${scannedAt}, ` +
+        `${nextState.adopters?.length ?? 0} entr(y/ies), ${scan.resolved.size} seen by this scan, ` +
+        `${missed} carrying a missed run.`;
+      console.log(
+        `\nRefreshed adopter state at ${statePath}: lastScan=${scannedAt}, ` +
+          `${nextState.adopters?.length ?? 0} entr(y/ies), ${scan.resolved.size} resolved, ` +
+          `${scan.absent.size} not found by this scan.`,
+      );
+    }
+  }
+  // Machine-readable, like ADOPTION_WALL_STATUS: the workflow greps this to
+  // decide whether to commit the refreshed file back to the orphan branch. It
+  // must NOT be a `  ! ` reason — those are classify()'s output and are what
+  // Slack names as the cause of a verdict, and this is neither.
+  console.log(`ADOPTION_STATE_WRITTEN=${stateWritten}`);
+
   if (summaryPath) {
     const md = buildSummary({
       status,
@@ -2353,6 +2654,7 @@ async function main(): Promise<number> {
       staleExclusions,
       malformedRepos: malformed,
       stateNote,
+      stateWriteNote,
     });
     writeFileSync(resolve(summaryPath), md, "utf-8");
     console.log(`Summary written to ${summaryPath}`);

--- a/src/__tests__/adoption-wall.test.ts
+++ b/src/__tests__/adoption-wall.test.ts
@@ -59,7 +59,12 @@ import {
   safeUrl,
   selectAdopters,
   topCandidate,
+  buildNextState,
+  scanIsConclusive,
+  serializeState,
+  withKnownAdopters,
   type AdopterState,
+  type AdoptersState,
   type CheckResult,
   type RepoMeta,
   type WallEntry,
@@ -3026,10 +3031,24 @@ const json = (body, status) =>
   });
 globalThis.fetch = async (input) => {
   const url = typeof input === "string" ? input : (input.url ?? String(input));
+  // The REST metadata fallback, reached only for a candidate the --meta-file
+  // does not cover. Defaults to the 404 GitHub gives for a repo that is gone.
+  if (/^https:\\/\\/api\\.github\\.com\\/repos\\//.test(url)) {
+    return json(
+      JSON.parse(process.env.AW_TEST_REPO_JSON ?? '{"message":"Not Found"}'),
+      Number(process.env.AW_TEST_REPO_STATUS ?? "404"),
+    );
+  }
   const m = /^https:\\/\\/api\\.github\\.com\\/user\\/(\\d+)$/.exec(url);
-  if (!m) return png();
-  const login = logins[m[1]];
-  return login === undefined ? json({ message: "Not Found" }, 404) : json({ login }, 200);
+  if (m) {
+    const login = logins[m[1]];
+    return login === undefined ? json({ message: "Not Found" }, 404) : json({ login }, 200);
+  }
+  // The avatar CDN. A non-200 here is how a case makes the logo probe reach no
+  // verdict at all (429 / 5xx), which is different from a definitely-dead logo.
+  const avatar = Number(process.env.AW_TEST_AVATAR_STATUS ?? "200");
+  if (avatar !== 200) return new Response("", { status: avatar });
+  return png();
 };
 process.argv = [process.argv[0], script, ...process.argv.slice(3)];
 await import(pathToFileURL(script).href);
@@ -3060,19 +3079,37 @@ interface MainRun {
   docs: string;
   /** The `--summary` file, or null if the run wrote none. */
   summary: string | null;
+  /** `adopters.json` as it stands AFTER the run — the run is its own producer. */
+  state: AdoptersState;
+  /** The sandbox root, so a case can run a SECOND time against what the first left. */
+  dir: string;
 }
 
 const awRepos = (n: number) => Array.from({ length: n }, (_, i) => `sbx${i}/r`);
 const awAdopters = (repos: string[]): AdopterState[] =>
   repos.map((r) => ({ repo: r, missedRuns: 0 }));
-/** Descending stars, so the rendered order is the argument order. */
-const awMeta = (repos: string[]): Record<string, RepoMeta> =>
-  Object.fromEntries(
+/**
+ * Descending stars, so the rendered order is the argument order.
+ *
+ * Every curated `ADOPTER_DISPLAY` repo is included too, at ZERO stars. The
+ * generator seeds those names into its own scan (see withKnownAdopters), so
+ * without a record here they would be resolved through the API — and the
+ * sandbox has no API, only a blanket avatar stub, so the run would die trying to
+ * read a PNG as JSON. Zero stars is the honest sandbox fact for them: they
+ * resolve, they sit far below STAR_FLOOR, they never render, and the wall these
+ * cases assert on stays exactly the wall the case built.
+ */
+const awMeta = (repos: string[]): Record<string, RepoMeta> => ({
+  ...Object.fromEntries(
+    Object.keys(ADOPTER_DISPLAY).map((r, i) => [r, { stars: 0, ownerId: 900 + i, isFork: false }]),
+  ),
+  ...Object.fromEntries(
     repos.map((r, i) => [r, { stars: OK_STARS - i, ownerId: 100 + i, isFork: false }]),
-  );
+  ),
+});
 const awWall = (repos: string[]) => selectAdopters(awAdopters(repos), metaMap(awMeta(repos)));
 
-async function runMain(opts: {
+interface MainOpts {
   /** What `docs/index.html` already shows when the run starts. */
   page: WallEntry[];
   /** What the state file on the orphan branch says. */
@@ -3083,7 +3120,77 @@ async function runMain(opts: {
   /** false writes the page as renderWall emits it, i.e. NOT prettier-clean. */
   formatted?: boolean;
   args?: string[];
-}): Promise<MainRun> {
+  /** The state file's own `lastScan`. Omitted, the file carries none. */
+  lastScan?: string;
+  /** Non-200 makes every avatar probe reach no verdict — a 429, not a dead logo. */
+  avatarStatus?: number;
+  /** What `api.github.com/repos/...` answers for a candidate the meta file misses. */
+  repoResponse?: { status: number; body: unknown };
+}
+
+/**
+ * Spawns the child against a sandbox that already exists, so a case can run the
+ * generator TWICE over one sandbox and watch the second run read what the first
+ * one wrote. That round trip is the whole point of the state write-back and it
+ * cannot be seen from a single run.
+ */
+function awSpawn(dir: string, opts: MainOpts): MainRun {
+  const script = join(dir, "scripts", "update-adoption-wall.ts");
+  const runner = join(dir, "runner.mjs");
+  const statePath = join(dir, "adopters.json");
+  const metaPath = join(dir, "meta.json");
+  const summaryPath = join(dir, "summary.md");
+  const docsPath = join(dir, "docs", "index.html");
+
+  const child = spawnSync(
+    AW_TSX_BIN,
+    [
+      runner,
+      script,
+      "--state",
+      opts.statePath ?? statePath,
+      "--meta-file",
+      metaPath,
+      "--summary",
+      summaryPath,
+      ...(opts.args ?? []),
+    ],
+    {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        GITHUB_TOKEN: "",
+        AW_TEST_AVATAR_STATUS: String(opts.avatarStatus ?? 200),
+        ...(opts.repoResponse
+          ? {
+              AW_TEST_REPO_STATUS: String(opts.repoResponse.status),
+              AW_TEST_REPO_JSON: JSON.stringify(opts.repoResponse.body),
+            }
+          : {}),
+        // Lets the child's fetch stub answer checkOwnerIdentity truthfully for
+        // the ids this run actually rendered.
+        AW_TEST_LOGINS: JSON.stringify(
+          Object.fromEntries(
+            Object.entries(opts.meta).map(([repo, m]) => [String(m.ownerId), repo.split("/")[0]]),
+          ),
+        ),
+      },
+    },
+  );
+  if (child.error) throw child.error;
+
+  const rawState = existsSync(statePath) ? readFileSync(statePath, "utf-8") : "{}";
+  return {
+    code: child.status ?? -1,
+    log: `${child.stdout}${child.stderr}`,
+    docs: readFileSync(docsPath, "utf-8"),
+    summary: existsSync(summaryPath) ? readFileSync(summaryPath, "utf-8") : null,
+    state: JSON.parse(rawState) as AdoptersState,
+    dir,
+  };
+}
+
+async function runMain(opts: MainOpts): Promise<MainRun> {
   mkdirSync(AW_SANDBOX_HOME, { recursive: true });
   const dir = mkdtempSync(join(AW_SANDBOX_HOME, "run-"));
   mkdirSync(join(dir, "scripts"));
@@ -3108,48 +3215,23 @@ async function runMain(opts: {
   );
 
   const statePath = join(dir, "adopters.json");
-  writeFileSync(statePath, JSON.stringify({ adopters: opts.adopters }), "utf-8");
-  const metaPath = join(dir, "meta.json");
-  writeFileSync(metaPath, JSON.stringify(opts.meta), "utf-8");
-  const summaryPath = join(dir, "summary.md");
-
-  const child = spawnSync(
-    AW_TSX_BIN,
-    [
-      runner,
-      script,
-      "--state",
-      opts.statePath ?? statePath,
-      "--meta-file",
-      metaPath,
-      "--summary",
-      summaryPath,
-      ...(opts.args ?? []),
-    ],
-    {
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        GITHUB_TOKEN: "",
-        // Lets the child's fetch stub answer checkOwnerIdentity truthfully for
-        // the ids this run actually rendered.
-        AW_TEST_LOGINS: JSON.stringify(
-          Object.fromEntries(
-            Object.entries(opts.meta).map(([repo, m]) => [String(m.ownerId), repo.split("/")[0]]),
-          ),
-        ),
-      },
-    },
+  writeFileSync(
+    statePath,
+    JSON.stringify(
+      opts.lastScan === undefined
+        ? { adopters: opts.adopters }
+        : { lastScan: opts.lastScan, adopters: opts.adopters },
+    ),
+    "utf-8",
   );
-  if (child.error) throw child.error;
+  writeFileSync(join(dir, "meta.json"), JSON.stringify(opts.meta), "utf-8");
 
-  return {
-    code: child.status ?? -1,
-    log: `${child.stdout}${child.stderr}`,
-    docs: readFileSync(docsPath, "utf-8"),
-    summary: existsSync(summaryPath) ? readFileSync(summaryPath, "utf-8") : null,
-  };
+  return awSpawn(dir, opts);
 }
+
+/** An ISO timestamp `days` in the past, for a state file's `lastScan`. */
+const awDaysAgo = (days: number): string =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 
 /** Exactly what `sed -n 's/^  ! //p'` at workflow :181 pulls out of the log. */
 const scrapedReasons = (log: string): string[] =>
@@ -3316,5 +3398,362 @@ describe("main() end to end: the exit code and log the workflow reads", () => {
     expect(run.summary).toContain("does not exist");
     expect(run.summary).toContain("_No adopter data was read; `docs/` was not modified._");
     expect(run.docs).toContain(`data-repo="sbx0/r"`);
+  }, 60_000);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The state write-back: this script is the PRODUCER of adopters.json
+//
+// It used to be only the reader. Nothing anywhere wrote the file — not this
+// script, not the workflow, not any of the other fifteen workflows — so
+// `lastScan` was stamped by hand once, when the orphan branch was seeded, and
+// never moved again. That turned MAX_STATE_AGE_DAYS from a guard into a FUSE:
+// every run was green until the seed aged past 21 days, and every run after that
+// reported NEEDS-REVIEW and opened a review PR, weekly and forever, over a wall
+// nothing had actually changed.
+//
+// The property these cases exist to hold is narrow and it is the only one that
+// matters: a fresh `lastScan` is a CLAIM that the run resolved the whole adopter
+// list, so a run that could not resolve it must not stamp one. Get that wrong
+// and the staleness guard is measuring how recently the JOB RAN — which it can
+// already tell — instead of how recently the DATA was confirmed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("withKnownAdopters seeds the scan from the curated list, not from the wall", () => {
+  const now = "2026-09-01T00:00:00.000Z";
+
+  // The orphan branch was seeded by parsing the LIVE WALL, so it could only ever
+  // contain repos that were already rendering. `cacheplane/dawnai` is a curated
+  // adopter sitting below the wall's cut, so the parse never saw it — and since
+  // the file is also the candidate list, a repo missing from it could never climb
+  // back on. missingFromState reported the gap every week and nothing closed it.
+  it("adds a curated adopter the incoming file never mentioned", () => {
+    const seeded = withKnownAdopters([{ repo: "a/one" }], now);
+    const dawn = seeded.find((a) => a.repo === "cacheplane/dawnai");
+    expect(dawn).toBeDefined();
+    expect(dawn?.firstSeen).toBe(now);
+    // missedRuns is an INPUT meaning "ask about this one", not a claim that the
+    // scan saw it: buildNextState overwrites it with the scan's real answer.
+    expect(dawn?.missedRuns).toBe(0);
+  });
+
+  it("closes the gap missingFromState reports, for every curated name", () => {
+    expect(missingFromState(withKnownAdopters([], now))).toEqual([]);
+  });
+
+  it("keeps the incoming entry rather than adding a second one, whatever the casing", () => {
+    const incoming: AdopterState[] = [
+      { repo: "CACHEPLANE/DawnAI", channels: ["package"], missedRuns: 4 },
+    ];
+    const seeded = withKnownAdopters(incoming, now);
+    expect(seeded.filter((a) => a.repo.toLowerCase() === "cacheplane/dawnai")).toEqual(incoming);
+  });
+
+  it("never drops or rewrites an entry the file already had", () => {
+    const incoming: AdopterState[] = [{ repo: "a/one", isFork: true, missedRuns: 2 }];
+    expect(withKnownAdopters(incoming, now).slice(0, 1)).toEqual(incoming);
+  });
+});
+
+describe("scanIsConclusive withholds the freshness stamp from a run that reached no verdict", () => {
+  it("says yes when everything resolved and every probe reached a verdict", () => {
+    expect(scanIsConclusive({ indeterminate: [], checks: [ok("a/one"), dead("a/two")] })).toEqual({
+      ok: true,
+    });
+  });
+
+  // A DEAD logo is a finding. A run that established one scanned fine, and
+  // withholding the stamp from it would freeze `lastScan` on the first broken
+  // avatar — three weeks later every run would carry an invented staleness
+  // reason ahead of the real one, and the workflow only carries three reasons
+  // into Slack.
+  it("does not confuse a definitely-dead logo with a probe that reached no verdict", () => {
+    expect(scanIsConclusive({ indeterminate: [], checks: [dead("a/one")] }).ok).toBe(true);
+    expect(scanIsConclusive({ indeterminate: [], checks: [inconclusive("a/one")] }).ok).toBe(false);
+  });
+
+  it("says no when a repo returned no usable metadata, and names it", () => {
+    const verdict = scanIsConclusive({ indeterminate: ["a/one"], checks: [] });
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) throw new Error("unreachable");
+    expect(verdict.detail).toContain("a/one");
+    expect(verdict.detail).toContain("did not resolve the whole adopter list");
+  });
+});
+
+describe("buildNextState records what the scan found and invents nothing", () => {
+  const scannedAt = "2026-09-01T00:00:00.000Z";
+  const build = (adopters: AdopterState[], resolved: string[], absent: string[]) =>
+    buildNextState({
+      adopters,
+      resolved: new Set(resolved),
+      absent: new Set(absent),
+      scannedAt,
+    });
+
+  it("stamps lastScan with the run's own timestamp", () => {
+    expect(build([{ repo: "a/one" }], ["a/one"], []).lastScan).toBe(scannedAt);
+  });
+
+  it("clears missedRuns for a repo that came back", () => {
+    const next = build([{ repo: "a/one", missedRuns: 3 }], ["a/one"], []);
+    expect(next.adopters?.[0].missedRuns).toBe(0);
+  });
+
+  it("increments missedRuns for a repo the scan definitively did not find", () => {
+    expect(build([{ repo: "a/one", missedRuns: 2 }], [], ["a/one"]).adopters?.[0].missedRuns).toBe(
+      3,
+    );
+    expect(build([{ repo: "a/one" }], [], ["a/one"]).adopters?.[0].missedRuns).toBe(1);
+  });
+
+  // THE ONE THAT MATTERS. An entry already at missedRuns > 0 is filtered out
+  // before the API is asked, so this run never looked at it; a repo that is not
+  // `owner/name` cannot be asked about at all. Incrementing either manufactures
+  // evidence of a disappearance out of a repo nobody looked at, and three of
+  // those in a row is how an adopter falls off a public page for no reason.
+  it("leaves a repo it never looked at exactly as it found it", () => {
+    const untouched: AdopterState[] = [
+      { repo: "a/already-missed", missedRuns: 2 },
+      { repo: "not-owner-slash-name", missedRuns: 0 },
+    ];
+    const next = build(untouched, [], []);
+    expect(next.adopters?.map((a) => a.missedRuns)).toEqual([2, 0]);
+  });
+
+  it("never deletes an entry, however long it has been missing", () => {
+    const next = build(
+      [{ repo: "a/one", missedRuns: 99, firstSeen: "2020-01-01T00:00:00.000Z" }],
+      [],
+      ["a/one"],
+    );
+    expect(next.adopters).toHaveLength(1);
+    expect(next.adopters?.[0].firstSeen).toBe("2020-01-01T00:00:00.000Z");
+  });
+
+  // The TRUST MODEL note at the top of the script says the reader uses the
+  // file's fork claim for NOTHING and reports every disagreement with the API.
+  // A producer that overwrote the claim with the API's answer would erase the
+  // evidence that report exists to surface.
+  it("carries isFork, channels and firstSeen through verbatim", () => {
+    const entry: AdopterState = {
+      repo: "a/one",
+      isFork: true,
+      channels: ["package", "discord"],
+      firstSeen: "2024-05-05T00:00:00.000Z",
+    };
+    expect(build([entry], ["a/one"], []).adopters?.[0]).toEqual({ ...entry, missedRuns: 0 });
+  });
+
+  it("sorts by repo so the orphan branch's weekly diff is the delta, not a reshuffle", () => {
+    const next = build([{ repo: "z/last" }, { repo: "A/first" }, { repo: "m/mid" }], [], []);
+    expect(next.adopters?.map((a) => a.repo)).toEqual(["A/first", "m/mid", "z/last"]);
+  });
+
+  it("serializes in the exact on-disk shape the orphan branch already holds", () => {
+    const text = serializeState(build([{ repo: "a/one" }], ["a/one"], []));
+    expect(text.endsWith("\n")).toBe(true);
+    expect(text).toContain('\n  "lastScan"');
+    expect(JSON.parse(text)).toEqual(build([{ repo: "a/one" }], ["a/one"], []));
+  });
+});
+
+describe("a repo that answered without the facts is not a repo that went away", () => {
+  // fetchRepoMeta yields no meta for BOTH a 404 and a reply missing `fork`, and
+  // before this split the two were indistinguishable downstream. Recording the
+  // second as "the scan did not see it" is how a flaky API becomes a fabricated
+  // missedRuns and, three runs later, an adopter deleted from a public page.
+  it("REST: 404 is a definitive answer, incomplete metadata is not", async () => {
+    const bodies: Record<string, { status: number; body: unknown }> = {
+      "https://api.github.com/repos/a/gone": { status: 404, body: { message: "Not Found" } },
+      "https://api.github.com/repos/a/partial": {
+        status: 200,
+        body: { stargazers_count: 10, owner: { id: 4 } },
+      },
+    };
+    vi.stubGlobal("fetch", async (url: string) => {
+      const r = bodies[url];
+      return new Response(JSON.stringify(r.body), {
+        status: r.status,
+        statusText: r.status === 404 ? "Not Found" : "OK",
+        headers: { "content-type": "application/json" },
+      });
+    });
+    try {
+      const m = new Map<string, RepoMeta>();
+      const indeterminate = new Set<string>();
+      await fetchRepoMetaRest(["a/gone", "a/partial"], m, indeterminate);
+      expect(m.size).toBe(0);
+      expect([...indeterminate]).toEqual(["a/partial"]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("GraphQL: a null node is a definitive answer, a node missing a field is not", async () => {
+    vi.stubGlobal("fetch", async () =>
+      Response.json({
+        data: {
+          r0: null,
+          r1: { isFork: false, owner: { databaseId: 7 } },
+        },
+        errors: [{ type: "NOT_FOUND", message: "Could not resolve to a Repository" }],
+      }),
+    );
+    try {
+      const m = new Map<string, RepoMeta>();
+      const indeterminate = new Set<string>();
+      await fetchRepoMetaGraphQL(["a/gone", "a/partial"], m, indeterminate);
+      expect(m.size).toBe(0);
+      expect([...indeterminate]).toEqual(["a/partial"]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("main() is the producer: the weekly run refreshes the state it read", () => {
+  afterAll(() => {
+    rmSync(AW_SANDBOX_HOME, { recursive: true, force: true });
+  });
+
+  const scenario = (n = MIN_WALL_SIZE) => {
+    const repos = awRepos(n);
+    return { page: awWall(repos), adopters: awAdopters(repos), meta: awMeta(repos), repos };
+  };
+
+  // RED WITHOUT THE FIX: the run resolved everything, exited 0, and left
+  // `lastScan` exactly where it found it, because nothing anywhere wrote the
+  // file. Three weeks of that and the wall reports itself frozen.
+  it("advances lastScan on a CLEAN run that resolved the whole list", async () => {
+    const s = scenario();
+    const before = awDaysAgo(7);
+    const run = await runMain({ ...s, lastScan: before });
+    expect(run.code).toBe(EXIT_CLEAN);
+    expect(run.log).toContain("ADOPTION_STATE_WRITTEN=true");
+    expect(run.state.lastScan).toBeDefined();
+    expect(new Date(run.state.lastScan ?? 0).getTime()).toBeGreaterThan(new Date(before).getTime());
+  }, 60_000);
+
+  // The generator's own staleness check, on the real surface, with the real exit
+  // code the workflow branches on — and then the recovery the write-back buys.
+  it("recovers a state file that has aged past MAX_STATE_AGE_DAYS in one run", async () => {
+    const s = scenario();
+    const first = await runMain({ ...s, lastScan: awDaysAgo(MAX_STATE_AGE_DAYS + 9) });
+    expect(first.code).toBe(EXIT_NEEDS_REVIEW);
+    expect(scrapedReasons(first.log).some((r) => r.includes("past the"))).toBe(true);
+    expect(first.log).toContain("ADOPTION_STATE_WRITTEN=true");
+
+    // The SAME sandbox, reading what the first run wrote. Before the write-back
+    // this second run was byte-identical to the first: NEEDS-REVIEW, a review PR,
+    // every Monday, for a wall that never changed.
+    const second = awSpawn(first.dir, s);
+    expect(second.code).toBe(EXIT_CLEAN);
+    expect(scrapedReasons(second.log)).toEqual([]);
+    // A CLEAN verdict means the generator wrote nothing to docs/, so the workflow
+    // has nothing to commit to the default branch.
+    expect(second.log).toContain("Data changed: false");
+    expect(second.log).not.toContain("Updated docs/index.html.");
+    expect(second.docs).toBe(first.docs);
+  }, 60_000);
+
+  // The stamp is a property of the SCAN, not of the verdict. A run that found a
+  // dead adopter found something out; freezing lastScan on it would add an
+  // invented staleness reason ahead of the real one three weeks later.
+  it("still refreshes state on a NEEDS-REVIEW run whose scan was conclusive", async () => {
+    const before = awRepos(MIN_WALL_SIZE + 1);
+    const after = awRepos(MIN_WALL_SIZE);
+    const run = await runMain({
+      page: awWall(before),
+      adopters: awAdopters(after),
+      meta: awMeta(after),
+      lastScan: awDaysAgo(7),
+    });
+    expect(run.code).toBe(EXIT_NEEDS_REVIEW);
+    expect(run.log).toContain("ADOPTION_STATE_WRITTEN=true");
+  }, 60_000);
+
+  // THE CORRECTNESS PROPERTY. A 429 from the avatar CDN is the run reporting
+  // that its own answers this minute cannot be trusted. Stamping a fresh
+  // lastScan on it would launder a failed scan into apparent freshness, and the
+  // staleness guard would never fire again.
+  it("does NOT advance lastScan when the avatar probes reached no verdict", async () => {
+    const s = scenario();
+    const before = awDaysAgo(7);
+    const run = await runMain({ ...s, lastScan: before, avatarStatus: 429 });
+    expect(run.code).toBe(EXIT_NEEDS_REVIEW);
+    expect(run.log).toContain("ADOPTION_STATE_WRITTEN=false");
+    expect(run.state.lastScan).toBe(before);
+    expect(run.log).toContain("`lastScan` did not advance");
+    // And the reviewer reading the PR is told, because nothing else in the
+    // document would show it.
+    expect(run.summary).toContain("NOT refreshed");
+  }, 60_000);
+
+  // The same rule from the other direction: the verdict was CLEAN and the exit
+  // code was 0, and the stamp is STILL withheld, because one repo answered
+  // without the facts the ranking needs.
+  it("does NOT advance lastScan when a repo returned no usable metadata", async () => {
+    const s = scenario();
+    const before = awDaysAgo(7);
+    const run = await runMain({
+      ...s,
+      adopters: [...s.adopters, { repo: "flaky/repo", missedRuns: 0 }],
+      lastScan: before,
+      repoResponse: { status: 200, body: { stargazers_count: 10, owner: { id: 4242 } } },
+    });
+    expect(run.code).toBe(EXIT_CLEAN);
+    expect(run.log).toContain("ADOPTION_STATE_WRITTEN=false");
+    expect(run.state.lastScan).toBe(before);
+    expect(run.log).toContain("flaky/repo");
+  }, 60_000);
+
+  // A repo the API definitively does not have is the other case, and it IS
+  // recorded: one scan's silence is a missed run, not a removal, and the entry
+  // stays on file with its counter raised.
+  it("records a definitively-absent repo as a missed run without deleting it", async () => {
+    const s = scenario();
+    const run = await runMain({
+      ...s,
+      adopters: [
+        ...s.adopters,
+        { repo: "gone/repo", missedRuns: 0, firstSeen: "2024-01-01T00:00:00.000Z" },
+      ],
+      lastScan: awDaysAgo(7),
+      repoResponse: { status: 404, body: { message: "Not Found" } },
+    });
+    expect(run.log).toContain("ADOPTION_STATE_WRITTEN=true");
+    const gone = run.state.adopters?.find((a) => a.repo === "gone/repo");
+    expect(gone).toBeDefined();
+    expect(gone?.missedRuns).toBe(1);
+    expect(gone?.firstSeen).toBe("2024-01-01T00:00:00.000Z");
+  }, 60_000);
+
+  // --dry-run promises to write nothing. Stamping the state file would be
+  // exactly the write it promised not to make, and would hand the next real run
+  // a freshness claim no scan ever landed.
+  it("writes no state on a dry run", async () => {
+    const s = scenario();
+    const before = awDaysAgo(7);
+    const run = await runMain({ ...s, lastScan: before, args: ["--dry-run"] });
+    expect(run.log).toContain("ADOPTION_STATE_WRITTEN=false");
+    expect(run.state.lastScan).toBe(before);
+  }, 60_000);
+
+  // A curated adopter that never made it into the file gets scanned, and the
+  // refreshed file carries it — so the gap closes itself instead of being
+  // reported forever.
+  it("writes back the curated adopters the incoming file was missing", async () => {
+    const s = scenario();
+    const run = await runMain({ ...s, lastScan: awDaysAgo(7) });
+    expect(run.log).toContain("ADOPTION_STATE_WRITTEN=true");
+    const repos = (run.state.adopters ?? []).map((a) => a.repo);
+    expect(repos).toContain("cacheplane/dawnai");
+    // And it is recorded as SEEN, because the scan actually resolved it.
+    expect(run.state.adopters?.find((a) => a.repo === "cacheplane/dawnai")?.missedRuns).toBe(0);
+    // The report of the INCOMING file's gap is untouched: it describes what the
+    // producer that wrote the file failed to discover, and running it over the
+    // seeded list would answer "none" every time.
+    expect(run.summary).toContain("Known adopters the scan did not report");
   }, 60_000);
 });


### PR DESCRIPTION
## The fuse

`adopters.json` on the orphan `adoption-data` branch was **read and never written**. This script had no write path, and none of the sixteen workflows wrote it either — the only branch-touching steps were a `git ls-remote` probe and a sparse read-only checkout. `lastScan` was stamped by hand once, when the branch was seeded (`cd1a474`, 22 repos parsed off the live wall), and nothing advanced it.

`MAX_STATE_AGE_DAYS = 21`. So the feature was correct today and **self-destructing on ~2026-09-22**: from that Monday on, every weekly run flips to NEEDS-REVIEW and opens a review PR, forever, over a wall that has not changed. `MAX_STATE_AGE_DAYS` was a fuse, not a guard.

## RED — observed on the real surface

The real generator, run as a real child process against a sandbox repo root (stubbed `fetch`, no network), `origin/main` @ `32be6ec` unmodified:

```
SCENARIO           : stale        (lastScan 30 days old, wall otherwise unchanged)
EXIT CODE          : 20
ADOPTION_WALL_STATUS=NEEDS-REVIEW
  ! Adopter state was last scanned 30 day(s) ago (…), past the 21-day limit: the routine
    that writes `adopters.json` on the orphan `adoption-data` branch has stopped, so the
    wall is frozen on stale data.
lastScan ADVANCED  : false     ← and it never will
```

And the defect itself — a **fully successful** run leaves the file untouched:

```
SCENARIO           : fresh
EXIT CODE          : 0     ADOPTION_WALL_STATUS=CLEAN     Data changed: false
lastScan BEFORE    : 2026-08-31T07:35:54.344Z
lastScan AFTER     : 2026-08-31T07:35:54.344Z
lastScan ADVANCED  : false
```

Run twice over one sandbox on unmodified `main`, the stale state never recovers: `FIRST exit=20 … EXIT CODE: 20, lastScan ADVANCED: false`.

## GREEN — same harness, this branch

```
=== fresh ===       exit 0   CLEAN            ADOPTION_STATE_WRITTEN=true   lastScan ADVANCED: true
=== stale ===       exit 20  NEEDS-REVIEW     ADOPTION_STATE_WRITTEN=true   lastScan ADVANCED: true
```

and the recovery, twice over one sandbox:

```
FIRST  exit=20  lastScan=2026-09-01T07:36:28.672Z
SECOND exit=0   ADOPTION_WALL_STATUS=CLEAN   ADOPTION_STATE_WRITTEN=true
docs/index.html CHANGED BY RUN(S): false
```

The second run is CLEAN, so nothing is written to `docs/` and the workflow has nothing to commit to `main`.

## A failed scan must not stamp freshness

This is the property the whole change turns on: if a run that could not resolve the list stamps `lastScan` anyway, the staleness guard stops measuring how recently the DATA was confirmed and starts measuring how recently the JOB RAN — which it can already tell. Both failure shapes, on the real surface:

```
=== probe429 ===    (avatar CDN answers 429 — the probe reaches no verdict)
exit 20   ADOPTION_STATE_WRITTEN=false
⚠ Adopter state was NOT refreshed and `lastScan` did not advance: 8 avatar probe(s)
  reached no verdict (timeout, 429 or 5xx) …
lastScan ADVANCED  : false

=== incomplete ===  (one repo answers 200 but without `fork` — GREEN VERDICT, stamp still withheld)
exit 0    CLEAN   ADOPTION_STATE_WRITTEN=false
⚠ … 1 repo(s) returned no usable metadata, so this run did not resolve the whole
  adopter list: flaky/repo
lastScan ADVANCED  : false
```

A rate-limited **metadata** pass never reaches the write at all: both fetch paths already throw on 403/429/5xx and `main()` exits 1.

## Design, and why

**Written on all three verdicts (0 / 10 / 20), gated on the SCAN and never on the status.** `lastScan` records that the adopter list was resolved, which is a different question from whether a human should look at the result. A dead avatar, a vanished adopter, a wall under its floor — those are things the run FOUND OUT, and a run that found something out scanned fine. Gating on `status` would be actively harmful: the first dead logo freezes `lastScan`, and three weeks later every run carries a **second, invented** staleness reason on top of the real one — and the workflow only carries three reasons into Slack, so the invented one displaces the real cause from the one line a human reads. The runs that must not stamp are the ones that did not learn the answer, and that is exactly what `scanIsConclusive` tests. A corrupt or missing state file never reaches the write path at all.

**`missedRuns`** keeps the semantics the reader already relies on (`> 0` ⇒ not a candidate):
- resolved by this scan → `0`, unconditionally (a repo that comes back is back)
- **definitively** absent (GraphQL `NOT_FOUND`, REST 404/451) → `previous + 1`
- **neither** → carried through **unchanged**. Two populations land here and both must be left alone: entries already at `missedRuns > 0`, which are filtered out before the API is asked and so were never looked at; and entries whose `repo` is not `owner/name`. Incrementing a repo nobody looked at manufactures evidence of a disappearance, and three of those in a row drops an adopter off a public page for no reason.

That distinction did not exist before: `fetchRepoMeta` yielded no meta for both a 404 and a reply missing `fork`, and the two were indistinguishable downstream. They are now split (`MetaResolution.indeterminate`), which is what makes "could not tell" safe.

**Entries absent from the latest scan are never deleted.** They keep their row, their `firstSeen` and a rising counter, so a repo that reappears is recognised as the same repo. `isFork`, `channels` and `firstSeen` are carried through verbatim — overwriting `isFork` with the API's answer would make the fork-disagreement report self-cancelling, erasing the very evidence it exists to surface. Entries are sorted by repo so the orphan branch's weekly diff is the delta, not a reshuffle.

**Writing state pushes nothing to `main`.** The new workflow step runs inside the orphan-branch checkout, stages **one named file** (never `git add -A`), and pushes to `refs/heads/adoption-data` named in full. `adoption-data` stays a true orphan: it is a checkout of that branch in its own gitignored directory, so no repo history and no repo files can reach it. `Guard adoption-data naming` is untouched and still passes (verified locally). No retry, no rebase, no force — this job is the branch's only writer and `concurrency` serialises it against itself, so a rejected push means someone else wrote there; it fails loudly and `lastScan` simply does not advance that week, which is the safe direction and leaves three weeks of budget.

## `cacheplane/dawnai`

Root cause: the branch was **seeded by parsing the live wall**, which can only ever contain repos that were already rendering. `cacheplane/dawnai` is a curated adopter sitting below the wall's cut, so the parse could not see it — and because the file is *also* the candidate list, a repo missing from it could never climb back on. `missingFromState` reported the gap every week and nothing could close it.

The producer's state now derives from the scan: `withKnownAdopters` seeds every `ADOPTER_DISPLAY` key the incoming file does not mention into the scan itself, so they are resolved from the API, ranked on their real numbers, and written back with whatever the scan actually found. `missedRuns: 0` there is an INPUT meaning "ask about this one", not an assertion — `buildNextState` overwrites it with the scan's answer, and if the scan was inconclusive nothing is persisted. `missingFromState` still reports against the **incoming** file, so it keeps describing what the upstream producer failed to discover instead of answering "none" every time.

## Tests

25 new cases. Each was observed FAILING under a targeted mutation and passing with the fix restored (script byte-identical after restore, verified with `cmp`):

| Mutation | Red |
| --- | --- |
| the stamp is never withheld | 2 failed — both "does NOT advance lastScan" cases |
| the write removed (the shipped defect) | 5 failed — advances / recovers / NEEDS-REVIEW-still-refreshes / absent-repo / curated-writeback |
| unscanned entries incremented | 1 failed — "leaves a repo it never looked at exactly as it found it" |
| indeterminate tracking removed | 3 failed — REST + GraphQL definitive-vs-not, and the no-usable-metadata run |
| curated seeding removed | 3 failed — both `withKnownAdopters` cases and the curated write-back |

## Gates (raw exit codes)

| Gate | Code |
| --- | --- |
| `prettier --check .` | 0 |
| `npx eslint .` | 0 |
| `npx tsc --noEmit` | 0 |
| `npx vitest run` | 0 — **5592 passed / 46 skipped** (baseline 5567/46; +25 new) |
| `actionlint .github/workflows/update-adoption-wall.yml` | 0 |
| `npx commitlint --from origin/main --to HEAD` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvkmhXVLqSSEW6FvPQHSu5
