### PR TITLE
ci: type-check the repo, and make type-checking safe to run

### DIFF
--- a/.github/workflows/static-quality.yml
+++ b/.github/workflows/static-quality.yml
@@ -31,6 +31,17 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with: { persist-credentials: false }
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with: { node-version: 24, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+
   exports:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -167,9 +167,10 @@
     "test": "vitest run",
     "test:drift": "vitest run --config vitest.config.drift.ts",
     "test:exports": "publint && attw --pack .",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p scripts/tsconfig.json --noEmit",
     "lint": "eslint .",
     "format:check": "prettier --check .",
-    "release": "pnpm format:check && pnpm build && pnpm test && pnpm lint && pnpm test:exports && npm publish",
+    "release": "pnpm format:check && pnpm typecheck && pnpm build && pnpm test && pnpm lint && pnpm test:exports && npm publish",
     "prepare": "husky || true"
   },
   "lint-staged": {

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "noEmit": true,
     "types": ["node"]
   },
   "include": ["."]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "noEmit": true,
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
Two changes, ordered: make `tsc` safe to run, then make it run.

## `noEmit` on both tsconfigs

Neither tsconfig set `noEmit`, so invoking `tsc -p` wrote build output into tracked and published directories. Observed on the pre-fix tree:

```
$ git status --porcelain scripts/          # empty
$ npx tsc -p scripts/tsconfig.json ; echo RC=$?
RC=0
$ git status --porcelain scripts/
?? scripts/changelog-radar.js
?? scripts/convert-mockllm.js
... 12 .js files next to their .ts sources, plus 8 more in src/
   (reached through the scripts' relative imports)

$ pnpm build && find dist -type f | sort > baseline   # 555 files
$ npx tsc -p tsconfig.json && find dist -type f | sort | diff baseline -
   47 added files: .d.ts / .d.ts.map / .js.map written into dist/,
   the directory tsdown owns and the package publishes
```

After adding `"noEmit": true` to both, the same two commands emit nothing: `scripts/*.js` count 0, `dist/` not created.

Non-regression — `noEmit` does not disturb tsdown:

```
pnpm build           RC=0, dist file set IDENTICAL to baseline (555 files, diff RC=0)
                     68 .d.ts / 68 .d.cts pairs present, incl. index.d.ts + index.d.cts
pnpm test:exports    RC=0  (publint clean; attw all green)
```

(The dist *tree hash* is nondeterministic build-to-build, so the file set is the signal here, not a hash.)

## `typecheck` script + CI job

`grep "typecheck\|tsc "` over `package.json` and every workflow returned nothing — no type-check gate existed anywhere. The configs were already fine; only the runner was missing. Adds `pnpm typecheck` (both projects, `--noEmit` on the CLI as well as in the configs), a `typecheck` job in Static Quality matching the existing jobs' pinned SHAs and pnpm setup, and `typecheck` to the `release` chain.

**A new gate is only worth something if it has been watched fail.** Proven locally with throwaway probe files, one per project, neither committed:

```
# probe in src/
$ pnpm typecheck ; echo RC=$?
src/__typecheck_red_probe.ts(1,14): error TS2322: Type 'string' is not assignable to type 'number'.
RC=2

# probe in scripts/
$ pnpm typecheck ; echo RC=$?
scripts/__typecheck_red_probe.ts(1,14): error TS2322: Type 'string' is not assignable to type 'number'.
RC=2

# probes removed, real tree
$ pnpm typecheck ; echo RC=$?
RC=0
```

### What the gate covers, and what it does not

- **Covers:** `src/` (via `tsconfig.json`) and `scripts/` (via `scripts/tsconfig.json`) — including the 83 KB of unattended CI TypeScript that runs through `tsx`, which strips types without checking them.
- **Does NOT cover:** `src/__tests__`, which `tsconfig.json` already excludes. Including it produces 126 errors across ~40 files (38×TS2345, 21×TS2352, 17×TS2531, 11×TS6059 `rootDir` violations, …) and needs its own tsconfig. That is separate work, deliberately not attempted here and not papered over with `exclude` hacks — the exclusion is the pre-existing config, unchanged.
- The repo has **no required status checks**, so this job alerts; it does not block a merge.

## Gates

```
pnpm install --frozen-lockfile   RC=0   (no pnpm-lock.yaml drift)
prettier --check .               RC=0
npx eslint .                     RC=0
npx tsc --noEmit                 RC=0
pnpm typecheck                   RC=0
npx vitest run                   RC=0   180 files, 5638 tests passed
actionlint static-quality.yml    RC=0
npx commitlint --from origin/main --to HEAD   RC=0
```