### PR TITLE
fix(adoption-wall): curate the two adopters shipped unmapped, unredding main

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1683,7 +1683,7 @@
                 </a>
                 <a
                   class="adopter"
-                  href="https://github.com/octelium/octelium"
+                  href="https://octelium.com"
                   data-repo="octelium/octelium"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -1697,7 +1697,7 @@
                     loading="lazy"
                     referrerpolicy="no-referrer"
                   />
-                  <span class="adopter-name">octelium</span>
+                  <span class="adopter-name">Octelium</span>
                 </a>
                 <a
                   class="adopter"
@@ -1863,7 +1863,7 @@
                 </a>
                 <a
                   class="adopter"
-                  href="https://github.com/supabitapp/supaterm"
+                  href="https://supaterm.com"
                   data-repo="supabitapp/supaterm"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -1877,7 +1877,7 @@
                     loading="lazy"
                     referrerpolicy="no-referrer"
                   />
-                  <span class="adopter-name">supabitapp</span>
+                  <span class="adopter-name">Supaterm</span>
                 </a>
                 <a
                   class="adopter"
@@ -2129,7 +2129,7 @@
                 </a>
                 <a
                   class="adopter"
-                  href="https://github.com/octelium/octelium"
+                  href="https://octelium.com"
                   data-repo="octelium/octelium"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -2145,7 +2145,7 @@
                     loading="lazy"
                     referrerpolicy="no-referrer"
                   />
-                  <span class="adopter-name">octelium</span>
+                  <span class="adopter-name">Octelium</span>
                 </a>
                 <a
                   class="adopter"
@@ -2329,7 +2329,7 @@
                 </a>
                 <a
                   class="adopter"
-                  href="https://github.com/supabitapp/supaterm"
+                  href="https://supaterm.com"
                   data-repo="supabitapp/supaterm"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -2345,7 +2345,7 @@
                     loading="lazy"
                     referrerpolicy="no-referrer"
                   />
-                  <span class="adopter-name">supabitapp</span>
+                  <span class="adopter-name">Supaterm</span>
                 </a>
                 <a
                   class="adopter"

--- a/scripts/update-adoption-wall.ts
+++ b/scripts/update-adoption-wall.ts
@@ -343,6 +343,8 @@ export const ADOPTER_DISPLAY: Record<string, AdopterDisplay> = {
   "Zoo-Code-Org/Zoo-Code": { name: "Zoo Code", url: "https://www.zoocode.dev" },
   "BodhiSearch/BodhiApp": { name: "Bodhi", url: "https://getbodhi.app" },
   "liveloveapp/hashbrown": { name: "Hashbrown", url: "https://www.hashbrown.dev" },
+  "octelium/octelium": { name: "Octelium", url: "https://octelium.com" },
+  "supabitapp/supaterm": { name: "Supaterm", url: "https://supaterm.com" },
 };
 
 /**


### PR DESCRIPTION
## Why

`main` has been red since **26e5cb9** ("docs: refresh adoption wall", 2026-09-07) — [test-unit run](https://github.com/CopilotKit/aimock/actions/runs/34285340161). That blocks every open PR from going green, which is how I found it.

That commit added `octelium/octelium` and `supabitapp/supaterm` to the wall on the page but added no `ADOPTER_DISPLAY` entry for either. `resolveDisplay` fell through to its org-login fallback, so the shipped page carries two tiles reading **"octelium"** and **"supabitapp"** — the latter is the org, not the product — each linking to GitHub instead of a homepage. `reads the live wall back as a full set of curated tiles` is precisely the guard for that, and it has failed on every run since.

## What

Curate both, from their own repo metadata rather than invented copy:

| repo | name | url | source |
|---|---|---|---|
| `octelium/octelium` | Octelium | https://octelium.com | `homepage` declares the `/docs` path; the root resolves 200 and matches the marketing-homepage convention the other 30 entries follow |
| `supabitapp/supaterm` | Supaterm | https://supaterm.com | declared `homepage`, resolves 200 |

The wall region is then re-rendered through `renderWall` so the page round-trips byte for byte against the renderer — what the sibling `re-renders the page's own adopters byte for byte` test asserts. Both marquee tracks change, so it's four tiles for two adopters.

## Red / green, observed locally

Before:
```
vitest run src/__tests__/adoption-wall.test.ts
  Tests  1 failed | 269 passed (270)
  × round-tripping the shipped page > reads the live wall back as a full set of curated tiles
    → expected [ 'octelium/octelium', 'supabitapp/supaterm' ] to deeply equal []
```

After:
```
  Tests  270 passed (270)
```

Full suite goes from `1 failed | 5637 passed` to **`5638 passed`, 180/180 files**. `eslint` and `prettier --check` clean on both changed files.

Worth a follow-up, not fixed here: nothing gated this. `update-adoption-wall.ts` already *knows* about unmapped adopters — it emits a "these adopters have no entry in `ADOPTER_DISPLAY`" section in its run summary — but that is a report, not a gate, so the refresh commit shipped anyway and the failure surfaced only after merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y445N6QQBeAdiLcEvEpqGe
