### PR TITLE
fix(drift): classify the 2026-09-05 model-family wave (3 include, 1 exclude)

### DIFF
--- a/drift-proposals/anthropic-claude-fable-5-1-new-family.md
+++ b/drift-proposals/anthropic-claude-fable-5-1-new-family.md
@@ -1,0 +1,46 @@
+# New / unclassified model family: claude-fable-5-1
+
+Provider: anthropic
+Detected: 2026-09-05
+Status: RESOLVED — decision recorded below and applied to the registry
+
+This model family appeared in a live /models listing but matches no classification rule (include, exclude, -preview, gemma). drift-sync never silently classifies a new family.
+
+## Decision
+<!-- drift-sync never auto-classifies a new family. To approve adding it to
+     the registry, change the line below to `Decision: include` — the NEXT
+     drift-sync run will then apply the mechanical registry edit (still
+     zero-LLM: this is a human-authored decision, not generated code). -->
+<!-- NOTE: the automated `Decision: include` path CANNOT apply this one. It
+     writes into the family sets in `model-registry.ts`, whose membership is
+     checksum-pinned in `logic-pin.test.ts` (DATA_FROZEN), and drift-sync-check
+     gate-2 re-runs that exact test after the edit. drift-sync cannot update the
+     pin — the gate-1 changed-file allowlist admits only `model-registry.ts` and
+     `drift-proposals/`, so `logic-pin.test.ts` is off-limits to it. Leaving
+     `Decision: include` here would therefore produce `reason=gate-failed` and
+     revert the edit, not `ok-applied`. So the decision is applied BY HAND
+     together with its re-pin, in one reviewed commit — the same way every prior
+     classification landed (72f85f8 claude-opus-5, aa51d0c
+     gemini-3.5-flash-lite/3.6-flash, and the gemini-3.7-flash note here). -->
+
+Decision: INCLUDE (applied — includeFamilies.anthropic in
+`src/__tests__/drift/model-registry.ts`, with the `includeFamilies.anthropic`
+re-pin in `src/__tests__/drift/logic-pin.test.ts`).
+
+Rationale: point release of the already-included `claude-fable-5`, exactly as
+`claude-opus-4-1` is of `claude-opus-4`.
+
+EVIDENCE LIMIT, stated plainly: no live capability probe was run for this one.
+Anthropic's `/v1/models` carries no capability field at all (`id` /
+`display_name` / `created_at` only), so the `supportedGenerationMethods` /
+chat-probe evidence used for the Gemini and OpenAI entries in this wave has no
+Anthropic equivalent — and separately, the only Anthropic key indexed for this
+repo is invalid (`/v1/models` → HTTP 401 `authentication_error`, so it needs
+rotating; tracked outside this note). The argument is therefore the same one
+commit 72f85f8 used to classify `claude-opus-5`: the family is present on the
+live listing (drift run 34193766572, 2026-09-08), its sibling `claude-fable-5` is
+already included, and the canary reported exactly ONE unclassified anthropic
+family that run — so every other live id normalized into `includeFamilies`,
+i.e. the whole live Anthropic listing is text-chat Claude families plus this one.
+If that inference is ever wrong the canary is the thing that catches it, which is
+why this is recorded rather than assumed.

--- a/drift-proposals/gemini-gemini-3.8-flash-new-family.md
+++ b/drift-proposals/gemini-gemini-3.8-flash-new-family.md
@@ -1,0 +1,38 @@
+# New / unclassified model family: gemini-3.8-flash
+
+Provider: gemini
+Detected: 2026-09-05
+Status: RESOLVED — decision recorded below and applied to the registry
+
+This model family appeared in a live /models listing but matches no classification rule (include, exclude, -preview, gemma). drift-sync never silently classifies a new family.
+
+## Decision
+<!-- drift-sync never auto-classifies a new family. To approve adding it to
+     the registry, change the line below to `Decision: include` — the NEXT
+     drift-sync run will then apply the mechanical registry edit (still
+     zero-LLM: this is a human-authored decision, not generated code). -->
+<!-- NOTE: the automated `Decision: include` path CANNOT apply this one. It
+     writes into the family sets in `model-registry.ts`, whose membership is
+     checksum-pinned in `logic-pin.test.ts` (DATA_FROZEN), and drift-sync-check
+     gate-2 re-runs that exact test after the edit. drift-sync cannot update the
+     pin — the gate-1 changed-file allowlist admits only `model-registry.ts` and
+     `drift-proposals/`, so `logic-pin.test.ts` is off-limits to it. Leaving
+     `Decision: include` here would therefore produce `reason=gate-failed` and
+     revert the edit, not `ok-applied`. So the decision is applied BY HAND
+     together with its re-pin, in one reviewed commit — the same way every prior
+     classification landed (72f85f8 claude-opus-5, aa51d0c
+     gemini-3.5-flash-lite/3.6-flash, and the gemini-3.7-flash note here). -->
+
+Decision: INCLUDE (applied — includeFamilies.gemini in
+`src/__tests__/drift/model-registry.ts`, with the `includeFamilies.gemini` re-pin
+in `src/__tests__/drift/logic-pin.test.ts`).
+
+Rationale: stable GA text tier. Google's live `/models` entry declares
+`supportedGenerationMethods: [generateContent, countTokens, createCachedContent,
+batchGenerateContent]` — set-identical to the already-included
+`gemini-3.7-flash` (verified against the same live listing in the same call, not
+quoted from the earlier note), and to `gemini-3.6-flash` / `gemini-3.5-flash` —
+with `displayName: "Gemini 3.8 Flash"` and no preview, experimental,
+confidential or EAP marker. It declares no `bidiGenerateContent` (so it is not a
+Live / native-audio surface), no `embedContent`, and no `predict`. It is the next
+release in the flash line aimock already mocks at 3.5 through 3.7.

--- a/drift-proposals/gemini-lyria-3.5-new-family.md
+++ b/drift-proposals/gemini-lyria-3.5-new-family.md
@@ -1,0 +1,46 @@
+# New / unclassified model family: lyria-3.5
+
+Provider: gemini
+Detected: 2026-09-05
+Status: RESOLVED — decision recorded below and applied to the registry
+
+This model family appeared in a live /models listing but matches no classification rule (include, exclude, -preview, gemma). drift-sync never silently classifies a new family.
+
+## Decision
+<!-- drift-sync never auto-classifies a new family. To approve adding it to
+     the registry, change the line below to `Decision: include` — the NEXT
+     drift-sync run will then apply the mechanical registry edit (still
+     zero-LLM: this is a human-authored decision, not generated code). -->
+<!-- NOTE: the automated `Decision: include` path CANNOT apply this one. It
+     writes into the family sets in `model-registry.ts`, whose membership is
+     checksum-pinned in `logic-pin.test.ts` (DATA_FROZEN), and drift-sync-check
+     gate-2 re-runs that exact test after the edit. drift-sync cannot update the
+     pin — the gate-1 changed-file allowlist admits only `model-registry.ts` and
+     `drift-proposals/`, so `logic-pin.test.ts` is off-limits to it. Leaving
+     `Decision: include` here would therefore produce `reason=gate-failed` and
+     revert the edit, not `ok-applied`. So the decision is applied BY HAND
+     together with its re-pin, in one reviewed commit — the same way every prior
+     classification landed (72f85f8 claude-opus-5, aa51d0c
+     gemini-3.5-flash-lite/3.6-flash, and the gemini-3.7-flash note here). -->
+
+Decision: EXCLUDE (applied — excludeFamilies.gemini in
+`src/__tests__/drift/model-registry.ts`, with the `excludeFamilies.gemini`
+re-pin in `src/__tests__/drift/logic-pin.test.ts`).
+
+Rationale: non-text generative media — the GA tier of Google's music-generation
+line, same category as the `imagen-*` / `veo-*` / `gemini-omni-1.1-flash`
+entries.
+
+This is the sharpest case yet for classifying on the MODEL CARD rather than on
+`supportedGenerationMethods` alone. Its live entry declares
+`supportedGenerationMethods: [generateContent, countTokens]`, so a
+methods-only rule would have called it text-capable and argued INCLUDE. The rest
+of its own entry settles it: `displayName: "Lyria 3.5"`,
+`description: "Music Generation model"`. It emits audio, not a text turn, so it
+can never be text-generation drift. (Mirrors `gemini-omni-1.1-flash`, where the
+"omni" substring argued the opposite of the truth and the card decided.)
+
+Its `-preview` siblings `lyria-3-clip-preview` and `lyria-3-pro-preview` are
+present on the same live listing and are already auto-excluded by
+PREVIEW_FAMILY. This GA id carries no `-preview` token, so that rule cannot
+reach it and it must be enumerated.

--- a/drift-proposals/openai-gpt-6-astra-new-family.md
+++ b/drift-proposals/openai-gpt-6-astra-new-family.md
@@ -1,0 +1,41 @@
+# New / unclassified model family: gpt-6-astra
+
+Provider: openai
+Detected: 2026-09-05
+Status: RESOLVED — decision recorded below and applied to the registry
+
+This model family appeared in a live /models listing but matches no classification rule (include, exclude, -preview, gemma). drift-sync never silently classifies a new family.
+
+## Decision
+<!-- drift-sync never auto-classifies a new family. To approve adding it to
+     the registry, change the line below to `Decision: include` — the NEXT
+     drift-sync run will then apply the mechanical registry edit (still
+     zero-LLM: this is a human-authored decision, not generated code). -->
+<!-- NOTE: the automated `Decision: include` path CANNOT apply this one. It
+     writes into the family sets in `model-registry.ts`, whose membership is
+     checksum-pinned in `logic-pin.test.ts` (DATA_FROZEN), and drift-sync-check
+     gate-2 re-runs that exact test after the edit. drift-sync cannot update the
+     pin — the gate-1 changed-file allowlist admits only `model-registry.ts` and
+     `drift-proposals/`, so `logic-pin.test.ts` is off-limits to it. Leaving
+     `Decision: include` here would therefore produce `reason=gate-failed` and
+     revert the edit, not `ok-applied`. So the decision is applied BY HAND
+     together with its re-pin, in one reviewed commit — the same way every prior
+     classification landed (72f85f8 claude-opus-5, aa51d0c
+     gemini-3.5-flash-lite/3.6-flash, and the gemini-3.7-flash note here). -->
+
+Decision: INCLUDE (applied — includeFamilies.openai in
+`src/__tests__/drift/model-registry.ts`, with the `includeFamilies.openai`
+re-pin in `src/__tests__/drift/logic-pin.test.ts`).
+
+Rationale: plain GA text chat. Classified on a DECLARED-CAPABILITY probe, not on
+the name — "astra" carries no modality signal, and OpenAI's `/v1/models` exposes
+none either (`id` / `owned_by` / `created` only; the entry is
+`gpt-6-astra owned_by=system created=1787853604`, i.e. 2026-08-27T18:00:04Z), so
+the name shape alone could not decide this. A minimal `/v1/chat/completions` call
+(`max_completion_tokens: 16`, one user turn) returns **HTTP 200** with
+`finish_reason: "stop"`, `model: "gpt-6-astra"` and a real assistant turn —
+identical in shape to the already-included `gpt-5.6-luna` probed the same way in
+the same run. Negative control: `whisper-1` on the same endpoint returns **404**
+`"This is not a chat model and thus not supported in the v1/chat/completions
+endpoint"`, so the probe does discriminate. It is the text-chat surface aimock
+mocks.

--- a/src/__tests__/drift/logic-pin.test.ts
+++ b/src/__tests__/drift/logic-pin.test.ts
@@ -421,15 +421,15 @@ describe("classification-logic checksum freeze (Phase-0 anti-silence guard)", ()
 const DATA_FROZEN: Record<string, { members: () => string[]; pin: string }> = {
   "includeFamilies.openai": {
     members: () => [...includeFamilies.openai].sort(),
-    pin: "802989cfefe27838cf7303ac905dbb5fb6641e9fb859924834422b86cce8fb9c",
+    pin: "65899f85f8a87178b19fdb0be4ea1b37c3f18aabe925733c8d78e1beaf956c8e",
   },
   "includeFamilies.anthropic": {
     members: () => [...includeFamilies.anthropic].sort(),
-    pin: "ab79ff332fadeff93c2678ebe3e0af7a6280ce6f0deb4694228e316944dfeb74",
+    pin: "3934772426666eb3cc770fe879c53e02b0432368b40b0cdcf8a6d4a6c4cad272",
   },
   "includeFamilies.gemini": {
     members: () => [...includeFamilies.gemini].sort(),
-    pin: "566fb89af6862badeff1d95ecfa511dcd1fc757feeb60a8ff8fec563952cadbc",
+    pin: "eded621072bfe853b144378c8988a4ab3c471861f44dacc56c75c90a6016cd55",
   },
   "excludeFamilies.openai": {
     members: () => [...excludeFamilies.openai].sort(),
@@ -441,7 +441,7 @@ const DATA_FROZEN: Record<string, { members: () => string[]; pin: string }> = {
   },
   "excludeFamilies.gemini": {
     members: () => [...excludeFamilies.gemini].sort(),
-    pin: "8afbca596165c15f956e94fe0a358adf2144c8f3c5f93b6599ddb81e0eb2ecfa",
+    pin: "748359a2dc129363e1a3d754c007ec6f1ef7b2a731a2fd58650bdbb62cbf6265",
   },
   // The realtime canary's seed sets, previously pinned NOWHERE. An edit to
   // either one was invisible to every guard in the repo: adding a family to

--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -92,6 +92,19 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     "gpt-5.6-luna",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
+    // gpt-6 named variant (text chat), first listed 2026-08-27. Classified on a
+    // DECLARED-CAPABILITY probe, not on the name — "astra" carries no modality
+    // signal, and the /v1/models listing exposes none either (id / owned_by /
+    // created only), so shape alone could not decide this. A minimal
+    // /v1/chat/completions call returns 200 with `finish_reason: "stop"` and a
+    // real assistant turn, byte-for-byte the same shape the already-included
+    // `gpt-5.6-luna` returns; the negative control `whisper-1` is refused on the
+    // same endpoint with "This is not a chat model". So it is plain text chat,
+    // the surface aimock mocks.
+    //
+    // Decision: INCLUDE, recorded in
+    // drift-proposals/openai-gpt-6-astra-new-family.md.
+    "gpt-6-astra",
     // Codex line (coding chat; text output)
     "gpt-5-codex",
     "gpt-5.1-codex",
@@ -135,6 +148,18 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     // the forward-looking rationale for the exclude-by-rule patterns below,
     // PREVIEW_FAMILY / GEMMA_FAMILY).
     "claude-fable-5",
+    // Point release of the already-included `claude-fable-5`, exactly as
+    // `claude-opus-4-1` is of `claude-opus-4`. Anthropic's /v1/models carries no
+    // capability field at all (id / display_name / created_at only), so the
+    // capability probe available for the OpenAI and Gemini entries has no
+    // equivalent here; the argument is the same one commit 72f85f8 used for
+    // `claude-opus-5`. The canary reported exactly ONE unclassified anthropic
+    // family this run, so every other live id normalized into this set — i.e.
+    // the whole live listing is text-chat Claude families plus this one.
+    //
+    // Decision: INCLUDE, recorded in
+    // drift-proposals/anthropic-claude-fable-5-1-new-family.md.
+    "claude-fable-5-1",
   ]),
   gemini: familySet("gemini", [
     // Gemini 2.0 / 2.5 text families
@@ -149,6 +174,18 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     "gemini-3.5-flash-lite",
     "gemini-3.6-flash",
     "gemini-3.7-flash",
+    // Stable GA text tier. Google's live /models entry declares
+    // `supportedGenerationMethods: [generateContent, countTokens,
+    // createCachedContent, batchGenerateContent]` — set-identical to the
+    // already-included `gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`
+    // — with `displayName: "Gemini 3.8 Flash"` and no preview, experimental,
+    // confidential or EAP marker. No `bidiGenerateContent` (not a Live /
+    // native-audio surface), no `embedContent`, no `predict`. Next release in the
+    // flash line aimock already mocks at 3.5 through 3.7.
+    //
+    // Decision: INCLUDE, recorded in
+    // drift-proposals/gemini-gemini-3.8-flash-new-family.md.
+    "gemini-3.8-flash",
   ]),
 };
 
@@ -351,6 +388,26 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     // Decision: EXCLUDE, recorded in
     // drift-proposals/gemini-gemini-3.7-flash-video-understanding-eap-new-family.md.
     "gemini-3.7-flash-video-understanding-eap",
+    // Lyria 3.5, the GA tier of Google's music-generation line. Non-text
+    // generative media, same category as the imagen-* / veo-* /
+    // gemini-omni-1.1-flash entries.
+    //
+    // This one is the sharpest case yet for classifying on the model card rather
+    // than on `supportedGenerationMethods` ALONE: it declares
+    // `[generateContent, countTokens]`, so a methods-only rule would have called
+    // it text-capable and argued INCLUDE. Its own live entry settles it —
+    // `displayName: "Lyria 3.5"`, `description: "Music Generation model"`. It
+    // emits audio, not a text turn, so it can never be text-generation drift.
+    // (Mirrors `gemini-omni-1.1-flash` above, where the name argued the wrong way
+    // and the card decided.)
+    //
+    // Its `-preview` siblings `lyria-3-clip-preview` and `lyria-3-pro-preview`
+    // are already auto-excluded by PREVIEW_FAMILY; this GA id carries no
+    // `-preview` token, so that rule cannot reach it and it must be enumerated.
+    //
+    // Decision: EXCLUDE, recorded in
+    // drift-proposals/gemini-lyria-3.5-new-family.md.
+    "lyria-3.5",
     // NOTE: every `-preview` family (gemini-3.x preview tiers, deep-research
     // previews, antigravity-preview-05, computer-use-preview-10, image/tts/robotics
     // previews, lyria/veo/nano-banana previews, gemini-embedding-2-preview, …) is

--- a/src/__tests__/drift/text-drift.test.ts
+++ b/src/__tests__/drift/text-drift.test.ts
@@ -210,3 +210,102 @@ describe("gemini transcription + omni-video line is classified as EXCLUDED", () 
     ]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// The 2026-09-05 wave — BEHAVIOURAL coverage of the four classifications made
+// in this change, in the same shape as the two blocks above.
+//
+// `gpt-6-astra`, `claude-fable-5-1` and `gemini-3.8-flash` were classified
+// INCLUDE and `lyria-3.5` EXCLUDE in model-registry.ts, each on the provider's
+// own declared capability (see the rationale comment beside each entry, and
+// drift-proposals/). Without the assertions below the only thing that would
+// redden if an entry were dropped is that set's membership CHECKSUM in
+// logic-pin.test.ts — which says "the data moved" and nothing about what the
+// classification MEANS.
+//
+// `claude-fable-5-1` is the prefix case in this wave, and it is asserted in both
+// directions: the already-included `claude-fable-5` is a strict PREFIX of it, so
+// a `startsWith`-shaped classification bug would let the shorter key classify
+// the longer one — and the negative control below proves a FURTHER point release
+// is still reported rather than swallowed by either.
+//
+// `lyria-3.5` is the one entry a methods-only rule would have got backwards: its
+// live /models entry declares `generateContent`, so only the model card
+// (`description: "Music Generation model"`) distinguishes it from a text tier.
+// It is asserted beside its `-preview` sibling, which reaches the same verdict
+// by the PREVIEW_FAMILY rule rather than by enumeration.
+// ---------------------------------------------------------------------------
+
+describe("the 2026-09-05 model-family wave is classified", () => {
+  it("gpt-6-astra is INCLUDED in a /models-shaped payload", () => {
+    expect(isClassifiedFamily("gpt-6-astra", "openai")).toBe(true);
+    expect(
+      unclassifiedFamilies(
+        [
+          "gpt-5.6-luna", // the sibling named variant it was probed against
+          "gpt-6-astra",
+          "gpt-6-astra-2026-08-27", // dated snapshot collapses onto the family
+          "whisper-1", // the negative control from that probe, excluded
+        ],
+        "openai",
+      ),
+    ).toEqual([]);
+  });
+
+  it("claude-fable-5-1 is INCLUDED in a /models-shaped payload", () => {
+    expect(isClassifiedFamily("claude-fable-5-1", "anthropic")).toBe(true);
+    expect(
+      unclassifiedFamilies(
+        [
+          "claude-fable-5", // the prefix sibling, already included
+          "claude-fable-5-1",
+          "claude-fable-5-1-20260901", // dated snapshot collapses onto the family
+          "claude-opus-5",
+        ],
+        "anthropic",
+      ),
+    ).toEqual([]);
+  });
+
+  it("gemini-3.8-flash is INCLUDED in a /models-shaped payload", () => {
+    expect(isClassifiedFamily("gemini-3.8-flash", "gemini")).toBe(true);
+    expect(
+      unclassifiedFamilies(
+        [
+          "gemini-3.7-flash", // the tier whose method set it matches exactly
+          "gemini-3.8-flash",
+          "gemini-3.8-flash-2026-09-05", // dated snapshot collapses onto the family
+        ],
+        "gemini",
+      ),
+    ).toEqual([]);
+  });
+
+  it("lyria-3.5 is EXCLUDED in a /models-shaped payload", () => {
+    expect(isClassifiedFamily("lyria-3.5", "gemini")).toBe(true);
+    expect(excludeFamilies.gemini.has("lyria-3.5")).toBe(true);
+    expect(
+      unclassifiedFamilies(
+        [
+          "gemini-3.8-flash",
+          "lyria-3.5",
+          "lyria-3.5-2026-09-05", // dated snapshot collapses onto the family
+          "lyria-3-pro-preview", // sibling preview tier, excluded by pattern
+        ],
+        "gemini",
+      ),
+    ).toEqual([]);
+  });
+
+  it("no key in this wave classifies a neighbouring family", () => {
+    // Each entry is its own family. NEGATIVE CONTROLS: without these,
+    // `toEqual([])` above is also what a neutered `unclassifiedFamilies` would
+    // produce, and a prefix-shaped bug would look identical to a correct pass.
+    expect(normalizeModelFamily("claude-fable-5-1", "anthropic")).toBe("claude-fable-5-1");
+    expect(unclassifiedFamilies(["claude-fable-5-2"], "anthropic")).toEqual(["claude-fable-5-2"]);
+    expect(unclassifiedFamilies(["gpt-6"], "openai")).toEqual(["gpt-6"]);
+    expect(unclassifiedFamilies(["gpt-6-astra-pro"], "openai")).toEqual(["gpt-6-astra-pro"]);
+    expect(unclassifiedFamilies(["gemini-3.8-pro"], "gemini")).toEqual(["gemini-3.8-pro"]);
+    expect(unclassifiedFamilies(["lyria-4"], "gemini")).toEqual(["lyria-4"]);
+  });
+});


### PR DESCRIPTION
## What

The live `/models` family canary has been red on `main` since 2026-09-05. Four families were unclassified; this classifies all four — three `include`, one `exclude` — and re-pins the four `DATA_FROZEN` checksums that move as a result.

Supersedes and closes #406, #409, #411, #412 (see *Why four PRs* below).

## Decisions, and the evidence for each

Every one is classified on **declared capability read off the live listing**, never on the name — the house standard the `gemini-omni-1.1-flash` entry already documents.

| Family | Provider | Decision | Evidence |
|---|---|---|---|
| `gpt-6-astra` | openai | **include** | live `/v1/chat/completions` probe → 200, `finish_reason: "stop"`, real assistant turn |
| `gemini-3.8-flash` | gemini | **include** | `supportedGenerationMethods` set-identical to the included `gemini-3.7-flash` |
| `lyria-3.5` | gemini | **exclude** | live entry `description: "Music Generation model"` |
| `claude-fable-5-1` | anthropic | **include** | no capability probe available — see the caveat below |

**`gpt-6-astra`** is the one my own first pass got only half right. OpenAI's `/v1/models` exposes no capability field (`id` / `owned_by` / `created` only — the entry is `owned_by=system created=1787853604`, i.e. 2026-08-27T18:00:04Z), and "astra" carries no modality signal, so shape alone could not decide it. A minimal `/v1/chat/completions` call returns **200** with a real assistant turn, identical in shape to the already-included `gpt-5.6-luna` probed in the same run. Negative control: `whisper-1` on the same endpoint returns **404** `"This is not a chat model"`, so the probe discriminates.

**`lyria-3.5`** is the sharpest case yet for reading the model card rather than `supportedGenerationMethods` alone. It declares `[generateContent, countTokens]` — a methods-only rule would have called it text-capable and argued *include*. Its own entry settles it: `displayName: "Lyria 3.5"`, `description: "Music Generation model"`. Its `-preview` siblings `lyria-3-clip-preview` / `lyria-3-pro-preview` are already swept by `PREVIEW_FAMILY`; this GA id carries no `-preview` token, so it must be enumerated.

**`claude-fable-5-1` — stated evidence limit.** No capability probe was run. Anthropic's `/v1/models` carries no capability field at all, and separately the only Anthropic key indexed for this repo returns **401 `authentication_error`** and needs rotating. The argument is the one `72f85f8` used for `claude-opus-5`: present on the live listing (run 34193766572), sibling `claude-fable-5` already included, and the canary reported exactly **one** unclassified anthropic family — so every other live id normalized into `includeFamilies`, i.e. the whole live listing is text-chat Claude families plus this one. That limit is recorded in the note file, not just here.

## Why this is one hand-applied commit, not a `Decision: include` merge

The automated path cannot apply it: family membership is checksum-pinned in `logic-pin.test.ts` (`DATA_FROZEN`), drift-sync-check gate-2 re-runs that test after the edit, and gate-1's changed-file allowlist admits only `model-registry.ts` and `drift-proposals/` — so `logic-pin.test.ts` is off-limits to drift-sync and it would report `gate-failed`, not `ok-applied`. Same as every prior classification (`72f85f8`, `aa51d0c`, and the `gemini-3.7-flash` note).

Two claims in the bot's PR-body template are stale and worth fixing separately: there is no "offline `/models` wave" to update (nothing outside the drift registry enumerates families), and the body says `includeFamilies` is checksum-pinned without naming `logic-pin.test.ts`, which is the only file that actually does it.

## Why four PRs existed — a real dedup gap

`computeChangesetKey` is `sha256(sorted set of non-no-op family outcomes)`. It dedups an **identical** set only; it has no notion of subset/superset. So while a needs-human decision sits unresolved, every day a *new* family appears the set changes → new key → dedup misses → a new PR opens, and the previous PR, a strict subset still unresolved, is left open:

| PR | date | changeset | families |
|---|---|---|---|
| #406 | 09-02 | `6db8beb2877122b5` | fable-5-1 |
| #409 | 09-03 | `e781a95af8f195ba` | + 3.8-flash, flash-latest-high-res-exp |
| #411 | 09-04 | `1ffab239aa41912c` | + lyria-3.5, − flash-latest-high-res-exp |
| #412 | 09-05 | `3e05bca9db7f9505` | + gpt-6-astra |

The key's own doc comment names "unbounded PR-spam" as the thing it prevents — it prevents the *same-set* re-fire, not the *growing-set* one. Fix shape, for a follow-up: the per-family `drift-proposal-note:` markers already in each body make the changeset sets comparable, so a run whose set is a strict superset of an open bot PR's should update that PR in place (the backlog is cumulative by nature) rather than open a sibling. Also note #409's `gemini-flash-latest-high-res-exp` vanished from every later listing, and nothing retires a needs-human PR whose family no longer exists upstream.

## Semantic coverage, not just a checksum

Second commit. The registry edit on its own is covered only by the four `DATA_FROZEN` membership checksums — which say "the data moved" and nothing about what the classification *means*. That is the exact gap the two existing blocks in `text-drift.test.ts` were written to close for the earlier waves; this wave had none, so it gets a block in the same shape: each family asserted through the real enumerate → normalize → subtract pipeline on `/models`-shaped payloads, including the dated-snapshot form each provider actually lists, plus the sibling it was judged against.

`claude-fable-5-1` is asserted in both directions — the already-included `claude-fable-5` is a strict **prefix** of it, so a `startsWith`-shaped bug would let the shorter key classify the longer one. Negative controls (`claude-fable-5-2`, `gpt-6`, `gpt-6-astra-pro`, `gemini-3.8-pro`, `lyria-4`) must all still be *reported*, since without them `toEqual([])` is also what a neutered `unclassifiedFamilies` would produce.

Mutation-tested rather than assumed — deleting each registry entry in turn reddens these tests:

| entry deleted | text-drift result |
|---|---|
| `gpt-6-astra` | 1 failed \| 13 passed |
| `claude-fable-5-1` | 1 failed \| 13 passed |
| `gemini-3.8-flash` | 2 failed \| 12 passed (also the mixed-listing include in the lyria payload) |
| `lyria-3.5` | 1 failed \| 13 passed |
| *(restored)* | 14 passed |

## Red / green, observed locally

Before, on this branch's parent:
```
openai/gpt-6-astra          -> classified=false
anthropic/claude-fable-5-1  -> classified=false
gemini/gemini-3.8-flash     -> classified=false
gemini/lyria-3.5            -> classified=false

vitest run src/__tests__/drift/logic-pin.test.ts
  Tests  4 failed | 29 passed (33)
  × freezes includeFamilies.openai membership
  × freezes includeFamilies.anthropic membership
  × freezes includeFamilies.gemini membership
  × freezes excludeFamilies.gemini membership
```

After the registry edit and the four re-pins:
```
openai/gpt-6-astra          -> classified=true
anthropic/claude-fable-5-1  -> classified=true
gemini/gemini-3.8-flash     -> classified=true
gemini/lyria-3.5            -> classified=true

vitest run src/__tests__/drift/logic-pin.test.ts
  Tests  33 passed (33)
```

Full suite: **`5658 passed | 1 failed (5659)`**. The one failure is `adoption-wall.test.ts > reads the live wall back as a full set of curated tiles` — pre-existing, red on `main` since 26e5cb9, verified failing identically on a clean `origin/main` worktree. It is **fixed in #417**, which must land first for this PR to go fully green; nothing here touches it.

CI on this branch: **24 pass, 1 fail** (that same adoption-wall test), 2 skipping. Notably `drift-live-pr` **passes** — that is the live family canary running against the real provider listings on this PR, so the classification is confirmed end to end, not just against the offline registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y445N6QQBeAdiLcEvEpqGe
