### PR TITLE
ci(adoption-wall): publish the run summary, and stop calling SAFE additive-only

### DIFF
--- a/.github/workflows/update-adoption-wall.yml
+++ b/.github/workflows/update-adoption-wall.yml
@@ -430,8 +430,10 @@ jobs:
             echo "The diff is confined to the generated region; it may auto-land."
           fi
 
-      # The whole point of the wall: a healthy, purely-additive refresh lands
-      # itself. No weekly click.
+      # The whole point of the wall: a healthy refresh that tripped none of the
+      # guardrails lands itself. No weekly click. SAFE is not "the wall only
+      # grew" -- classify() returns it for any change no guardrail stopped, so
+      # a reorder, an avatar refresh or an EXPLAINED removal auto-lands here too.
       #
       # NOTE: there is no separate opt-in variable gating this. A safe, changed,
       # region-confined run pushes to ${{ github.ref_name }} unattended, and the

--- a/.github/workflows/update-adoption-wall.yml
+++ b/.github/workflows/update-adoption-wall.yml
@@ -245,6 +245,59 @@ jobs:
             *)  echo "Adoption wall script failed with exit ${CODE}"; exit "$CODE" ;;
           esac
 
+      # THE RUN'S ACCOUNT OF ITSELF, ROUTED SOMEWHERE A HUMAN READS IT.
+      # The generator writes its summary to $RUNNER_TEMP on EVERY verdict, but
+      # until this step existed its only consumer was the --body-file of "Open
+      # review PR" below, which fires on the NEEDS-REVIEW path alone. So on the
+      # two verdicts that are the base case -- CLEAN, and SAFE, the one that
+      # pushes to a public homepage unattended -- the exclude-list suppression
+      # count, the fork-disagreement table, the unmapped-adopter queue, the org
+      # runners-up and the selected wall were written, read by nobody, and
+      # discarded with the runner. One of them had no other channel at all:
+      # staleExclusions is computed only to build this summary and is never
+      # console.log'd, so on a green run it existed nowhere.
+      #
+      # `if: always()` and a body that CANNOT FAIL THE JOB. This step reports; it
+      # does not decide. A failure here after a successful auto-land would flip a
+      # genuinely-successful run to "failed" and fire a Slack alert naming no
+      # real cause, so every append is `|| true`: losing the summary must never
+      # lose the run's verdict.
+      #
+      # "Open review PR" still reads the same file. This step only copies it.
+      - name: Publish run summary
+        if: always()
+        run: |
+          SUMMARY="${RUNNER_TEMP}/adoption-wall-summary.md"
+          LOG="${RUNNER_TEMP}/adoption-wall.log"
+          # $GITHUB_STEP_SUMMARY is capped at 1 MiB and the runner DISCARDS an
+          # oversized file rather than truncating it, which would lose the very
+          # thing this step exists to keep. Leave headroom for the notice.
+          LIMIT=$((1024 * 1024 - 4096))
+          if [ -s "$SUMMARY" ]; then
+            head -c "$LIMIT" "$SUMMARY" >> "$GITHUB_STEP_SUMMARY" || true
+            if [ "$(wc -c < "$SUMMARY")" -gt "$LIMIT" ]; then
+              {
+                echo
+                echo "_Truncated at ${LIMIT} bytes for the job-summary cap; the full text is in the \`Update adoption wall\` step log._"
+              } >> "$GITHUB_STEP_SUMMARY" || true
+            fi
+          else
+            # The generator writes the summary BEFORE it returns its verdict and
+            # does not gate that write on the status, so on exit 0/10/20 the file
+            # is there. Absent means the run died earlier than that -- the step
+            # above `exit`ed with the raw code -- and the log tail is then the
+            # only account of the run that exists.
+            {
+              echo "## Adoption wall: no summary was produced"
+              echo
+              echo "The generator did not write a summary, so it failed before reaching that point. Tail of its log:"
+              echo
+              echo '```'
+              tail -c 60000 "$LOG" 2>/dev/null || echo "(the generator produced no log either)"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY" || true
+          fi
+
       # THE PRODUCER'S OTHER HALF. The generator rewrote adoption-data/adopters.json
       # in place; this lands it on the orphan branch. Without it `lastScan` never
       # moves, and MAX_STATE_AGE_DAYS turns from a guard into a fuse: three weeks

--- a/scripts/update-adoption-wall.ts
+++ b/scripts/update-adoption-wall.ts
@@ -92,7 +92,12 @@
  *
  * Exit codes (the workflow branches on these, not on prose):
  *   0  CLEAN         — logos healthy, no data change. Nothing to commit.
- *   10 CHANGED_SAFE  — logos healthy, wall changed additively. Safe to push.
+ *   10 CHANGED_SAFE  — logos healthy, the wall changed, and none of the
+ *                      guardrails listed under 20 fired. Safe to push. This is
+ *                      NOT "the wall only grew": classify() returns SAFE for any
+ *                      change it found no reason to stop, which includes
+ *                      reorders, star-driven reshuffles, avatar refreshes and
+ *                      EXPLAINED removals. A removal can auto-land. See classify.
  *   20 NEEDS_REVIEW  — human. Any of: a logo is dead or unverifiable; the wall
  *                      shrank past its explained removals; it would render fewer
  *                      than MIN_WALL_SIZE tiles; the highest-starred candidate the


### PR DESCRIPTION
Two changes to the live weekly adoption-wall job. Separate commits: the behavioural one first, the comment-only one second, so a bisect over the workflow file stays meaningful.

## A1 — the run summary now reaches a channel a human reads

`scripts/update-adoption-wall.ts` writes its run summary to `$RUNNER_TEMP` on **every** verdict, but its only consumer was the `--body-file` of **Open review PR**, which fires on the NEEDS-REVIEW path alone. So on the two verdicts that are the base case — CLEAN, and SAFE, the verdict that pushes to the public homepage unattended — the exclude-list suppression count, the fork-disagreement table, the unmapped-adopter queue, the org runners-up and the selected wall were written, read by nobody, and discarded with the runner. `grep -c GITHUB_STEP_SUMMARY` over the workflow was **0**.

`staleExclusions` had no other channel at all: it is computed at the `buildSummary` call site and is never `console.log`'d, so on a green run it existed nowhere.

One new `if: always()` step, **Publish run summary**, appends the summary to `$GITHUB_STEP_SUMMARY`. It falls back to the tail of the generator's log when the run died before the summary was written, and truncates at just under the 1 MiB cap. Every append is `|| true`: this step reports, it does not decide — a failure here after a successful auto-land would flip a genuinely-successful run to "failed" and fire a Slack alert naming no real cause.

**Open review PR is untouched** and still reads the same file. Proven mechanically: the step's `run:` body extracted from the YAML before and after the change is byte-identical.

### Red — pre-fix

Harness executes the **real** step body parsed straight out of the workflow YAML (no hand-copied script), with `RUNNER_TEMP` / `GITHUB_OUTPUT` / `GITHUB_STEP_SUMMARY` pointed at temp files:

```
### STEP 1: 'Update adoption wall' (real body from YAML)
step1 rc=0
summary FILE bytes:                 599
$GITHUB_STEP_SUMMARY bytes:          0

### STEP 2: 'Publish run summary' — NO SUCH STEP IN THIS YAML (pre-fix)
```

Content produced, channel never written. That is the defect, observed.

Historical corroboration: the last successful production run before this PR has an empty Summary tab.

### Green — post-fix, same harness

```
### STEP 1: 'Update adoption wall' (real body from YAML)
step1 rc=0
summary FILE bytes:                 599
$GITHUB_STEP_SUMMARY bytes:          0

### STEP 2: 'Publish run summary' (real body from YAML)
step2 rc=0
$GITHUB_STEP_SUMMARY bytes:        599
byte-identical to summary file? YES

### FAILURE ARM: summary file deleted, step re-run
step2(fallback) rc=0
## Adoption wall: no summary was produced

The generator did not write a summary, so it failed before reaching that point. Tail of its log:
...
```

Truncation arm, exercised with a 1,500,006-byte summary:

```
rc=0
input bytes: 1500006
GSS bytes:   1044592          # under the 1 MiB cap
tail: _Truncated at 1044480 bytes for the job-summary cap; the full text is in the `Update adoption wall` step log._
```

### Green — live

One `workflow_dispatch` on this branch. **This cannot reach `main`:** the auto-land push is `git push origin "HEAD:${GITHUB_REF_NAME}"`, and on a branch dispatch `GITHUB_REF_NAME` is this branch. The only ref named absolutely anywhere in the workflow is `refs/heads/adoption-data` (the orphan state branch, gated on `state_written`). Verified by reading both push sites. Run id and rendered Summary recorded in a comment below.

## A3 — the two comments that describe SAFE as additive-only

`classify()` ends `return { status: input.changed ? "SAFE" : "CLEAN", reasons, notes }` — reached only once no reason was pushed. So SAFE means *"the wall changed and no guardrail fired"*, which also covers reorders, star-driven reshuffles, avatar refreshes and **explained removals**. Both comments said the wall changed *additively*, which would have a reader believe a removal can never auto-land. It can.

**`scripts/update-adoption-wall.ts:95` — before**

```
 *   10 CHANGED_SAFE  — logos healthy, wall changed additively. Safe to push.
```

**after**

```
 *   10 CHANGED_SAFE  — logos healthy, the wall changed, and none of the
 *                      guardrails listed under 20 fired. Safe to push. This is
 *                      NOT "the wall only grew": classify() returns SAFE for any
 *                      change it found no reason to stop, which includes
 *                      reorders, star-driven reshuffles, avatar refreshes and
 *                      EXPLAINED removals. A removal can auto-land. See classify.
```

It now points at the guardrail enumeration immediately below it under `20 NEEDS_REVIEW`, which was already correct.

**`.github/workflows/update-adoption-wall.yml:380` — before**

```yaml
      # The whole point of the wall: a healthy, purely-additive refresh lands
      # itself. No weekly click.
```

**after**

```yaml
      # The whole point of the wall: a healthy refresh that tripped none of the
      # guardrails lands itself. No weekly click. SAFE is not "the wall only
      # grew" -- classify() returns it for any change no guardrail stopped, so
      # a reorder, an avatar refresh or an EXPLAINED removal auto-lands here too.
```

No runtime red-green applies — these are comments, and inventing a test for them would be theatre. The evidence that matters is that the replacement is *accurate against `classify()`*, cited above. The 11 other "additive" hits in the repo are about API back-compat and are untouched; so is the one at `:512`, which correctly says two open PRs are not additive to each other.

## Gates — raw exit codes

| gate | rc |
| --- | --- |
| `prettier --check .` | 0 |
| `npx eslint .` | 0 |
| `npx tsc --noEmit` | 0 |
| `npx tsc -p scripts/tsconfig.json --noEmit` | 0 |
| `npx vitest run` | 0 — 5592 passed, 46 skipped (5638), 179 files |
| `actionlint .github/workflows/update-adoption-wall.yml` | 0 |
| `npx commitlint --from origin/main --to HEAD` | 0 |
