### PR TITLE
fix(gitignore): anchor local-run artifact patterns to the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,11 @@ docs/specs/
 # The workflow writes these to $RUNNER_TEMP (outside the checkout) so the
 # drift-success predicate's `git status` scan never sees them; this glob is
 # belt-and-suspenders for local runs and covers the post-fix / pinned variants.
-claude-code-output.log
-drift-report*.json
+# Anchored to the repo root deliberately: these are root-CWD local-run artifacts,
+# not a name to suppress at any depth (an unanchored glob would silently hide a
+# fixture such as src/__tests__/fixtures/drift-report-*.json).
+/claude-code-output.log
+/drift-report*.json
 
 # Adopter state checked out from the orphan adoption-data branch by
 # .github/workflows/update-adoption-wall.yml. Never committed to main.


### PR DESCRIPTION
## C-06 — unanchored `.gitignore` patterns

`.gitignore:22-23` carried `claude-code-output.log` and `drift-report*.json` unanchored, so git matched those names at **any depth**. Both are root-CWD artifacts of local runs — the comment block directly above them already says the stanza is "belt-and-suspenders for local runs". Anchoring them to `/` keeps the intent and removes the over-match.

This is **preventive, not a live bug**: no file matching either pattern exists anywhere in the tree today, so nothing changes tracked/untracked status.

### Before / after

```diff
-claude-code-output.log
-drift-report*.json
+/claude-code-output.log
+/drift-report*.json
```
(plus three explanatory comment lines recording that the anchor is deliberate)

### Red / green — via `git check-ignore -v`

Since nothing currently matches, the RED is a scratch file created at the path the broken rule wrongly matched.

**RED** (pre-fix, scratch files present):
```
$ git check-ignore -v src/__tests__/fixtures/drift-report-foo.json docs/claude-code-output.log
.gitignore:23:drift-report*.json	src/__tests__/fixtures/drift-report-foo.json
.gitignore:22:claude-code-output.log	docs/claude-code-output.log
RC=0
$ git status --porcelain
(empty — both files invisible to git)
```

**GREEN** (post-fix, same scratch files):
```
$ git check-ignore -v src/__tests__/fixtures/drift-report-foo.json docs/claude-code-output.log
RC=1        # no match
$ git status --porcelain
?? docs/claude-code-output.log
?? src/__tests__/fixtures/drift-report-foo.json
```

**Positive control** — the paths the rule is *supposed* to ignore are still ignored:
```
$ git check-ignore -v drift-report.json drift-report.sync-check.json claude-code-output.log
.gitignore:26:/drift-report*.json	drift-report.json
.gitignore:26:/drift-report*.json	drift-report.sync-check.json
.gitignore:25:/claude-code-output.log	claude-code-output.log
RC=0
```
`drift-report.sync-check.json` matters specifically: `scripts/drift-sync-check.ts:163` defaults to that name, and the anchored glob still catches it at root.

All scratch files were deleted; the only change in the tree is `.gitignore`.

### Gates

| Gate | Exit code |
| --- | --- |
| `npx eslint .` | 0 |
| `npx tsc --noEmit` | 0 |
| `npx vitest run` | 0 — 5592 passed / 46 skipped (5638), 179 files passed / 1 skipped |
| `npx commitlint --from origin/main --to HEAD` | 0 |

Prettier has no parser for `.gitignore`, so a prettier check on this file is **not applicable** — not run, not claimed as a pass.