### PR TITLE
docs(drift): replace the claude-fable-5-1 evidence limit with the measurement

### DIFF
--- a/drift-proposals/anthropic-claude-fable-5-1-new-family.md
+++ b/drift-proposals/anthropic-claude-fable-5-1-new-family.md
@@ -27,20 +27,20 @@ Decision: INCLUDE (applied — includeFamilies.anthropic in
 `src/__tests__/drift/model-registry.ts`, with the `includeFamilies.anthropic`
 re-pin in `src/__tests__/drift/logic-pin.test.ts`).
 
-Rationale: point release of the already-included `claude-fable-5`, exactly as
-`claude-opus-4-1` is of `claude-opus-4`.
+Rationale: GA text chat, measured. Anthropic's `/v1/models` carries no
+capability field (`id` / `display_name` / `created_at` only), so the
+`supportedGenerationMethods` evidence used for the Gemini entries has no
+equivalent here — but `/v1/messages` does: a minimal call
+(`max_tokens: 16`, one user turn) returns **HTTP 200** with
+`stop_reason: "end_turn"`, `model: "claude-fable-5-1"` and a real assistant
+turn. Its listing entry is `display_name: "Claude Fable 5.1"`,
+`created_at: 2026-08-28`, i.e. the point release of the already-included
+`claude-fable-5` ("Claude Fable 5", 2026-06-07) — the same relationship
+`claude-opus-4-1` has to `claude-opus-4`.
 
-EVIDENCE LIMIT, stated plainly: no live capability probe was run for this one.
-Anthropic's `/v1/models` carries no capability field at all (`id` /
-`display_name` / `created_at` only), so the `supportedGenerationMethods` /
-chat-probe evidence used for the Gemini and OpenAI entries in this wave has no
-Anthropic equivalent — and separately, the only Anthropic key indexed for this
-repo is invalid (`/v1/models` → HTTP 401 `authentication_error`, so it needs
-rotating; tracked outside this note). The argument is therefore the same one
-commit 72f85f8 used to classify `claude-opus-5`: the family is present on the
-live listing (drift run 34193766572, 2026-09-08), its sibling `claude-fable-5` is
-already included, and the canary reported exactly ONE unclassified anthropic
-family that run — so every other live id normalized into `includeFamilies`,
-i.e. the whole live Anthropic listing is text-chat Claude families plus this one.
-If that inference is ever wrong the canary is the thing that catches it, which is
-why this is recorded rather than assumed.
+Corroborating: all 11 ids on the live listing are text-chat Claude families
+(`claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`,
+`claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-opus-4-6`,
+`claude-opus-4-5`, `claude-haiku-4-5`, `claude-sonnet-4-5`), and the canary
+reported exactly ONE unclassified anthropic family — so every other live id
+already normalized into `includeFamilies`.

--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -149,13 +149,17 @@ export const includeFamilies: Record<Provider, Set<string>> = {
     // PREVIEW_FAMILY / GEMMA_FAMILY).
     "claude-fable-5",
     // Point release of the already-included `claude-fable-5`, exactly as
-    // `claude-opus-4-1` is of `claude-opus-4`. Anthropic's /v1/models carries no
-    // capability field at all (id / display_name / created_at only), so the
-    // capability probe available for the OpenAI and Gemini entries has no
-    // equivalent here; the argument is the same one commit 72f85f8 used for
-    // `claude-opus-5`. The canary reported exactly ONE unclassified anthropic
-    // family this run, so every other live id normalized into this set — i.e.
-    // the whole live listing is text-chat Claude families plus this one.
+    // `claude-opus-4-1` is of `claude-opus-4` — `display_name: "Claude Fable
+    // 5.1"`, `created_at: 2026-08-28`, against Fable 5's 2026-06-07.
+    //
+    // Classified on a DECLARED-CAPABILITY probe like the rest of this wave.
+    // Anthropic's /v1/models carries no capability field (id / display_name /
+    // created_at only), so there is no `supportedGenerationMethods` to compare
+    // — but /v1/messages answers the same question directly: a minimal call
+    // returns 200 with `stop_reason: "end_turn"` and a real assistant turn.
+    // Corroborating: all 11 ids on the live listing are text-chat Claude
+    // families, and the canary reported exactly ONE unclassified anthropic
+    // family, so every other live id already normalized into this set.
     //
     // Decision: INCLUDE, recorded in
     // drift-proposals/anthropic-claude-fable-5-1-new-family.md.


### PR DESCRIPTION
Prose-only follow-up to #416. No classification changes, no membership moves, no re-pin.

#416 classified `claude-fable-5-1` on precedent and recorded — in both the `drift-proposals/` note and the registry comment — that no capability probe was possible, because Anthropic's `/v1/models` carries no capability field *and* the indexed Anthropic key returned 401.

The second half was my error. The 401 key was the **showcase** key. aimock's own drift key is a different 1Password item (`op://DevOps/aimock/<field>`, per the key-rotation runbook) and it works fine — I resolved the wrong one and concluded the credential was dead rather than that I'd picked the wrong credential.

With the right key, the classification is measured rather than inferred:

```
GET /v1/models          → 200, 11 models
  claude-fable-5-1   "Claude Fable 5.1"   created_at 2026-08-28
  claude-fable-5     "Claude Fable 5"     created_at 2026-06-07

POST /v1/messages  model=claude-fable-5-1, max_tokens=16
  → 200  stop_reason="end_turn"  model="claude-fable-5-1"  text="ok"
```

`/v1/models` still has no capability field, so there is no `supportedGenerationMethods` to compare against a sibling the way the Gemini entries do — but `/v1/messages` answers the same question directly, and is the Anthropic equivalent of the `/v1/chat/completions` probe that decided `gpt-6-astra`.

Two things that were previously assertions are now observations: the point-release relationship to `claude-fable-5` is visible in the display names and creation dates, and the claim that the rest of the listing is entirely text-chat Claude families checks out across all 11 ids (`claude-fable-5-1`, `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-opus-4-5`, `claude-haiku-4-5`, `claude-sonnet-4-5`).

The decision in #416 was right; only its stated basis was weaker than it needed to be. This replaces the recorded evidence limit with the measurement, so the note doesn't leave a future reader believing the Anthropic surface is unverifiable — it isn't, it just needs the right key.

`typecheck` exit 0 · `logic-pin` + `text-drift` + `drift-remediation-strings` 106 tests passing (the note files are test-enumerated, so the rewrite is covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y445N6QQBeAdiLcEvEpqGe
