### PR TITLE
ci: typecheck the test tree too (C-03)

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "test": "vitest run",
     "test:drift": "vitest run --config vitest.config.drift.ts",
     "test:exports": "publint && attw --pack .",
-    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p scripts/tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit && tsc -p scripts/tsconfig.json --noEmit",
     "lint": "eslint .",
     "format:check": "prettier --check .",
     "release": "pnpm format:check && pnpm typecheck && pnpm build && pnpm test && pnpm lint && pnpm test:exports && npm publish",

--- a/src/__tests__/agui-mock.test.ts
+++ b/src/__tests__/agui-mock.test.ts
@@ -3,7 +3,7 @@ import * as http from "node:http";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { AGUIEvent, AGUIRunAgentInput, AGUITokenUsage } from "../agui-types.js";
+import type { AGUIEvent, AGUIMessage, AGUIRunAgentInput, AGUITokenUsage } from "../agui-types.js";
 import { AGUIMock } from "../agui-mock.js";
 import {
   buildTextResponse,
@@ -257,9 +257,9 @@ describe("AGUIMock core", () => {
 
   it("6. messages snapshot", async () => {
     agui = new AGUIMock({ port: 0 });
-    const msgs = [
-      { role: "user", content: "hi" },
-      { role: "assistant", content: "hello" },
+    const msgs: AGUIMessage[] = [
+      { id: "m1", role: "user", content: "hi" },
+      { id: "m2", role: "assistant", content: "hello" },
     ];
     const events = buildMessagesSnapshot(msgs);
     agui.addFixture({
@@ -482,7 +482,7 @@ describe("AGUIMock builders", () => {
     expect(delta.map((e) => e.type)).toEqual(["RUN_STARTED", "STATE_DELTA", "RUN_FINISHED"]);
 
     // buildMessagesSnapshot
-    const msgs = buildMessagesSnapshot([{ role: "user", content: "hi" }]);
+    const msgs = buildMessagesSnapshot([{ id: "m1", role: "user", content: "hi" }]);
     expect(msgs.map((e) => e.type)).toEqual(["RUN_STARTED", "MESSAGES_SNAPSHOT", "RUN_FINISHED"]);
 
     // buildErrorResponse
@@ -1477,6 +1477,8 @@ describe("extractLastUserMessage", () => {
   it("returns plain string content verbatim", () => {
     expect(
       extractLastUserMessage({
+        threadId: "t1",
+        runId: "r1",
         messages: [{ id: "1", role: "user", content: "hello" }],
       }),
     ).toBe("hello");
@@ -1485,6 +1487,8 @@ describe("extractLastUserMessage", () => {
   it("returns text from a single-part array", () => {
     expect(
       extractLastUserMessage({
+        threadId: "t1",
+        runId: "r1",
         messages: [{ id: "1", role: "user", content: [{ type: "text", text: "hello" }] }],
       }),
     ).toBe("hello");
@@ -1493,6 +1497,8 @@ describe("extractLastUserMessage", () => {
   it("joins multiple text parts with a single space", () => {
     expect(
       extractLastUserMessage({
+        threadId: "t1",
+        runId: "r1",
         messages: [
           {
             id: "1",
@@ -1510,6 +1516,8 @@ describe("extractLastUserMessage", () => {
   it("extracts only text parts when mixed with non-text parts (e.g. file attachments)", () => {
     expect(
       extractLastUserMessage({
+        threadId: "t1",
+        runId: "r1",
         messages: [
           {
             id: "1",
@@ -1530,6 +1538,8 @@ describe("extractLastUserMessage", () => {
   it("returns empty string when content has no text parts", () => {
     expect(
       extractLastUserMessage({
+        threadId: "t1",
+        runId: "r1",
         messages: [
           {
             id: "1",
@@ -1549,6 +1559,8 @@ describe("extractLastUserMessage", () => {
   it("ignores non-text parts that happen to carry a 'text' field", () => {
     expect(
       extractLastUserMessage({
+        threadId: "t1",
+        runId: "r1",
         messages: [
           {
             id: "1",
@@ -1563,6 +1575,8 @@ describe("extractLastUserMessage", () => {
   it("returns the last user turn's text when multiple user turns exist", () => {
     expect(
       extractLastUserMessage({
+        threadId: "t1",
+        runId: "r1",
         messages: [
           { id: "1", role: "user", content: "first" },
           { id: "2", role: "assistant", content: "ack" },
@@ -1575,6 +1589,8 @@ describe("extractLastUserMessage", () => {
   it("skips non-user roles even when they have text content", () => {
     expect(
       extractLastUserMessage({
+        threadId: "t1",
+        runId: "r1",
         messages: [
           { id: "1", role: "user", content: "real user message" },
           { id: "2", role: "assistant", content: "assistant turn" },
@@ -1584,13 +1600,15 @@ describe("extractLastUserMessage", () => {
   });
 
   it("returns empty string for empty or missing messages", () => {
-    expect(extractLastUserMessage({ messages: [] })).toBe("");
+    expect(extractLastUserMessage({ threadId: "t1", runId: "r1", messages: [] })).toBe("");
     expect(extractLastUserMessage({} as AGUIRunAgentInput)).toBe("");
   });
 
   it("returns empty string when user message content is undefined", () => {
     expect(
       extractLastUserMessage({
+        threadId: "t1",
+        runId: "r1",
         messages: [{ id: "1", role: "user" }],
       }),
     ).toBe("");
@@ -1650,7 +1668,7 @@ describe("AGUIMock recorder — structured user content", () => {
           ],
         },
       ],
-    } as AGUIRunAgentInput);
+    });
     expect(resp.status).toBe(200);
 
     const files = fs.readdirSync(tmpDir);
@@ -1670,6 +1688,8 @@ describe("AGUIMock recorder — structured user content", () => {
     await agui.start();
 
     const resp = await post(agui.url, {
+      threadId: "t1",
+      runId: "r1",
       messages: [
         {
           id: "u1",
@@ -1682,13 +1702,15 @@ describe("AGUIMock recorder — structured user content", () => {
           ],
         },
       ],
-    } as AGUIRunAgentInput);
+    });
     expect(resp.status).toBe(200);
 
     const files = fs.readdirSync(tmpDir);
     expect(files.length).toBe(0);
 
     const resp2 = await post(agui.url, {
+      threadId: "t2",
+      runId: "r2",
       messages: [
         {
           id: "u2",
@@ -1701,7 +1723,7 @@ describe("AGUIMock recorder — structured user content", () => {
           ],
         },
       ],
-    } as AGUIRunAgentInput);
+    });
     expect(resp2.status).toBe(200);
   });
 });

--- a/src/__tests__/api-key-auth.test.ts
+++ b/src/__tests__/api-key-auth.test.ts
@@ -105,11 +105,12 @@ describe("API key HTTP boundary", () => {
       [{ match: { userMessage: "hello" }, response: { content: "ok" } }],
       { auth: { apiKeys: ["primary", "rotated"] } },
     );
-    for (const headers of [
+    const rejectedHeaderSets: Record<string, string>[] = [
       {},
       { Authorization: "Bearer wrong" },
       { Authorization: "Bearer primary", "X-Api-Key": "rotated" },
-    ]) {
+    ];
+    for (const headers of rejectedHeaderSets) {
       const result = await request(`${instance.url}/v1/chat/completions`, headers);
       expect(result.status).toBe(401);
       expect(result.body).toBe(
@@ -124,7 +125,7 @@ describe("API key HTTP boundary", () => {
       [{ match: { userMessage: "hello" }, response: { content: "ok" } }],
       { auth: { apiKeys: ["primary"] } },
     );
-    for (const headers of [
+    const acceptedHeaderSets: Record<string, string>[] = [
       { Authorization: "Bearer primary" },
       { Authorization: "Key primary" },
       { Authorization: "bearer primary" },
@@ -133,7 +134,8 @@ describe("API key HTTP boundary", () => {
       { "X-Goog-Api-Key": "primary" },
       { "Api-Key": "primary" },
       { "Xi-Api-Key": "primary" },
-    ])
+    ];
+    for (const headers of acceptedHeaderSets)
       expect((await request(`${instance.url}/v1/chat/completions`, headers)).status).toBe(200);
     expect((await request(`${instance.url}/health`, {}, "GET")).status).toBe(200);
   });

--- a/src/__tests__/bedrock.test.ts
+++ b/src/__tests__/bedrock.test.ts
@@ -281,7 +281,7 @@ describe("POST /model/{modelId}/invoke (journal)", () => {
     expect(entry!.path).toBe("/model/anthropic.claude-3-5-sonnet-20241022-v2:0/invoke");
     expect(entry!.response.status).toBe(200);
     expect(entry!.response.fixture).toBe(textFixture);
-    expect(entry!.body.model).toBe("anthropic.claude-3-5-sonnet-20241022-v2:0");
+    expect(entry!.body!.model).toBe("anthropic.claude-3-5-sonnet-20241022-v2:0");
   });
 });
 

--- a/src/__tests__/cohere.test.ts
+++ b/src/__tests__/cohere.test.ts
@@ -954,7 +954,7 @@ describe("POST /v2/chat (journal)", () => {
     expect(entry!.path).toBe("/v2/chat");
     expect(entry!.response.status).toBe(200);
     expect(entry!.response.fixture).toBe(textFixture);
-    expect(entry!.body.model).toBe("command-r-plus");
+    expect(entry!.body!.model).toBe("command-r-plus");
   });
 });
 
@@ -1194,6 +1194,7 @@ function createDefaults(overrides: Partial<HandlerDefaults> = {}): HandlerDefaul
   return {
     latency: 0,
     chunkSize: 100,
+    replaySpeed: 1,
     logger: new Logger("silent"),
     ...overrides,
   };

--- a/src/__tests__/competitive-matrix.test.ts
+++ b/src/__tests__/competitive-matrix.test.ts
@@ -16,7 +16,7 @@ import {
   applyChanges,
   COMPETITOR_MIGRATION_PAGES,
   type DetectedChange,
-} from "../../scripts/update-competitive-matrix.ts";
+} from "../../scripts/update-competitive-matrix.js";
 
 // Repo root: this file lives at <root>/src/__tests__/, so up two levels.
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -140,12 +140,12 @@ describe("C4: checkDeprecatedFamiliesLive (infra-error short-circuit via isInfra
 
 describe("C4: isFamilyStillReferenced (real source-tree ref-scan, zero-LLM)", () => {
   it("finds a real reference (gpt-4 and gpt-4o are both referenced in src/server.ts)", () => {
-    expect(isFamilyStillReferenced("gpt-4", "openai")).toBe(true);
-    expect(isFamilyStillReferenced("gpt-4o", "openai")).toBe(true);
+    expect(isFamilyStillReferenced("gpt-4")).toBe(true);
+    expect(isFamilyStillReferenced("gpt-4o")).toBe(true);
   });
 
   it("reports zero-reference for a synthetic family that appears nowhere in src/", () => {
-    expect(isFamilyStillReferenced("zzz-totally-fictional-family-not-real", "openai")).toBe(false);
+    expect(isFamilyStillReferenced("zzz-totally-fictional-family-not-real")).toBe(false);
   });
 
   it("does not false-positive from being a strict substring of a longer live id", () => {
@@ -154,7 +154,7 @@ describe("C4: isFamilyStillReferenced (real source-tree ref-scan, zero-LLM)", ()
     // not confuse the two. gpt-4 IS separately, exactly referenced in
     // DEFAULT_MODELS (asserted above) — this confirms the match is a real
     // boundary hit, not a substring artifact.
-    expect(isFamilyStillReferenced("gpt-4-turbo-nonexistent-suffix", "openai")).toBe(false);
+    expect(isFamilyStillReferenced("gpt-4-turbo-nonexistent-suffix")).toBe(false);
   });
 });
 

--- a/src/__tests__/embeddings.test.ts
+++ b/src/__tests__/embeddings.test.ts
@@ -774,11 +774,16 @@ function createMockRes(): http.ServerResponse {
     headers[name.toLowerCase()] = String(value);
     return res;
   };
-  res.writeHead = (statusCode: number, hdrs?: Record<string, string>) => {
+  res.writeHead = (
+    statusCode: number,
+    arg1?: string | http.OutgoingHttpHeaders | http.OutgoingHttpHeader[],
+    arg2?: http.OutgoingHttpHeaders | http.OutgoingHttpHeader[],
+  ) => {
     (res as { statusCode: number }).statusCode = statusCode;
-    if (hdrs) {
+    const hdrs = typeof arg1 === "string" ? arg2 : arg1;
+    if (hdrs && !Array.isArray(hdrs)) {
       for (const [k, v] of Object.entries(hdrs)) {
-        headers[k.toLowerCase()] = v;
+        headers[k.toLowerCase()] = String(v);
       }
     }
     return res;
@@ -802,7 +807,7 @@ describe("handleEmbeddings (direct call — ?? fallback branches)", () => {
   it("uses fallback POST and /v1/embeddings when req.method and req.url are undefined", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -834,7 +839,7 @@ describe("handleEmbeddings (direct call — ?? fallback branches)", () => {
   it("uses fallback method/path on malformed JSON with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -855,7 +860,7 @@ describe("handleEmbeddings (direct call — ?? fallback branches)", () => {
   it("uses fallback for strict mode with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger, strict: true };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger, strict: true };
 
     const mockReq = {
       method: undefined,
@@ -887,7 +892,7 @@ describe("handleEmbeddings (direct call — ?? fallback branches)", () => {
   it("uses fallback for error fixture with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const errorFixture: Fixture = {
       match: { inputText: "err" },
@@ -927,7 +932,7 @@ describe("handleEmbeddings (direct call — ?? fallback branches)", () => {
   it("uses fallback for embedding fixture with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const embFixture: Fixture = {
       match: { inputText: "embed" },
@@ -964,7 +969,7 @@ describe("handleEmbeddings (direct call — ?? fallback branches)", () => {
   it("uses fallback for incompatible fixture response with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const badFixture: Fixture = {
       match: { predicate: () => true },

--- a/src/__tests__/fal-audio.test.ts
+++ b/src/__tests__/fal-audio.test.ts
@@ -295,7 +295,7 @@ describe("fal.ai audio queue — record walk (round 5)", () => {
     // the synthesized envelope's headers have not been sent when
     // persistFixture fails, so the failure can ride the response.
     let selfUrl = "http://stub";
-    upstream = await new Promise((resolve, reject) => {
+    upstream = await new Promise<{ url: string; close: () => Promise<void> }>((resolve, reject) => {
       const server = http.createServer((req, res) => {
         const chunks: Buffer[] = [];
         req.on("data", (c: Buffer) => chunks.push(c));

--- a/src/__tests__/fal.test.ts
+++ b/src/__tests__/fal.test.ts
@@ -685,7 +685,7 @@ describe("fal.ai general handler — record and replay", () => {
     // so a bogus host would fail on DNS/connect instead of exercising the
     // intended status-500 branch (round-4 B8).
     let selfUrl = "http://stub";
-    upstream = await new Promise((resolve, reject) => {
+    upstream = await new Promise<{ url: string; close: () => Promise<void> }>((resolve, reject) => {
       const server = http.createServer((req, res) => {
         const chunks: Buffer[] = [];
         req.on("data", (c: Buffer) => chunks.push(c));
@@ -776,42 +776,44 @@ describe("fal.ai general handler — record and replay", () => {
       // Real upstream: the submit envelope nominates the EVIL host; the
       // constructed canonical paths on this origin serve the true lifecycle.
       let selfUrl = "http://stub";
-      upstream = await new Promise((resolve, reject) => {
-        const server = http.createServer((req, res) => {
-          const chunks: Buffer[] = [];
-          req.on("data", (c: Buffer) => chunks.push(c));
-          req.on("end", () => {
-            const url = new URL(req.url ?? "/", selfUrl);
-            const send = (status: number, body: unknown): void => {
-              res.writeHead(status, { "Content-Type": "application/json" });
-              res.end(JSON.stringify(body));
-            };
-            if (req.method === "POST") {
-              send(200, {
-                request_id: "r-a6",
-                status_url: `${evilUrl}/hijacked/requests/r-a6/status`,
-                response_url: `${evilUrl}/hijacked/requests/r-a6`,
-                status: "IN_QUEUE",
-              });
-              return;
-            }
-            if (url.pathname.endsWith("/status")) {
-              send(200, { status: "COMPLETED", request_id: "r-a6" });
-              return;
-            }
-            send(200, FINAL_BODY);
+      upstream = await new Promise<{ url: string; close: () => Promise<void> }>(
+        (resolve, reject) => {
+          const server = http.createServer((req, res) => {
+            const chunks: Buffer[] = [];
+            req.on("data", (c: Buffer) => chunks.push(c));
+            req.on("end", () => {
+              const url = new URL(req.url ?? "/", selfUrl);
+              const send = (status: number, body: unknown): void => {
+                res.writeHead(status, { "Content-Type": "application/json" });
+                res.end(JSON.stringify(body));
+              };
+              if (req.method === "POST") {
+                send(200, {
+                  request_id: "r-a6",
+                  status_url: `${evilUrl}/hijacked/requests/r-a6/status`,
+                  response_url: `${evilUrl}/hijacked/requests/r-a6`,
+                  status: "IN_QUEUE",
+                });
+                return;
+              }
+              if (url.pathname.endsWith("/status")) {
+                send(200, { status: "COMPLETED", request_id: "r-a6" });
+                return;
+              }
+              send(200, FINAL_BODY);
+            });
           });
-        });
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => {
-          const { port } = server.address() as { port: number };
-          selfUrl = `http://127.0.0.1:${port}`;
-          resolve({
-            url: selfUrl,
-            close: () => new Promise<void>((r) => server.close(() => r())),
+          server.once("error", reject);
+          server.listen(0, "127.0.0.1", () => {
+            const { port } = server.address() as { port: number };
+            selfUrl = `http://127.0.0.1:${port}`;
+            resolve({
+              url: selfUrl,
+              close: () => new Promise<void>((r) => server.close(() => r())),
+            });
           });
-        });
-      });
+        },
+      );
       tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aimock-fal-a6-"));
       mock = new LLMock({
         port: 0,
@@ -894,7 +896,7 @@ describe("fal.ai general handler — record and replay", () => {
     // existing 502/no-fixture failure handling.
     let selfUrl = "http://stub";
     const sockets = new Set<net.Socket>();
-    upstream = await new Promise((resolve, reject) => {
+    upstream = await new Promise<{ url: string; close: () => Promise<void> }>((resolve, reject) => {
       const server = http.createServer((req, res) => {
         const chunks: Buffer[] = [];
         req.on("data", (c: Buffer) => chunks.push(c));
@@ -998,7 +1000,7 @@ describe("fal.ai general handler — record and replay", () => {
     // JSON.parse("null") passes parseJsonOrThrow — the walk must reject the
     // non-object shape itself instead of TypeError-ing on env.request_id.
     let selfUrl = "http://stub";
-    upstream = await new Promise((resolve, reject) => {
+    upstream = await new Promise<{ url: string; close: () => Promise<void> }>((resolve, reject) => {
       const server = http.createServer((req, res) => {
         req.resume();
         req.on("end", () => {

--- a/src/__tests__/fix-drift.test.ts
+++ b/src/__tests__/fix-drift.test.ts
@@ -99,6 +99,19 @@ function makeEntry(overrides: Partial<DriftEntry> = {}): DriftEntry {
   };
 }
 
+/**
+ * The `readDriftReport` validation tests deliberately poke values that
+ * `DriftEntry` forbids, to prove the reader rejects malformed reports.
+ * `DriftEntry` is an interface, so it carries no implicit index signature and
+ * cannot be narrowed to `Record<string, unknown>` directly. Widening through
+ * `object` — which every interface is assignable to — keeps that reinterpretation
+ * in exactly one place instead of at each mutation site, and it returns the SAME
+ * object so the mutation is visible on the enclosing report.
+ */
+function looseEntry(entry: object): Record<string, unknown> {
+  return entry as Record<string, unknown>;
+}
+
 function makeReport(overrides: Partial<DriftReport> = {}): DriftReport {
   return {
     timestamp: "2026-03-19T00:00:00.000Z",
@@ -178,7 +191,7 @@ describe("readDriftReport", () => {
 
   it("throws when entry is missing provider", () => {
     const report = makeReport();
-    (report.entries[0] as Record<string, unknown>).provider = "";
+    looseEntry(report.entries[0]).provider = "";
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockReturnValue(JSON.stringify(report));
 
@@ -189,7 +202,7 @@ describe("readDriftReport", () => {
 
   it("throws when entry has no diffs array", () => {
     const report = makeReport();
-    (report.entries[0] as Record<string, unknown>).diffs = "not-array";
+    looseEntry(report.entries[0]).diffs = "not-array";
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockReturnValue(JSON.stringify(report));
 
@@ -212,7 +225,7 @@ describe("readDriftReport", () => {
 
   it("throws when entry is missing builderFile", () => {
     const report = makeReport();
-    (report.entries[0] as Record<string, unknown>).builderFile = "";
+    looseEntry(report.entries[0]).builderFile = "";
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockReturnValue(JSON.stringify(report));
 
@@ -232,7 +245,7 @@ describe("readDriftReport", () => {
 
   it("throws when builderFunctions contains non-string elements", () => {
     const report = makeReport();
-    (report.entries[0] as Record<string, unknown>).builderFunctions = ["valid", 42];
+    looseEntry(report.entries[0]).builderFunctions = ["valid", 42];
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockReturnValue(JSON.stringify(report));
 
@@ -243,7 +256,7 @@ describe("readDriftReport", () => {
 
   it("throws when entry is missing scenario", () => {
     const report = makeReport();
-    (report.entries[0] as Record<string, unknown>).scenario = 123;
+    looseEntry(report.entries[0]).scenario = 123;
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockReturnValue(JSON.stringify(report));
 
@@ -252,7 +265,7 @@ describe("readDriftReport", () => {
 
   it("throws when entry is missing sdkShapesFile", () => {
     const report = makeReport();
-    (report.entries[0] as Record<string, unknown>).sdkShapesFile = "";
+    looseEntry(report.entries[0]).sdkShapesFile = "";
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockReturnValue(JSON.stringify(report));
 
@@ -261,7 +274,7 @@ describe("readDriftReport", () => {
 
   it("throws when typesFile is not a string or null", () => {
     const report = makeReport();
-    (report.entries[0] as Record<string, unknown>).typesFile = 42;
+    looseEntry(report.entries[0]).typesFile = 42;
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockReturnValue(JSON.stringify(report));
 

--- a/src/__tests__/fixture-blocks-responses.test.ts
+++ b/src/__tests__/fixture-blocks-responses.test.ts
@@ -79,8 +79,8 @@ describe("OpenAI Responses API — fixture block ordering (#274)", () => {
     );
     expect(fcAdded).toBeDefined();
     expect(msgAdded).toBeDefined();
-    expect((fcAdded as { output_index: number }).output_index).toBe(0);
-    expect((msgAdded as { output_index: number }).output_index).toBe(1);
+    expect(fcAdded!.output_index).toBe(0);
+    expect(msgAdded!.output_index).toBe(1);
 
     // The final completed.output array must lead with the function_call item.
     const completed = events.find((e) => e.type === "response.completed");
@@ -135,8 +135,8 @@ describe("OpenAI Responses API — fixture block ordering (#274)", () => {
         (e.item as { type: string })?.type === "function_call",
     );
     // Legacy hardcoding: message at index 0, function_call at index 1.
-    expect((msgAdded as { output_index: number }).output_index).toBe(0);
-    expect((fcAdded as { output_index: number }).output_index).toBe(1);
+    expect(msgAdded!.output_index).toBe(0);
+    expect(fcAdded!.output_index).toBe(1);
 
     const completed = events.find((e) => e.type === "response.completed");
     const output = (completed!.response as { output: Array<{ type: string }> }).output;

--- a/src/__tests__/fixture-loader.test.ts
+++ b/src/__tests__/fixture-loader.test.ts
@@ -31,6 +31,15 @@ vi.mock("node:fs", async (importOriginal) => {
   };
 });
 
+/**
+ * `vi.spyOn(console, "warn")` replaces the method in place, so the only handle
+ * these afterEach hooks have is `console.warn` itself. Narrow it through a type
+ * guard rather than asserting across the overloaded `Console["warn"]` signature.
+ */
+function isRestorableSpy(fn: unknown): fn is { mockRestore: () => void } {
+  return typeof fn === "function" && "mockRestore" in fn;
+}
+
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), "fixture-loader-test-"));
 }
@@ -52,8 +61,9 @@ describe("loadFixtureFile", () => {
     // Restore console spies that individual tests create via vi.spyOn(console, "warn").
     // We cannot use vi.restoreAllMocks() here because the top-level vi.mock("node:fs")
     // overrides would also be wiped, breaking subsequent tests.
-    if ("mockRestore" in console.warn) {
-      (console.warn as ReturnType<typeof vi.spyOn>).mockRestore();
+    const warn: unknown = console.warn;
+    if (isRestorableSpy(warn)) {
+      warn.mockRestore();
     }
     rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -395,8 +405,9 @@ describe("loadFixturesFromDir", () => {
     // Restore console spies that individual tests create via vi.spyOn(console, "warn").
     // We cannot use vi.restoreAllMocks() here because the top-level vi.mock("node:fs")
     // overrides would also be wiped, breaking subsequent tests.
-    if ("mockRestore" in console.warn) {
-      (console.warn as ReturnType<typeof vi.spyOn>).mockRestore();
+    const warn: unknown = console.warn;
+    if (isRestorableSpy(warn)) {
+      warn.mockRestore();
     }
     rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -2055,7 +2066,7 @@ describe("auto-stringify JSON objects in fixture entries", () => {
     const fixture = entryToFixture(entry);
     const resp = fixture.response as ContentWithToolCallsResponse;
     expect(resp.content).toBe('{"summary":"done"}');
-    expect(resp.toolCalls[0].arguments).toBe('{"id":1}');
+    expect(resp.toolCalls![0].arguments).toBe('{"id":1}');
   });
 
   it("preserves ResponseOverrides fields through normalization", () => {
@@ -2177,7 +2188,7 @@ describe("auto-stringify JSON objects in fixture entries", () => {
     };
     // Serialize -> parse (same as writing JSON to disk and reading it back)
     const parsed = JSON.parse(JSON.stringify(fixtureData)) as { fixtures: FixtureFileEntry[] };
-    const fixtures = parsed.fixtures.map(entryToFixture);
+    const fixtures = parsed.fixtures.map((entry) => entryToFixture(entry));
 
     expect(fixtures).toHaveLength(2);
 

--- a/src/__tests__/gemini.test.ts
+++ b/src/__tests__/gemini.test.ts
@@ -847,7 +847,7 @@ describe("Gemini routing", () => {
 
     const entry = instance.journal.getLast();
     expect(entry).not.toBeNull();
-    expect(entry!.body.model).toBe("gemini-1.5-pro");
+    expect(entry!.body!.model).toBe("gemini-1.5-pro");
   });
 });
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -357,14 +357,14 @@ describe("integration: journal verification", () => {
     // First entry
     expect(entries[0].method).toBe("POST");
     expect(entries[0].path).toBe("/v1/chat/completions");
-    expect(entries[0].body.messages[0].content).toBe("first message");
+    expect(entries[0].body!.messages[0].content).toBe("first message");
     expect(entries[0].response.status).toBe(200);
     expect(entries[0].response.fixture).not.toBeNull();
     expect(entries[0].id).toBeTruthy();
     expect(entries[0].timestamp).toBeGreaterThan(0);
 
     // Second entry
-    expect(entries[1].body.messages[0].content).toBe("second message");
+    expect(entries[1].body!.messages[0].content).toBe("second message");
     expect(entries[1].response.status).toBe(200);
 
     // Journal also records unmatched requests

--- a/src/__tests__/jsonrpc.test.ts
+++ b/src/__tests__/jsonrpc.test.ts
@@ -13,23 +13,24 @@ function makeReqRes(): {
   };
 } {
   const req = Object.create(http.IncomingMessage.prototype) as http.IncomingMessage;
-  const res = {
-    _statusCode: 0,
-    _headers: {} as Record<string, string>,
-    _body: "",
-    writeHead(statusCode: number, headers?: Record<string, string>) {
-      this._statusCode = statusCode;
-      if (headers) Object.assign(this._headers, headers);
-      return this;
-    },
-    end(body?: string) {
-      if (body !== undefined) this._body = body;
-    },
-  } as unknown as http.ServerResponse & {
+  type Captured = {
     _statusCode: number;
     _headers: Record<string, string>;
     _body: string;
   };
+  const res = {
+    _statusCode: 0,
+    _headers: {} as Record<string, string>,
+    _body: "",
+    writeHead(this: Captured, statusCode: number, headers?: Record<string, string>) {
+      this._statusCode = statusCode;
+      if (headers) Object.assign(this._headers, headers);
+      return this;
+    },
+    end(this: Captured, body?: string) {
+      if (body !== undefined) this._body = body;
+    },
+  } as unknown as http.ServerResponse & Captured;
   return { req, res };
 }
 

--- a/src/__tests__/llmock.test.ts
+++ b/src/__tests__/llmock.test.ts
@@ -141,8 +141,9 @@ describe("LLMock", () => {
     });
 
     it("addFixturesFromJSON throws a contextful error on malformed JSON", () => {
-      mock = new LLMock();
-      expect(() => mock.addFixturesFromJSON("{ not valid json")).toThrow(/addFixturesFromJSON/);
+      const m = new LLMock();
+      mock = m;
+      expect(() => m.addFixturesFromJSON("{ not valid json")).toThrow(/addFixturesFromJSON/);
     });
 
     it("chaining API works across multiple calls", () => {
@@ -474,7 +475,7 @@ describe("LLMock", () => {
       expect(mock.journal.size).toBe(1);
       const entry = mock.journal.getLast();
       expect(entry).not.toBeNull();
-      expect(entry!.body.messages[0].content).toBe("journal-test");
+      expect(entry!.body!.messages[0].content).toBe("journal-test");
     });
   });
 
@@ -909,7 +910,7 @@ describe("LLMock", () => {
 
       const last = mock.getLastRequest();
       expect(last).not.toBeNull();
-      expect(last!.body.messages[0].content).toBe("b");
+      expect(last!.body!.messages[0].content).toBe("b");
     });
 
     it("getLastRequest returns null when no requests", async () => {

--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -760,8 +760,8 @@ describe("POST /v1/messages (journal)", () => {
     });
 
     const entry = instance.journal.getLast();
-    expect(entry!.body.model).toBe("claude-3-5-sonnet-20241022");
-    expect(entry!.body.messages).toEqual([
+    expect(entry!.body!.model).toBe("claude-3-5-sonnet-20241022");
+    expect(entry!.body!.messages).toEqual([
       { role: "system", content: "Be nice" },
       { role: "user", content: "hello" },
     ]);
@@ -1476,11 +1476,16 @@ function createMockRes(): http.ServerResponse {
     headers[name.toLowerCase()] = String(value);
     return res;
   };
-  res.writeHead = (statusCode: number, hdrs?: Record<string, string>) => {
+  res.writeHead = (
+    statusCode: number,
+    arg1?: string | http.OutgoingHttpHeaders | http.OutgoingHttpHeader[],
+    arg2?: http.OutgoingHttpHeaders | http.OutgoingHttpHeader[],
+  ) => {
     (res as { statusCode: number }).statusCode = statusCode;
-    if (hdrs) {
+    const hdrs = typeof arg1 === "string" ? arg2 : arg1;
+    if (hdrs && !Array.isArray(hdrs)) {
       for (const [k, v] of Object.entries(hdrs)) {
-        headers[k.toLowerCase()] = v;
+        headers[k.toLowerCase()] = String(v);
       }
     }
     return res;
@@ -1504,7 +1509,7 @@ describe("handleMessages (direct call — ?? fallback branches)", () => {
   it("uses fallback POST and /v1/messages when req.method and req.url are undefined", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1537,7 +1542,7 @@ describe("handleMessages (direct call — ?? fallback branches)", () => {
   it("uses fallback method/path on malformed JSON with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1558,7 +1563,7 @@ describe("handleMessages (direct call — ?? fallback branches)", () => {
   it("uses fallback method/path on no-match with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1591,7 +1596,7 @@ describe("handleMessages (direct call — ?? fallback branches)", () => {
   it("uses fallback for error fixture with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1624,7 +1629,7 @@ describe("handleMessages (direct call — ?? fallback branches)", () => {
   it("uses fallback for streaming text with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1658,7 +1663,7 @@ describe("handleMessages (direct call — ?? fallback branches)", () => {
   it("uses fallback for streaming tool call with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1692,7 +1697,7 @@ describe("handleMessages (direct call — ?? fallback branches)", () => {
   it("uses fallback for unknown response type with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1725,7 +1730,7 @@ describe("handleMessages (direct call — ?? fallback branches)", () => {
   it("uses fallback for strict mode no-match with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger, strict: true };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger, strict: true };
 
     const mockReq = {
       method: undefined,

--- a/src/__tests__/mount.test.ts
+++ b/src/__tests__/mount.test.ts
@@ -304,8 +304,8 @@ describe("Mountable interface", () => {
 
     it("journal entry can include service field", async () => {
       // Create a mount that writes a journal entry with service field
-      const serviceMount: Mountable = {
-        journal: null as Journal | null,
+      const serviceMount: Mountable & { journal: Journal | null } = {
+        journal: null,
         /* eslint-disable @typescript-eslint/no-unused-vars */
         async handleRequest(
           req: http.IncomingMessage,

--- a/src/__tests__/ollama.test.ts
+++ b/src/__tests__/ollama.test.ts
@@ -445,6 +445,7 @@ describe("POST /api/chat (streaming)", () => {
     const chunks = parseNDJSON(res.body) as Array<{
       message: { tool_calls?: Array<{ function: { name: string; arguments: unknown } }> };
       done: boolean;
+      created_at: string;
     }>;
     const toolChunk = chunks.find((c) => c.message.tool_calls && c.message.tool_calls.length > 0);
     expect(toolChunk).toBeDefined();
@@ -453,7 +454,7 @@ describe("POST /api/chat (streaming)", () => {
 
     // All chunks should have created_at
     for (const chunk of chunks) {
-      expect((chunk as { created_at: string }).created_at).toEqual(expect.any(String));
+      expect(chunk.created_at).toEqual(expect.any(String));
     }
   });
 
@@ -899,7 +900,7 @@ describe("POST /api/chat (journal)", () => {
     expect(entry!.path).toBe("/api/chat");
     expect(entry!.response.status).toBe(200);
     expect(entry!.response.fixture).toBe(textFixture);
-    expect(entry!.body.model).toBe("llama3");
+    expect(entry!.body!.model).toBe("llama3");
   });
 });
 
@@ -1426,6 +1427,7 @@ function createDefaults(overrides: Partial<HandlerDefaults> = {}): HandlerDefaul
   return {
     latency: 0,
     chunkSize: 100,
+    replaySpeed: 1,
     logger: new Logger("silent"),
     ...overrides,
   };

--- a/src/__tests__/openrouter-video-record.test.ts
+++ b/src/__tests__/openrouter-video-record.test.ts
@@ -3523,7 +3523,7 @@ describe("OpenRouter video record — round 3 CR", () => {
     // pending resolves AFTER the fast poll's capture replaced the entry.
     let statusCalls = 0;
     let selfUrl = "http://stub";
-    rawUpstream = await new Promise((resolve) => {
+    rawUpstream = await new Promise<{ url: string; close: () => Promise<void> }>((resolve) => {
       const server = http.createServer((req, res) => {
         const url = new URL(req.url ?? "/", selfUrl);
         const sendJson = (status: number, body: unknown): void => {
@@ -4620,24 +4620,26 @@ describe("OpenRouter video record — round 6 CR", () => {
     // A pathological multi-megabyte "envelope" must not be buffered in full
     // and relayed — the bounded read refuses it and the synthesis serves.
     let selfUrl = "http://stub";
-    rawUpstream = await new Promise((resolve, reject) => {
-      const server = http.createServer((req, res) => {
-        req.resume();
-        req.on("end", () => {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ data: [{ id: "x".repeat(2 * 1024 * 1024) }] }));
+    rawUpstream = await new Promise<{ url: string; close: () => Promise<void> }>(
+      (resolve, reject) => {
+        const server = http.createServer((req, res) => {
+          req.resume();
+          req.on("end", () => {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ data: [{ id: "x".repeat(2 * 1024 * 1024) }] }));
+          });
         });
-      });
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        const { port } = server.address() as { port: number };
-        selfUrl = `http://127.0.0.1:${port}`;
-        resolve({
-          url: selfUrl,
-          close: () => new Promise<void>((r) => server.close(() => r())),
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          const { port } = server.address() as { port: number };
+          selfUrl = `http://127.0.0.1:${port}`;
+          resolve({
+            url: selfUrl,
+            close: () => new Promise<void>((r) => server.close(() => r())),
+          });
         });
-      });
-    });
+      },
+    );
     const m = await startMock(rawUpstream.url);
     m.addFixture({
       match: { userMessage: "synth model render", endpoint: "video", model: "synth/model-1" },

--- a/src/__tests__/recorder-path-traversal.test.ts
+++ b/src/__tests__/recorder-path-traversal.test.ts
@@ -32,7 +32,7 @@ describe("recorder context path traversal", () => {
     return {
       match: {
         userMessage: "hello",
-        endpoint: "/v1/chat/completions",
+        endpoint: "chat",
         context,
       },
       response: { content: "hi" },

--- a/src/__tests__/response-overrides.test.ts
+++ b/src/__tests__/response-overrides.test.ts
@@ -20,7 +20,7 @@ function parseSSEResponse(body: string): SSEChunk[] {
     .map((line) => JSON.parse(line.slice(6)));
 }
 
-function parseClaudeSSE(body: string): object[] {
+function parseClaudeSSE(body: string): Record<string, unknown>[] {
   return body
     .split("\n\n")
     .filter((line) => line.includes("data: "))
@@ -329,7 +329,7 @@ describe("response overrides: OpenAI Chat Completions (streaming)", () => {
     });
     const chunks = parseSSEResponse(res.body);
     for (const chunk of chunks) {
-      expect((chunk as Record<string, unknown>).system_fingerprint).toBe("fp_stream");
+      expect(chunk.system_fingerprint).toBe("fp_stream");
     }
   });
 });

--- a/src/__tests__/responses.test.ts
+++ b/src/__tests__/responses.test.ts
@@ -856,8 +856,8 @@ describe("POST /v1/responses (journal)", () => {
     });
 
     const entry = instance.journal.getLast();
-    expect(entry!.body.model).toBe("gpt-4");
-    expect(entry!.body.messages).toEqual([
+    expect(entry!.body!.model).toBe("gpt-4");
+    expect(entry!.body!.messages).toEqual([
       { role: "system", content: "Be nice" },
       { role: "user", content: "hello" },
     ]);
@@ -1248,11 +1248,16 @@ function createMockRes(): http.ServerResponse {
     headers[name.toLowerCase()] = String(value);
     return res;
   };
-  res.writeHead = (statusCode: number, hdrs?: Record<string, string>) => {
+  res.writeHead = (
+    statusCode: number,
+    arg1?: string | http.OutgoingHttpHeaders | http.OutgoingHttpHeader[],
+    arg2?: http.OutgoingHttpHeaders | http.OutgoingHttpHeader[],
+  ) => {
     (res as { statusCode: number }).statusCode = statusCode;
-    if (hdrs) {
+    const hdrs = typeof arg1 === "string" ? arg2 : arg1;
+    if (hdrs && !Array.isArray(hdrs)) {
       for (const [k, v] of Object.entries(hdrs)) {
-        headers[k.toLowerCase()] = v;
+        headers[k.toLowerCase()] = String(v);
       }
     }
     return res;
@@ -1276,7 +1281,7 @@ describe("handleResponses (direct call — ?? fallback branches)", () => {
   it("uses fallback POST and /v1/responses when req.method and req.url are undefined", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1308,7 +1313,7 @@ describe("handleResponses (direct call — ?? fallback branches)", () => {
   it("uses fallback method/path on malformed JSON with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1329,7 +1334,7 @@ describe("handleResponses (direct call — ?? fallback branches)", () => {
   it("uses fallback method/path on no-match with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1361,7 +1366,7 @@ describe("handleResponses (direct call — ?? fallback branches)", () => {
   it("uses fallback method/path for error fixture with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1393,7 +1398,7 @@ describe("handleResponses (direct call — ?? fallback branches)", () => {
   it("uses fallback for streaming text with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1426,7 +1431,7 @@ describe("handleResponses (direct call — ?? fallback branches)", () => {
   it("uses fallback for streaming tool call with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1459,7 +1464,7 @@ describe("handleResponses (direct call — ?? fallback branches)", () => {
   it("uses fallback for unknown response type with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: undefined,
@@ -1491,7 +1496,7 @@ describe("handleResponses (direct call — ?? fallback branches)", () => {
   it("uses fallback for strict mode no-match with undefined req fields", async () => {
     const journal = new Journal();
     const logger = new Logger("silent");
-    const defaults = { latency: 0, chunkSize: 10, logger, strict: true };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger, strict: true };
 
     const mockReq = {
       method: undefined,
@@ -1605,7 +1610,7 @@ describe("Bug 2: output_text includes annotations: []", () => {
     const events = buildTextStreamEvents("Hello", "gpt-4", 100);
     const partAdded = events.find((e) => e.type === "response.content_part.added");
     expect(partAdded).toBeDefined();
-    const part = (partAdded as { part: { type: string; annotations: unknown[] } }).part;
+    const part = partAdded!.part as { type: string; annotations: unknown[] };
     expect(part.type).toBe("output_text");
     expect(part.annotations).toEqual([]);
   });
@@ -1614,8 +1619,7 @@ describe("Bug 2: output_text includes annotations: []", () => {
     const events = buildTextStreamEvents("Hello", "gpt-4", 100);
     const partDone = events.find((e) => e.type === "response.content_part.done");
     expect(partDone).toBeDefined();
-    const part = (partDone as { part: { type: string; text: string; annotations: unknown[] } })
-      .part;
+    const part = partDone!.part as { type: string; text: string; annotations: unknown[] };
     expect(part.type).toBe("output_text");
     expect(part.text).toBe("Hello");
     expect(part.annotations).toEqual([]);
@@ -1636,10 +1640,10 @@ describe("Bug 2: output_text includes annotations: []", () => {
     const events = buildTextStreamEvents("Hello", "gpt-4", 100);
     const completed = events.find((e) => e.type === "response.completed");
     expect(completed).toBeDefined();
-    const response = completed!.response as { output: { content: { annotations: unknown[] }[] }[] };
-    const msgOutput = response.output.find(
-      (o: { type?: string }) => (o as { type: string }).type === "message",
-    ) as { content: { annotations: unknown[] }[] };
+    const response = completed!.response as {
+      output: { type?: string; content: { annotations: unknown[] }[] }[];
+    };
+    const msgOutput = response.output.find((o) => o.type === "message")!;
     expect(msgOutput).toBeDefined();
     expect(msgOutput.content[0].annotations).toEqual([]);
   });
@@ -1669,7 +1673,7 @@ describe("Bug 2: output_text includes annotations: []", () => {
     );
     const partAdded = events.find((e) => e.type === "response.content_part.added");
     expect(partAdded).toBeDefined();
-    const part = (partAdded as { part: { annotations: unknown[] } }).part;
+    const part = partAdded!.part as { annotations: unknown[] };
     expect(part.annotations).toEqual([]);
   });
 });
@@ -2535,7 +2539,7 @@ describe("handleResponses debug logging", () => {
       debugMessages.push(String(args[0]));
       origDebug(...args);
     };
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: "POST",
@@ -2570,7 +2574,7 @@ describe("handleResponses debug logging", () => {
       debugMessages.push(String(args[0]));
       origDebug(...args);
     };
-    const defaults = { latency: 0, chunkSize: 10, logger };
+    const defaults = { latency: 0, chunkSize: 10, replaySpeed: 1, logger };
 
     const mockReq = {
       method: "POST",

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -729,7 +729,7 @@ describe("journal", () => {
     expect(entry).not.toBeNull();
     expect(entry!.method).toBe("POST");
     expect(entry!.path).toBe("/v1/chat/completions");
-    expect(entry!.body.model).toBe("gpt-4");
+    expect(entry!.body!.model).toBe("gpt-4");
     expect(entry!.response.status).toBe(200);
     expect(entry!.response.fixture).toBe(textFixture);
   });

--- a/src/__tests__/services.test.ts
+++ b/src/__tests__/services.test.ts
@@ -538,11 +538,11 @@ function createMockRes(): http.ServerResponse & { _status: number; _body: string
   }) as http.ServerResponse & { _status: number; _body: string };
   writable._status = 0;
   writable._body = "";
-  writable.writeHead = function (statusCode: number) {
+  writable.writeHead = function (this: typeof writable, statusCode: number) {
     this._status = statusCode;
     return this;
   } as unknown as typeof writable.writeHead;
-  writable.end = function (body?: string) {
+  writable.end = function (this: typeof writable, body?: string) {
     if (body) this._body = body;
     return this;
   } as unknown as typeof writable.end;

--- a/src/__tests__/sse-writer.test.ts
+++ b/src/__tests__/sse-writer.test.ts
@@ -58,7 +58,7 @@ function makeChunk(id: string, content: string): SSEChunk {
     object: "chat.completion.chunk",
     created: 1700000000,
     model: "gpt-4",
-    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+    choices: [{ index: 0, delta: { content }, logprobs: null, finish_reason: null }],
   };
 }
 

--- a/src/__tests__/streaming-physics.test.ts
+++ b/src/__tests__/streaming-physics.test.ts
@@ -48,7 +48,7 @@ function makeChunk(id: string, content: string): SSEChunk {
     object: "chat.completion.chunk",
     created: 1700000000,
     model: "gpt-4",
-    choices: [{ index: 0, delta: { content }, finish_reason: null }],
+    choices: [{ index: 0, delta: { content }, logprobs: null, finish_reason: null }],
   };
 }
 

--- a/src/__tests__/vertex-ai.test.ts
+++ b/src/__tests__/vertex-ai.test.ts
@@ -120,7 +120,7 @@ describe("Vertex AI: generateContent (non-streaming)", () => {
 
     const entry = instance.journal.getLast();
     expect(entry).not.toBeNull();
-    expect(entry!.body.model).toBe("gemini-1.5-pro");
+    expect(entry!.body!.model).toBe("gemini-1.5-pro");
   });
 
   it("returns tool call response with functionCall parts", async () => {

--- a/src/__tests__/ws-realtime.test.ts
+++ b/src/__tests__/ws-realtime.test.ts
@@ -1188,11 +1188,11 @@ describe("WebSocket /v1/realtime", () => {
 
   it("maps input_image to ChatMessage image_url format for fixture matching", async () => {
     // Use a predicate to verify the ChatMessage structure produced by realtimeItemsToMessages
-    let capturedMessages: unknown[] | null = null;
+    const captured: { messages: unknown[] | null } = { messages: null };
     const imageFixture: Fixture = {
       match: {
         predicate: (req) => {
-          capturedMessages = req.messages;
+          captured.messages = req.messages;
           // Match any request so we get a response
           const lastUser = req.messages.filter((m) => m.role === "user").pop();
           return !!lastUser;
@@ -1231,8 +1231,8 @@ describe("WebSocket /v1/realtime", () => {
     expect(textDelta!.delta).toContain("I see a cat.");
 
     // Verify the ChatMessage structure passed to fixture matching
-    expect(capturedMessages).not.toBeNull();
-    const userMsg = (capturedMessages as Record<string, unknown>[]).find((m) => m.role === "user");
+    expect(captured.messages).not.toBeNull();
+    const userMsg = (captured.messages as Record<string, unknown>[]).find((m) => m.role === "user");
     expect(userMsg).toBeDefined();
     // After mapping, content should be an array with text + image_url parts
     const content = userMsg!.content as Array<Record<string, unknown>>;
@@ -1912,7 +1912,7 @@ describe("WebSocket /v1/realtime", () => {
 
     const entry = instance.journal.getLast();
     expect(entry).not.toBeNull();
-    expect(entry!.body._endpointType).toBe("realtime");
+    expect(entry!.body!._endpointType).toBe("realtime");
 
     ws.close();
   });
@@ -1938,7 +1938,7 @@ describe("WebSocket /v1/realtime", () => {
 
     const entry = instance.journal.getLast();
     expect(entry).not.toBeNull();
-    expect(entry!.body._endpointType).toBe("realtime-transcription");
+    expect(entry!.body!._endpointType).toBe("realtime-transcription");
 
     ws.close();
   });
@@ -1964,7 +1964,7 @@ describe("WebSocket /v1/realtime", () => {
 
     const entry = instance.journal.getLast();
     expect(entry).not.toBeNull();
-    expect(entry!.body._endpointType).toBe("realtime-translation");
+    expect(entry!.body!._endpointType).toBe("realtime-translation");
 
     ws.close();
   });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "//": "Type coverage for the test tree. Extends the root project but drops rootDir, because tests legitimately import across into scripts/ (e.g. adoption-wall.test.ts -> scripts/update-adoption-wall.ts), which the root project's rootDir: \"src\" rejects with TS6059. Nothing is emitted from this project, so rootDir carries no meaning here.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src", "vitest.config.ts", "vitest.config.drift.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

`tsconfig.json` excludes `src/__tests__`, so the 180-file / 5,638-test suite has **never** been type-checked. The `typecheck` CI job added in #402 covers `src/` and `scripts/` only.

Removing the `exclude` line does not work. The root project pins `rootDir: "src"`, and tests import across into `scripts/` — that produces **11 `TS6059`** rootDir violations. This needed its own project, as the plan said.

## The tsconfig split

New `tsconfig.test.json`:
- `extends: "./tsconfig.json"` — same `strict`, same target/module/resolution, so the tests are held to the same bar as `src/`.
- `rootDir: "."` and `declaration: false` — both are emit-shape settings, and this project is `--noEmit`. Dropping `rootDir` is what removes the 11 `TS6059`s without weakening a single check.
- `include: ["src", "vitest.config.ts", "vitest.config.drift.ts"]`, `exclude: ["node_modules", "dist"]` — the tests are in, and the two vitest configs get covered for free.

`pnpm typecheck` now runs `tsc -p tsconfig.json && tsc -p tsconfig.test.json && tsc -p scripts/tsconfig.json`. **No workflow change** — the existing `typecheck` job already runs `pnpm typecheck`.

Program membership, not just a green exit: `tsc -p tsconfig.test.json --listFiles | grep -c src/__tests__` = **223** (vs **0** for the root project).

## Measured, not carried forward

| | plan | measured on `3a1b1de` |
|---|---|---|
| errors | 126 | **115** |
| files | ~40 | **29** |

By code: 38×TS2345, 21×TS2352, 17×TS2531, 8×TS18048, 6×TS2339, 6×TS2322, 5×TS2769, 4×TS2683, 4×TS2554, 3×TS2741, 1×TS5097, 1×TS2353, 1×TS18047.

`TS6059` shows as 0 here only because this config drops `rootDir`. The naive fix still hits all 11 — see proof 1b below.

## No suppressions

No `as any`, no `@ts-ignore`, no `@ts-expect-error`, no new `eslint-disable`, no widened `exclude`, no file relocation. `git diff | grep -E '^\+.*(as any|@ts-ignore|@ts-expect-error|eslint-disable)'` → empty.

Real defects the gate caught:
- **`isFamilyStillReferenced` takes one argument; four calls in `models.drift.ts` passed two.** The second argument was silently discarded.
- **`recorder-path-traversal.test.ts` set `endpoint: "/v1/chat/completions"`**, which is not in the `FixtureMatch["endpoint"]` union at all. The value is `"chat"`.
- **`HandlerDefaults.replaySpeed` is required** and 24 test `defaults` literals omitted it.
- **`createMockRes().writeHead` modelled only one of Node's two overloads** — it would have thrown away headers on a `(status, statusMessage, headers)` call.
- **`competitive-matrix.test.ts` imported a `.ts` extension**; every other test uses `.js`, which resolves the same under NodeNext.

The rest are honest assertions where the type is genuinely nullable (`JournalEntry.body`), narrowing that never happened (`let x: T | undefined = await new Promise(...)` — the promises are now explicitly generic), or missing required fields (`AGUIMessage.id`, `AGUIRunAgentInput.threadId`/`runId`, `SSEChoice.logprobs`). Two `as AGUIRunAgentInput` casts are **deleted** because the literals became valid.

Where a cast was genuinely needed, it is one documented single-site helper (`looseEntry` in `fix-drift.test.ts`, `isRestorableSpy` in `fixture-loader.test.ts`) rather than a scatter of double casts.

## Red-green proof

**1 — RED, the real state.** `origin/main` @ `3a1b1de` in a clean worktree, `tsconfig.test.json` dropped in, nothing else changed:

```
RED RC=2
115 errors
29 files
```

**1b — the structural blocker is real.** On the same pristine tree, the naive fix (delete `src/__tests__` from `exclude`, keep `rootDir`):

```
$ npx tsc -p tsconfig.naive.json --noEmit 2>&1 | grep -c "error TS6059"
11
scripts/drift-report-collector.ts(41,8): error TS6059: File '.../scripts/drift-types.ts' is not under 'rootDir' '.../src'.
```

Exactly the 11 the plan predicted.

**2 — GREEN on the real tree.**

```
$ pnpm typecheck ; echo $?
> tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit && tsc -p scripts/tsconfig.json --noEmit
0
```

**3 — the gate FAILS on a deliberate error.** Appended to `src/__tests__/jsonrpc.test.ts`:

```ts
const deliberateTypeError: number = "C-03 gate must catch this";
```

```
$ pnpm typecheck ; echo $?
src/__tests__/jsonrpc.test.ts(517,7): error TS2322: Type 'string' is not assignable to type 'number'.
 ELIFECYCLE  Command failed with exit code 2.
2
```

**4 — removed, green again.**

```
$ pnpm typecheck ; echo $?
0
```

## Gates

| gate | exit |
|---|---|
| `prettier --check .` | 0 |
| `npx eslint .` | 0 |
| `pnpm typecheck` | 0 |
| `npx vitest run` | 0 |
| `npx commitlint --from origin/main --to HEAD` | 0 |

**Suite unchanged against baseline:** 179 passed / 1 skipped (180 files), 5592 passed / 46 skipped (5638 tests). No workflow touched, so no `actionlint`. No dependency change, so no lockfile drift.

## Nothing left unfixed

All 115 are fixed. Zero remainder.