### PR TITLE
fix(drift): classify gpt-image-2.5-flare/sunburst as excludeFamilies (image modality)

### DIFF
--- a/drift-proposals/openai-gpt-image-2.5-flare-new-family.md
+++ b/drift-proposals/openai-gpt-image-2.5-flare-new-family.md
@@ -1,0 +1,30 @@
+# New / unclassified model family: gpt-image-2.5-flare
+
+Provider: openai
+Detected: 2026-09-10
+Status: RESOLVED — decision recorded below and applied to the registry
+
+This model family appeared in a live /models listing but matches no classification rule (include, exclude, -preview, gemma). drift-sync never silently classifies a new family.
+
+## Decision
+
+<!-- drift-sync never auto-classifies a new family. To approve adding it to
+     the registry, change the line below to `Decision: include` — the NEXT
+     drift-sync run will then apply the mechanical registry edit (still
+     zero-LLM: this is a human-authored decision, not generated code). -->
+
+<!-- NOTE: the `Decision: include` marker documented above is drift-sync's
+     AUTOMATED path, and it writes EXCLUSIVELY into `includeFamilies`
+     (scripts/drift-sync.ts: addFamilyLiteralInSource(..., "includeFamilies", ...)).
+     There is no automated exclude path, so an EXCLUDE decision is recorded here
+     in prose and applied by hand — writing `include` would misclassify. -->
+
+Decision: EXCLUDE (applied 2026-09-10 — excludeFamilies.openai in
+`src/__tests__/drift/model-registry.ts`, plus the static OpenAI /models wave in
+`src/__tests__/drift/models.drift.ts`).
+
+Rationale: wrong modality — `gpt-image-2.5-flare` is an image-generation
+model on the same lineage as the already-excluded `gpt-image-2`. It serves
+/v1/images/generations and never answers on /v1/chat/completions, so it is not
+text-generation drift. Mirrors the existing dall-e-\* / gpt-image-\* /
+chatgpt-image-latest entries.

--- a/drift-proposals/openai-gpt-image-2.5-sunburst-new-family.md
+++ b/drift-proposals/openai-gpt-image-2.5-sunburst-new-family.md
@@ -1,0 +1,30 @@
+# New / unclassified model family: gpt-image-2.5-sunburst
+
+Provider: openai
+Detected: 2026-09-10
+Status: RESOLVED — decision recorded below and applied to the registry
+
+This model family appeared in a live /models listing but matches no classification rule (include, exclude, -preview, gemma). drift-sync never silently classifies a new family.
+
+## Decision
+
+<!-- drift-sync never auto-classifies a new family. To approve adding it to
+     the registry, change the line below to `Decision: include` — the NEXT
+     drift-sync run will then apply the mechanical registry edit (still
+     zero-LLM: this is a human-authored decision, not generated code). -->
+
+<!-- NOTE: the `Decision: include` marker documented above is drift-sync's
+     AUTOMATED path, and it writes EXCLUSIVELY into `includeFamilies`
+     (scripts/drift-sync.ts: addFamilyLiteralInSource(..., "includeFamilies", ...)).
+     There is no automated exclude path, so an EXCLUDE decision is recorded here
+     in prose and applied by hand — writing `include` would misclassify. -->
+
+Decision: EXCLUDE (applied 2026-09-10 — excludeFamilies.openai in
+`src/__tests__/drift/model-registry.ts`, plus the static OpenAI /models wave in
+`src/__tests__/drift/models.drift.ts`).
+
+Rationale: wrong modality — `gpt-image-2.5-sunburst` is an image-generation
+model on the same lineage as the already-excluded `gpt-image-2`. It serves
+/v1/images/generations and never answers on /v1/chat/completions, so it is not
+text-generation drift. Mirrors the existing dall-e-\* / gpt-image-\* /
+chatgpt-image-latest entries.

--- a/src/__tests__/drift/logic-pin.test.ts
+++ b/src/__tests__/drift/logic-pin.test.ts
@@ -433,7 +433,7 @@ const DATA_FROZEN: Record<string, { members: () => string[]; pin: string }> = {
   },
   "excludeFamilies.openai": {
     members: () => [...excludeFamilies.openai].sort(),
-    pin: "e4484f780a6a64928a54004a52420969c28d92c861272b10fffbbc7f96625f76",
+    pin: "f54fe5d9552e4149cb7178fce6316c702fb5f0b00293c2299dfc9f7c64e02baa",
   },
   "excludeFamilies.anthropic": {
     members: () => [...excludeFamilies.anthropic].sort(),

--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -219,6 +219,13 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     "gpt-image-1-mini",
     "gpt-image-1.5",
     "gpt-image-2",
+    // 2026-09-10 image line. `gpt-image-2.5-flare` / `gpt-image-2.5-sunburst`
+    // are image-generation models on the same lineage as the already-excluded
+    // `gpt-image-2` — they serve /v1/images/generations, not
+    // /v1/chat/completions, so they are wrong-modality here and are NOT
+    // text-generation drift. Same treatment as every other gpt-image-* family.
+    "gpt-image-2.5-flare",
+    "gpt-image-2.5-sunburst",
     "chatgpt-image-latest",
     // Bare chat alias — a moving alias (not a stable mocked family); matches the
     // *-latest exclude policy (chatgpt-image-latest, omni-moderation-latest, etc.)

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -332,6 +332,8 @@ describe("full live /models wave is fully classified (2026-07-16 drift)", () => 
       "gpt-image-1-mini",
       "gpt-image-1.5",
       "gpt-image-2",
+      "gpt-image-2.5-flare",
+      "gpt-image-2.5-sunburst",
       "sora-2",
       "sora-2-pro",
       "omni-moderation",


### PR DESCRIPTION
Resolves the needs-human decision routed by #421 (drift changeset `8d60e214b0305f9c`).

## Decision: EXCLUDE

OpenAI shipped `gpt-image-2.5-flare` and `gpt-image-2.5-sunburst` on 2026-09-10. The nightly run flagged both as real-drift, confirmed across 3 runs.

Both are image-generation models on the same lineage as the already-excluded `gpt-image-2`. Neither answers on `/v1/chat/completions`, so neither is text-generation drift. Every image family in the registry is already excluded — `dall-e-2`, `dall-e-3`, `gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `chatgpt-image-latest` — and these get the same treatment.

The decision is recorded on both `drift-proposals/` notes **in prose**, not via drift-sync's `Decision: include` marker: that path calls `addFamilyLiteralInSource(..., "includeFamilies", ...)` exclusively, so using it would have put these in `includeFamilies` and mismarked them as families aimock mocks on the chat surface.

## Changes

- `model-registry.ts` — both families added to `excludeFamilies.openai`'s image cluster
- `models.drift.ts` — both ids added to the static OpenAI `/models` wave, so the offline coverage test grades them
- `logic-pin.test.ts` — `excludeFamilies.openai` membership pin re-pinned
- `drift-proposals/openai-gpt-image-2.5-{flare,sunburst}-new-family.md` — decision recorded, status RESOLVED

The pin was reviewed, not chased: the sorted-membership delta reported by the red freeze test is exactly these two additions and nothing else, and the new hash was recomputed from the module rather than pasted out of the failure message.

## Red-green

Both guarding surfaces were observed red before the fix and green after.

**1. Offline classification coverage** (`models.drift.ts`) — ids added to the wave, not yet classified:

```
FAIL  models.drift.ts > OpenAI: every live family is classified (zero unclassified)
AssertionError: expected [ 'gpt-image-2.5-flare', …(1) ] to deeply equal []
+ [ "gpt-image-2.5-flare", "gpt-image-2.5-sunburst" ]
```

Green after the `excludeFamilies` entries: `Tests 1 passed | 24 skipped`.

**2. Membership freeze** (`logic-pin.test.ts`) — red on the registry edit:

```
FAIL  freezes excludeFamilies.openai membership
Frozen data set "excludeFamilies.openai" membership changed …
expected 'f54fe5d9552e4149cb7178fce6316c702fb5f…' to be 'e4484f780a6a64928a54004a52420969c28d9…'
```

Green after the re-pin: `Tests 33 passed (33)`.

Full suite: **183 files, 5712 tests passing**. format / lint / typecheck / build all clean.

## Note on #421

#421 applies nothing on merge — `includeFamilies` is checksum-pinned and drift-sync's gate-1 allowlist covers only `model-registry.ts` and `drift-proposals/`, so it cannot re-pin. Per its own body, the working procedure is one hand-authored commit (this PR), then **close** #421 rather than merging it. Prior examples: 72f85f8, 936b59c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvkmhXVLqSSEW6FvPQHSu5