### PR TITLE
feat(drift-sync): close the classification loop — re-pin on apply, and add the exclude path

### DIFF
--- a/scripts/drift-sync-check.ts
+++ b/scripts/drift-sync-check.ts
@@ -93,7 +93,18 @@ export class SyncCheckConfigError extends Error {}
  * frozen logic surfaces — see the pin re-assert in gate (2), which still
  * blocks an edit here that touches one of those surfaces.
  */
-const ALLOWED_EXACT_FILES: ReadonlySet<string> = new Set(["src/__tests__/drift/model-registry.ts"]);
+const ALLOWED_EXACT_FILES: ReadonlySet<string> = new Set([
+  "src/__tests__/drift/model-registry.ts",
+  // The membership checksums live here, and drift-sync re-pins the ONE affected
+  // key in the same run that applies a human-approved classification. Admitting
+  // the file at the path level is not what keeps this narrow — `onlyPinsChanged`
+  // in drift-sync.ts refuses to write unless the edit is confined to `pin:`
+  // string literals, so the frozen LOGIC in this file remains untouchable by the
+  // sync. Without the entry the approved edit lands and gate-2 immediately reds
+  // on the now-stale pin, so every approval reported gate-failed instead of
+  // ok-applied — the approval affordance the note advertises never worked.
+  "src/__tests__/drift/logic-pin.test.ts",
+]);
 
 /**
  * Needs-human dedup note files (C2) live under this prefix — never a code

--- a/scripts/drift-sync.ts
+++ b/scripts/drift-sync.ts
@@ -37,6 +37,7 @@ import type { DriftReport, DriftSeverity } from "./drift-types.js";
 
 import { normalizeModelFamily } from "../src/__tests__/drift/model-family.js";
 import {
+  excludeFamilies,
   includeFamilies,
   isClassifiedFamily,
   isRecordedDeprecation,
@@ -480,7 +481,7 @@ export const DRIFT_PROPOSALS_DIR = "drift-proposals";
  * never produces a note and never pages anyone.
  */
 export type ProposalKind = "new-family" | "registry-structural-mismatch";
-export type ProposalDecision = "pending" | "include";
+export type ProposalDecision = "pending" | "include" | "exclude";
 
 /** Family-keyed dedup path — re-firing the same alert always resolves to the SAME path. */
 export function proposalNoteRelPath(
@@ -496,7 +497,13 @@ export function proposalNoteRelPath(
 /** Parse the note's `Decision:` line. Defaults to "pending" (fail-closed — never infers approval). */
 export function parseProposalDecision(noteText: string): ProposalDecision {
   const m = noteText.match(/^Decision:\s*(\S+)/m);
-  return m && m[1].toLowerCase() === "include" ? "include" : "pending";
+  if (!m) return "pending";
+  const word = m[1].toLowerCase();
+  // Fail-closed: anything that is not one of the two recognised human verdicts
+  // is `pending`. Never infer approval OR rejection from an unrecognised word.
+  if (word === "include") return "include";
+  if (word === "exclude") return "exclude";
+  return "pending";
 }
 
 export function renderProposalNote(
@@ -523,10 +530,16 @@ export function renderProposalNote(
   if (kind === "new-family") {
     lines.push(
       "## Decision",
-      "<!-- drift-sync never auto-classifies a new family. To approve adding it to",
-      "     the registry, change the line below to `Decision: include` — the NEXT",
-      "     drift-sync run will then apply the mechanical registry edit (still",
-      "     zero-LLM: this is a human-authored decision, not generated code). -->",
+      "<!-- drift-sync never auto-classifies a new family. A HUMAN decides, by",
+      "     changing the line below to either:",
+      "",
+      "       Decision: include   — aimock mocks this family on the chat surface",
+      "       Decision: exclude   — wrong modality / retired / preview; not ours",
+      "",
+      "     The NEXT drift-sync run then applies the mechanical registry edit to",
+      "     includeFamilies or excludeFamilies respectively, and re-pins that",
+      "     set's membership checksum in the same commit (still zero-LLM: this",
+      "     is a human-authored decision, not generated code). -->",
       "Decision: pending",
       "",
     );
@@ -547,7 +560,101 @@ export function renderProposalNote(
 
 export const MODEL_REGISTRY_REL_PATH = "src/__tests__/drift/model-registry.ts";
 
-type RegistrySetName = "includeFamilies" | "excludeFamilies" | "deprecatedFamilies";
+// ---------------------------------------------------------------------------
+// Membership re-pinning (logic-pin.test.ts).
+//
+// `includeFamilies` / `excludeFamilies` are membership-checksum-pinned in
+// logic-pin.test.ts so that NOBODY can quietly add or drop a classified family
+// without a human noticing. That guard is why the sync may not invent a
+// classification — and it is ALSO why, before this existed, the sync could not
+// finish a classification a human HAD already approved: the registry edit
+// landed, the pin went stale, gate-2 reds, and the run reported gate-failed.
+//
+// The review the pin exists to force still happens; it just happens EARLIER, as
+// the human-authored `Decision:` line in the drift-proposals/ note. Once that
+// verdict exists, moving the pin is bookkeeping, not judgement.
+//
+// Two things keep this narrow:
+//   1. `updateDataFrozenPin` rewrites the pin of exactly ONE named key, and
+//      refuses (locatorMiss) if that key is absent or appears more than once.
+//   2. `onlyPinsChanged` re-reads the result and refuses the write unless every
+//      byte outside a `pin:` string literal is identical. The frozen LOGIC in
+//      that file is therefore unreachable by the sync even though the path sits
+//      on drift-sync-check's allowlist.
+// ---------------------------------------------------------------------------
+
+export const LOGIC_PIN_REL_PATH = "src/__tests__/drift/logic-pin.test.ts";
+
+/** The DATA_FROZEN key a `<listName>[<provider>]` membership set is pinned under. */
+export function dataFrozenKey(listName: RegistrySetName, provider: Provider): string {
+  return `${listName}.${provider}`;
+}
+
+/**
+ * The pin value logic-pin.test.ts computes for a membership set:
+ * `sha256(JSON.stringify(sortedMembers))`. Mirrors that file's own `sha256`
+ * helper and its `members()` accessor, which sorts before hashing.
+ */
+export function computeMembershipPin(members: readonly string[]): string {
+  return createHash("sha256")
+    .update(JSON.stringify([...members].sort()))
+    .digest("hex");
+}
+
+/** Every `pin: "<hex>"` literal, normalised away — used to prove a diff is pin-only. */
+function maskPins(source: string): string {
+  return source.replace(/pin:\s*"[0-9a-f]{64}"/g, 'pin: "<PIN>"');
+}
+
+/**
+ * True when `after` differs from `before` ONLY inside `pin:` string literals.
+ * This is the guard that makes admitting logic-pin.test.ts to the sync's
+ * allowlist safe: a rewrite that touched a frozen source-hash, a member
+ * accessor, or any surrounding logic fails here and is never written.
+ */
+export function onlyPinsChanged(before: string, after: string): boolean {
+  return maskPins(before) === maskPins(after);
+}
+
+/**
+ * Replace the `pin:` literal belonging to ONE DATA_FROZEN key. Returns
+ * `locatorMiss` when the key is missing, duplicated, or carries no recognisable
+ * pin — the caller routes that to a human rather than guessing, exactly as it
+ * does for a registry structural mismatch.
+ */
+export function updateDataFrozenPin(
+  source: string,
+  key: string,
+  newPin: string,
+): { text: string; changed: boolean; locatorMiss: boolean } {
+  const keyLiteral = `"${key}":`;
+  const occurrences = source.split(keyLiteral).length - 1;
+  if (occurrences !== 1) return { text: source, changed: false, locatorMiss: true };
+
+  const keyStart = source.indexOf(keyLiteral);
+  // Scope the search to this entry only: from the key to the first `pin:` that
+  // follows it, refusing if another entry's key intervenes.
+  const pinMatch = /pin:\s*"([0-9a-f]{64})"/.exec(source.slice(keyStart));
+  if (!pinMatch || pinMatch.index === undefined) {
+    return { text: source, changed: false, locatorMiss: true };
+  }
+  const absoluteIndex = keyStart + pinMatch.index;
+  const between = source.slice(keyStart + keyLiteral.length, absoluteIndex);
+  if (/"[A-Za-z0-9_.-]+":\s*\{/.test(between)) {
+    // A different DATA_FROZEN entry starts before this key's pin — the file's
+    // shape is not what we assume. Refuse.
+    return { text: source, changed: false, locatorMiss: true };
+  }
+  if (pinMatch[1] === newPin) return { text: source, changed: false, locatorMiss: false };
+
+  const text =
+    source.slice(0, absoluteIndex) +
+    pinMatch[0].replace(pinMatch[1], newPin) +
+    source.slice(absoluteIndex + pinMatch[0].length);
+  return { text, changed: true, locatorMiss: false };
+}
+
+export type RegistrySetName = "includeFamilies" | "excludeFamilies" | "deprecatedFamilies";
 
 interface FamilySetLocation {
   /** family literal text -> 0-based source line index of that literal's own line. */
@@ -701,6 +808,16 @@ export interface SyncCoreDeps {
   isRecorded?: (family: string, provider: Provider) => boolean;
   readRegistrySource: () => string;
   writeRegistrySource: (text: string) => void;
+  /**
+   * Read/write logic-pin.test.ts, where the membership checksums live. The core
+   * re-pins ONLY the key whose set it just edited, and only after
+   * `onlyPinsChanged` proves the rewrite touched nothing but `pin:` literals.
+   * Optional so an existing caller that never triggers a classification keeps
+   * working unchanged; a run that WOULD re-pin without these routes to a human
+   * instead of silently leaving a stale pin behind.
+   */
+  readLogicPinSource?: () => string;
+  writeLogicPinSource?: (text: string) => void;
   readProposalNote: (relPath: string) => string | null;
   writeProposalNote: (relPath: string, text: string) => void;
   /**
@@ -722,6 +839,7 @@ export interface SyncCoreDeps {
 export type FamilyAction =
   | "deprecation-recorded"
   | "added"
+  | "excluded"
   | "needs-human-new-family"
   | "needs-human-structural-mismatch"
   | "no-op";
@@ -783,7 +901,7 @@ export function gate3SkipReason(outcomes: readonly FamilyOutcome[]): string | nu
   if (outcomes.some((o) => o.action.startsWith("needs-human-"))) {
     return "this run also deferred a family to a human, which a fresh collector pass would still report as residual critical drift";
   }
-  if (!outcomes.some((o) => o.action === "added")) {
+  if (!outcomes.some((o) => o.action === "added" || o.action === "excluded")) {
     return "this run only RECORDED deprecations, and no live drift surface reads deprecatedFamilies — a re-collect cannot observe this edit";
   }
   return null;
@@ -823,6 +941,11 @@ export function runDriftSyncCore(
 
   let registrySource = deps.readRegistrySource();
   let registryChanged = false;
+  /** Pinned membership sets this run moved → the families it added to each. */
+  const repins = new Map<
+    string,
+    { listName: RegistrySetName; provider: Provider; families: Set<string> }
+  >();
 
   for (const input of inputs) {
     if (input.liveModelIds === null) {
@@ -950,21 +1073,38 @@ export function runDriftSyncCore(
         touchedFiles,
       );
       const decision = existing !== null ? parseProposalDecision(existing) : "pending";
-      if (decision === "include") {
+      if (decision === "include" || decision === "exclude") {
+        // Both verdicts are the SAME mechanical edit against a different set.
+        // `include` = aimock mocks this family on the chat surface; `exclude` =
+        // wrong modality / retired / preview. Neither is ever inferred: the word
+        // came from a human's hand in the note.
+        const listName: RegistrySetName =
+          decision === "include" ? "includeFamilies" : "excludeFamilies";
+        const verb = decision === "include" ? "ADDED" : "EXCLUDED";
         const edit = addFamilyLiteralInSource(
           registrySource,
-          "includeFamilies",
+          listName,
           input.provider,
           family,
-          `ADDED ${stamp} (drift-sync): approved via ${notePath}`,
+          `${verb} ${stamp} (drift-sync): decided via ${notePath}`,
         );
         if (edit.changed) {
           registrySource = edit.text;
           registryChanged = true;
+          // Remember which pinned membership set moved, so the pin is re-pinned
+          // in THIS run's commit. A stale pin reds gate-2 and fails the run.
+          const key = dataFrozenKey(listName, input.provider);
+          const pending = repins.get(key) ?? {
+            listName,
+            provider: input.provider,
+            families: new Set<string>(),
+          };
+          pending.families.add(family);
+          repins.set(key, pending);
           outcomes.push({
             provider: input.provider,
             family,
-            action: "added",
+            action: decision === "include" ? "added" : "excluded",
             detail: edit.detail,
           });
         } else if (edit.locatorMiss) {
@@ -984,10 +1124,10 @@ export function runDriftSyncCore(
                 input.provider,
                 family,
                 "registry-structural-mismatch",
-                `An approved addition of "${family}" could not be applied: drift-sync could not ` +
-                  `locate the includeFamilies.${input.provider} array literal in ` +
+                `An approved classification of "${family}" could not be applied: drift-sync ` +
+                  `could not locate the ${listName}.${input.provider} array literal in ` +
                   `${MODEL_REGISTRY_REL_PATH} — the registry's structure changed. A human must ` +
-                  `apply the addition (or fix the locator).`,
+                  `apply the classification (or fix the locator).`,
                 stamp,
               ),
             touchedFiles,
@@ -1060,7 +1200,68 @@ export function runDriftSyncCore(
   // intact. Gate-3 (the live re-collect) runs only when the live suite has a
   // surface that can actually observe THIS run's edit — `gate3SkipReason` names
   // the two runs where it does not, with the evidence.
+  // Re-pin every membership set this run moved, in the SAME commit as the edit
+  // that moved it. Anything unexpected here is a REFUSAL, not a best effort: a
+  // half-applied classification (registry edited, pin stale) is precisely the
+  // gate-failed state this whole change exists to eliminate.
+  let logicPinSource: string | null = null;
+  if (repins.size > 0) {
+    const readPin = deps.readLogicPinSource;
+    const writePin = deps.writeLogicPinSource;
+    if (!readPin || !writePin) {
+      return {
+        ok: false,
+        reason: SyncCoreReason.NEEDS_HUMAN,
+        detail:
+          `a classification was approved but this caller cannot re-pin ` +
+          `${LOGIC_PIN_REL_PATH} — refusing to leave the registry edited with a stale pin`,
+        outcomes,
+        skipped,
+      };
+    }
+    const before = readPin();
+    let next = before;
+    for (const [key, { listName, provider, families }] of repins) {
+      const base =
+        listName === "includeFamilies" ? includeFamilies[provider] : excludeFamilies[provider];
+      // The compiled module holds the PRE-edit membership; the families this run
+      // applied are exactly the delta. Each one is already a normalized family
+      // key (it came out of the same normalizer the registry's familySet uses),
+      // so re-normalizing it is a no-op and this reproduces the post-edit set.
+      const members = [...base, ...families];
+      const edit = updateDataFrozenPin(next, key, computeMembershipPin(members));
+      if (edit.locatorMiss) {
+        return {
+          ok: false,
+          reason: SyncCoreReason.NEEDS_HUMAN,
+          detail:
+            `could not locate the DATA_FROZEN pin for "${key}" in ${LOGIC_PIN_REL_PATH} — ` +
+            `the pin file's structure changed; a human must re-pin by hand`,
+          outcomes,
+          skipped,
+        };
+      }
+      next = edit.text;
+    }
+    if (!onlyPinsChanged(before, next)) {
+      return {
+        ok: false,
+        reason: SyncCoreReason.NEEDS_HUMAN,
+        detail:
+          `re-pin of ${LOGIC_PIN_REL_PATH} would have changed something other than a ` +
+          `pin literal — refusing the write`,
+        outcomes,
+        skipped,
+      };
+    }
+    logicPinSource = next;
+  }
+
   deps.writeRegistrySource(registrySource);
+  if (logicPinSource !== null) {
+    deps.writeLogicPinSource!(logicPinSource);
+    touchedFiles.add(LOGIC_PIN_REL_PATH);
+  }
   const skipReason = gate3SkipReason(outcomes);
   const verdict = deps.runSyncCheck(
     skipReason !== null
@@ -1097,6 +1298,7 @@ export function runDriftSyncCore(
 // ---------------------------------------------------------------------------
 
 const REGISTRY_ABS_PATH = resolve(MODEL_REGISTRY_REL_PATH);
+const LOGIC_PIN_ABS_PATH = resolve(LOGIC_PIN_REL_PATH);
 
 const LIVE_MODEL_ENV_KEY: Record<Provider, string> = {
   openai: "OPENAI_API_KEY",
@@ -1283,6 +1485,8 @@ export function revertSyncFiles(relPaths: string[]): void {
 const REAL_SYNC_CORE_DEPS: SyncCoreDeps = {
   readRegistrySource: () => readFileSync(REGISTRY_ABS_PATH, "utf-8"),
   writeRegistrySource: (text: string) => writeFileSync(REGISTRY_ABS_PATH, text, "utf-8"),
+  readLogicPinSource: () => readFileSync(LOGIC_PIN_ABS_PATH, "utf-8"),
+  writeLogicPinSource: (text: string) => writeFileSync(LOGIC_PIN_ABS_PATH, text, "utf-8"),
   readProposalNote: (relPath: string) => {
     const abs = resolve(relPath);
     return existsSync(abs) ? readFileSync(abs, "utf-8") : null;
@@ -1404,7 +1608,7 @@ export function buildSyncCommitMessage(outcome: SyncCoreOutcome): {
   body: string;
 } {
   const applied = outcome.outcomes.filter(
-    (o) => o.action === "added" || o.action === "deprecation-recorded",
+    (o) => o.action === "added" || o.action === "excluded" || o.action === "deprecation-recorded",
   );
   if (applied.length === 0) {
     return { subject: `${SYNC_COMMIT_SUBJECT_PREFIX} (needs-human note file(s))`, body: "" };
@@ -1432,7 +1636,10 @@ export function buildSyncCommitMessage(outcome: SyncCoreOutcome): {
 /** Stage + commit exactly the sync core's own touched files (never a catch-all `git add`). */
 function commitSyncChanges(outcome: SyncCoreOutcome): boolean {
   const changed = getChangedFiles().filter(
-    (f) => f === MODEL_REGISTRY_REL_PATH || f.startsWith(`${DRIFT_PROPOSALS_DIR}/`),
+    (f) =>
+      f === MODEL_REGISTRY_REL_PATH ||
+      f === LOGIC_PIN_REL_PATH ||
+      f.startsWith(`${DRIFT_PROPOSALS_DIR}/`),
   );
   if (changed.length === 0) return false;
   const { subject, body } = buildSyncCommitMessage(outcome);

--- a/src/__tests__/drift-sync-check.test.ts
+++ b/src/__tests__/drift-sync-check.test.ts
@@ -59,6 +59,10 @@ function report(criticalCounts: number[]): DriftReport {
 describe("isAllowedSyncFile / checkChangedFileAllowlist", () => {
   it("allows the model-registry data file", () => {
     expect(isAllowedSyncFile("src/__tests__/drift/model-registry.ts")).toBe(true);
+    // drift-sync re-pins the membership checksum in the SAME run that applies a
+    // human-approved classification. Without this the edit lands, gate-2 goes
+    // red on the stale pin, and the whole run reports gate-failed.
+    expect(isAllowedSyncFile("src/__tests__/drift/logic-pin.test.ts")).toBe(true);
   });
 
   it("allows a drift-proposals note file at any depth", () => {

--- a/src/__tests__/drift-sync-core.test.ts
+++ b/src/__tests__/drift-sync-core.test.ts
@@ -23,7 +23,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import ts from "typescript";
 
-import { includeFamilies, deprecatedFamilies } from "./drift/model-registry.js";
+import { includeFamilies, excludeFamilies, deprecatedFamilies } from "./drift/model-registry.js";
 import { MIN_LISTING_SIZE, FORWARD_LOOKING_FAMILIES } from "./drift/deprecation-detector.js";
 import {
   detectDeprecatedFamiliesForSync,
@@ -31,6 +31,10 @@ import {
   addFamilyLiteralInSource,
   proposalNoteRelPath,
   parseProposalDecision,
+  updateDataFrozenPin,
+  onlyPinsChanged,
+  computeMembershipPin,
+  dataFrozenKey,
   renderProposalNote,
   runDriftSyncCore,
   computeChangesetKey,
@@ -39,6 +43,7 @@ import {
   COMMIT_LINE_MAX_LENGTH,
   SyncCoreReason,
   MODEL_REGISTRY_REL_PATH,
+  LOGIC_PIN_REL_PATH,
   DRIFT_PROPOSALS_DIR,
   type SyncCoreDeps,
   type ProviderChurnInput,
@@ -67,6 +72,20 @@ function fixtureRegistrySource(): string {
     "  ]),",
     '  gemini: set("gemini", [',
     '    "gemini-2.5-flash",',
+    "  ]),",
+    "};",
+    // excludeFamilies — the set a `Decision: exclude` verdict lands in. Present
+    // in the fixture because the sync can now edit it; without it the exclude
+    // path can only ever report a structural mismatch.
+    "export const excludeFamilies = {",
+    '  openai: set("openai", [',
+    '    "dall-e-3",',
+    "  ]),",
+    '  anthropic: set("anthropic", [',
+    '    "claude-instant",',
+    "  ]),",
+    '  gemini: set("gemini", [',
+    '    "gemini-1.0-pro-vision",',
     "  ]),",
     "};",
     // The recorded-deprecation ledger, in the shape the real file ships it:
@@ -151,17 +170,23 @@ function parsedFamilyArray(sourceText: string, exportName: string, provider: str
 function makeFakeDeps(overrides: Partial<SyncCoreDeps> = {}): {
   deps: SyncCoreDeps;
   registry: { text: string };
+  logicPin: { text: string };
   notes: Map<string, string>;
   writeRegistrySource: ReturnType<typeof vi.fn>;
+  writeLogicPinSource: ReturnType<typeof vi.fn>;
   writeProposalNote: ReturnType<typeof vi.fn>;
   runSyncCheck: ReturnType<typeof vi.fn>;
   revertFiles: ReturnType<typeof vi.fn>;
 } {
   const registry = { text: fixtureRegistrySource() };
+  const logicPin = { text: fixtureLogicPinSource() };
   const notes = new Map<string, string>();
 
   const writeRegistrySource = vi.fn((text: string) => {
     registry.text = text;
+  });
+  const writeLogicPinSource = vi.fn((text: string) => {
+    logicPin.text = text;
   });
   const writeProposalNote = vi.fn((path: string, text: string) => {
     notes.set(path, text);
@@ -174,6 +199,8 @@ function makeFakeDeps(overrides: Partial<SyncCoreDeps> = {}): {
   const deps: SyncCoreDeps = {
     readRegistrySource: () => registry.text,
     writeRegistrySource,
+    readLogicPinSource: () => logicPin.text,
+    writeLogicPinSource,
     readProposalNote: (path: string) => notes.get(path) ?? null,
     writeProposalNote,
     runSyncCheck,
@@ -185,12 +212,36 @@ function makeFakeDeps(overrides: Partial<SyncCoreDeps> = {}): {
   return {
     deps,
     registry,
+    logicPin,
     notes,
     writeRegistrySource,
+    writeLogicPinSource,
     writeProposalNote,
     runSyncCheck,
     revertFiles,
   };
+}
+
+/**
+ * Minimal DATA_FROZEN-shaped stand-in for logic-pin.test.ts. Only the two keys
+ * the sync can move are modelled; the pin values are placeholders, since what
+ * the tests assert is that the RIGHT key moved and that nothing outside a
+ * `pin:` literal was touched — not any particular hash.
+ */
+function fixtureLogicPinSource(): string {
+  return [
+    "const DATA_FROZEN: Record<string, { members: () => string[]; pin: string }> = {",
+    '  "includeFamilies.openai": {',
+    "    members: () => [...includeFamilies.openai].sort(),",
+    '    pin: "' + "0".repeat(64) + '",',
+    "  },",
+    '  "excludeFamilies.openai": {',
+    "    members: () => [...excludeFamilies.openai].sort(),",
+    '    pin: "' + "1".repeat(64) + '",',
+    "  },",
+    "};",
+    "",
+  ].join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -536,6 +587,16 @@ describe("proposal notes", () => {
     expect(parseProposalDecision("garbage with no Decision line")).toBe("pending");
   });
 
+  it("parseProposalDecision recognizes an explicit human-authored REJECTION (exclude)", () => {
+    // The exclude path exists because a rejection is just as mechanical as an
+    // approval: it writes excludeFamilies instead of includeFamilies. Before
+    // this existed, `Decision: exclude` silently parsed as `pending` and the
+    // family was re-routed to a human every single run, forever.
+    expect(parseProposalDecision("Decision: exclude")).toBe("exclude");
+    expect(parseProposalDecision("Decision: EXCLUDE")).toBe("exclude");
+    expect(parseProposalDecision("Decision: Exclude\n")).toBe("exclude");
+  });
+
   it("parseProposalDecision recognizes an explicit human-authored approval", () => {
     expect(parseProposalDecision("Decision: include")).toBe("include");
   });
@@ -747,7 +808,7 @@ describe("runDriftSyncCore", () => {
     expect(outcome2.ok).toBe(false);
   });
 
-  it("ADDITION (human-approved via note Decision: include): mechanical registry edit + gate passes", () => {
+  it("ADDITION (human-decided via note Decision: include): mechanical registry edit + gate passes", () => {
     const { deps, registry, notes, runSyncCheck } = makeFakeDeps();
     // Simulate a human having already reviewed the RED alert and flipped the
     // note's Decision line to `include` (the only path that can ever add a
@@ -770,8 +831,74 @@ describe("runDriftSyncCore", () => {
     expect(outcome.ok).toBe(true);
     expect(outcome.reason).toBe(SyncCoreReason.OK_APPLIED);
     expect(registry.text).toContain('"gpt-live"');
-    expect(registry.text).toContain(`approved via ${notePath}`);
+    expect(registry.text).toContain(`decided via ${notePath}`);
     expect(runSyncCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("REJECTION (human-authored Decision: exclude): writes excludeFamilies, not includeFamilies", () => {
+    const { deps, registry, logicPin } = makeFakeDeps();
+    const notePath = proposalNoteRelPath("openai", "gpt-live", "new-family");
+    notes_set(deps, notePath, "exclude");
+
+    const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: ["gpt-live"] }];
+    const before = logicPin.text;
+    const outcome = runDriftSyncCore(inputs, deps);
+
+    expect(outcome.outcomes).toContainEqual(
+      expect.objectContaining({ provider: "openai", family: "gpt-live", action: "excluded" }),
+    );
+    expect(outcome.ok).toBe(true);
+    expect(outcome.reason).toBe(SyncCoreReason.OK_APPLIED);
+    // The family landed in excludeFamilies. Asserting the SECTION, not just the
+    // string: a bare `toContain('"gpt-live"')` would also pass if the edit had
+    // gone into includeFamilies, which is the exact bug this path prevents.
+    const excludeSection = registry.text.slice(registry.text.indexOf("excludeFamilies"));
+    expect(excludeSection).toContain('"gpt-live"');
+    expect(registry.text.slice(0, registry.text.indexOf("excludeFamilies"))).not.toContain(
+      '"gpt-live"',
+    );
+    // ...and the EXCLUDE pin moved, while the include pin did not.
+    expect(logicPin.text).not.toBe(before);
+    expect(pinFor(logicPin.text, "excludeFamilies.openai")).not.toBe(
+      pinFor(before, "excludeFamilies.openai"),
+    );
+    expect(pinFor(logicPin.text, "includeFamilies.openai")).toBe(
+      pinFor(before, "includeFamilies.openai"),
+    );
+  });
+
+  it("an APPROVED classification re-pins in the SAME run (the edit is never left with a stale pin)", () => {
+    const { deps, logicPin } = makeFakeDeps();
+    notes_set(deps, proposalNoteRelPath("openai", "gpt-live", "new-family"), "include");
+    const before = logicPin.text;
+
+    const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-live"] }], deps);
+
+    expect(outcome.reason).toBe(SyncCoreReason.OK_APPLIED);
+    expect(pinFor(logicPin.text, "includeFamilies.openai")).not.toBe(
+      pinFor(before, "includeFamilies.openai"),
+    );
+    // And the rewrite stayed inside pin literals — nothing else in the file moved.
+    expect(onlyPinsChanged(before, logicPin.text)).toBe(true);
+  });
+
+  it("REFUSES to apply a classification it cannot re-pin (no half-applied edit)", () => {
+    const { deps, registry, writeRegistrySource } = makeFakeDeps({
+      readLogicPinSource: undefined,
+      writeLogicPinSource: undefined,
+    });
+    notes_set(deps, proposalNoteRelPath("openai", "gpt-live", "new-family"), "include");
+    const registryBefore = registry.text;
+
+    const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-live"] }], deps);
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.reason).toBe(SyncCoreReason.NEEDS_HUMAN);
+    expect(outcome.detail).toContain("cannot re-pin");
+    // The registry was NOT written: a stale-pin half-apply is the failure mode
+    // this whole path exists to remove, so it must not be reachable.
+    expect(writeRegistrySource).not.toHaveBeenCalled();
+    expect(registry.text).toBe(registryBefore);
   });
 
   it("a FAILING drift-sync-check gate reverts every touched file and reports GATE_FAILED", () => {
@@ -801,7 +928,11 @@ describe("runDriftSyncCore", () => {
     expect(outcome.ok).toBe(false);
     expect(outcome.reason).toBe(SyncCoreReason.GATE_FAILED);
     expect(outcome.detail).toContain("pin-check-failed");
-    expect(revertFiles).toHaveBeenCalledWith([MODEL_REGISTRY_REL_PATH]);
+    // BOTH mutated files revert together. A gate failure that reverted the
+    // registry but kept the re-pin would leave the pin describing a membership
+    // that no longer exists — a silently-wrong canary, which is worse than the
+    // failure it was reverting.
+    expect(revertFiles).toHaveBeenCalledWith([MODEL_REGISTRY_REL_PATH, LOGIC_PIN_REL_PATH]);
   });
 
   it("recording a deprecation leaves the includeFamilies checksum pin GREEN", () => {
@@ -1229,5 +1360,83 @@ describe("buildSyncCommitMessage", () => {
     );
     expect(subject.length).toBeLessThanOrEqual(COMMIT_LINE_MAX_LENGTH);
     expect(body).toBe("");
+  });
+});
+
+/** Set a note's Decision line to a human verdict. */
+function notes_set(deps: SyncCoreDeps, notePath: string, verdict: "include" | "exclude"): void {
+  deps.writeProposalNote(
+    notePath,
+    renderProposalNote("openai", "gpt-live", "new-family", "detail", "2026-07-20").replace(
+      "Decision: pending",
+      `Decision: ${verdict}`,
+    ),
+  );
+}
+
+/** The pin literal currently recorded for one DATA_FROZEN key. */
+function pinFor(source: string, key: string): string {
+  const at = source.indexOf(`"${key}":`);
+  const m = /pin:\s*"([0-9a-f]{64})"/.exec(source.slice(at));
+  return m ? m[1] : "";
+}
+
+describe("membership re-pinning primitives", () => {
+  it("updateDataFrozenPin rewrites ONLY the named key's pin", () => {
+    const src = [
+      '  "includeFamilies.openai": {',
+      '    pin: "' + "a".repeat(64) + '",',
+      "  },",
+      '  "excludeFamilies.openai": {',
+      '    pin: "' + "b".repeat(64) + '",',
+      "  },",
+    ].join("\n");
+    const out = updateDataFrozenPin(src, "excludeFamilies.openai", "c".repeat(64));
+    expect(out.changed).toBe(true);
+    expect(out.locatorMiss).toBe(false);
+    expect(pinFor(out.text, "includeFamilies.openai")).toBe("a".repeat(64));
+    expect(pinFor(out.text, "excludeFamilies.openai")).toBe("c".repeat(64));
+  });
+
+  it("updateDataFrozenPin REFUSES an absent or duplicated key rather than guessing", () => {
+    const src = '  "includeFamilies.openai": {\n    pin: "' + "a".repeat(64) + '",\n  },';
+    expect(updateDataFrozenPin(src, "excludeFamilies.gemini", "c".repeat(64))).toMatchObject({
+      changed: false,
+      locatorMiss: true,
+    });
+    expect(updateDataFrozenPin(src + src, "includeFamilies.openai", "c".repeat(64))).toMatchObject({
+      changed: false,
+      locatorMiss: true,
+    });
+  });
+
+  it("onlyPinsChanged is the guard that keeps the sync off everything but pins", () => {
+    const a = 'pin: "' + "a".repeat(64) + '",\nconst FROZEN_LOGIC = 1;';
+    const pinOnly = 'pin: "' + "b".repeat(64) + '",\nconst FROZEN_LOGIC = 1;';
+    const logicToo = 'pin: "' + "b".repeat(64) + '",\nconst FROZEN_LOGIC = 2;';
+    expect(onlyPinsChanged(a, pinOnly)).toBe(true);
+    // Mutation proof: move one byte outside a pin literal and the guard refuses.
+    expect(onlyPinsChanged(a, logicToo)).toBe(false);
+  });
+
+  it("computeMembershipPin reproduces the REAL logic-pin.test.ts pins (no silent divergence)", () => {
+    // drift-sync writes these pins, logic-pin.test.ts verifies them. If the two
+    // ever compute the hash differently, every auto-re-pin would write a value
+    // that immediately reds gate-2 — and the failure would look like a spurious
+    // membership change rather than an algorithm mismatch. Pin the parity here,
+    // against the real file and the real registry, so divergence fails loudly.
+    const real = readFileSync("src/__tests__/drift/logic-pin.test.ts", "utf-8");
+    for (const [key, members] of [
+      ["includeFamilies.openai", [...includeFamilies.openai]],
+      ["excludeFamilies.openai", [...excludeFamilies.openai]],
+    ] as const) {
+      expect(pinFor(real, key), `no pin found for ${key}`).toMatch(/^[0-9a-f]{64}$/);
+      expect(computeMembershipPin(members), key).toBe(pinFor(real, key));
+    }
+  });
+
+  it("dataFrozenKey matches the key format logic-pin.test.ts actually uses", () => {
+    expect(dataFrozenKey("excludeFamilies", "openai")).toBe("excludeFamilies.openai");
+    expect(dataFrozenKey("includeFamilies", "anthropic")).toBe("includeFamilies.anthropic");
   });
 });

--- a/src/__tests__/drift-sync-gate-determinism.test.ts
+++ b/src/__tests__/drift-sync-gate-determinism.test.ts
@@ -54,6 +54,7 @@ import {
   computeChangesetKey,
   SyncCoreReason,
   MODEL_REGISTRY_REL_PATH,
+  LOGIC_PIN_REL_PATH,
   type SyncCoreDeps,
   type SyncCoreOutcome,
   type ProviderChurnInput,
@@ -242,12 +243,20 @@ function runSync(recollect: () => DriftReport, inputs = churnInputs()): RunResul
   const reverted: string[] = [];
   let recollectCalls = 0;
 
+  let logicPinSource = fixtureLogicPin();
   const deps: SyncCoreDeps = {
     isReferenced: (family) => family === "gemini-2.0-flash",
     isRecorded: () => false,
     readRegistrySource: () => registrySource,
     writeRegistrySource: (text) => {
       registrySource = text;
+    },
+    // The sync re-pins the membership checksum in the same run it applies a
+    // classification, so a harness that omits these gets a (correct) refusal
+    // rather than an applied edit.
+    readLogicPinSource: () => logicPinSource,
+    writeLogicPinSource: (text) => {
+      logicPinSource = text;
     },
     readProposalNote: () => null,
     writeProposalNote: () => {
@@ -356,12 +365,20 @@ function approvedNewFamilyRun(recollect: () => DriftReport): RunResult {
   let registrySource = fixtureRegistrySource();
   const reverted: string[] = [];
   let recollectCalls = 0;
+  let logicPinSource = fixtureLogicPin();
   const deps: SyncCoreDeps = {
     isReferenced: () => false,
     isRecorded: () => false,
     readRegistrySource: () => registrySource,
     writeRegistrySource: (text) => {
       registrySource = text;
+    },
+    // The sync re-pins the membership checksum in the same run it applies a
+    // classification, so a harness that omits these gets a (correct) refusal
+    // rather than an applied edit.
+    readLogicPinSource: () => logicPinSource,
+    writeLogicPinSource: (text) => {
+      logicPinSource = text;
     },
     // An already-approved note for the new family — the sync applies it.
     readProposalNote: () => "Decision: include\n",
@@ -453,7 +470,9 @@ describe("negative controls — the gate still refuses a wrong edit", () => {
     expect(run.outcome.ok).toBe(false);
     expect(run.outcome.reason).toBe(SyncCoreReason.GATE_FAILED);
     expect(run.outcome.detail).toContain(SyncCheckReason.RESIDUAL_CRITICAL_DRIFT);
-    expect(run.reverted).toEqual([MODEL_REGISTRY_REL_PATH]);
+    // Both mutated files revert: the registry edit AND the pin that was moved
+    // to match it. Reverting one without the other leaves a lying canary.
+    expect(run.reverted).toEqual([MODEL_REGISTRY_REL_PATH, LOGIC_PIN_REL_PATH]);
   });
 
   it("WRONG EDIT: an off-allowlist file -> reverted, gate-1 never reaches the re-collect", () => {
@@ -486,3 +505,21 @@ describe("negative controls — the gate still refuses a wrong edit", () => {
     expect(verdict.reason).toBe(SyncCheckReason.PIN_CHECK_FAILED);
   });
 });
+
+/** DATA_FROZEN stand-in covering every key this file's runs can move. */
+function fixtureLogicPin(): string {
+  const keys = [
+    "includeFamilies.openai",
+    "includeFamilies.anthropic",
+    "includeFamilies.gemini",
+    "excludeFamilies.openai",
+    "excludeFamilies.anthropic",
+    "excludeFamilies.gemini",
+  ];
+  return [
+    "const DATA_FROZEN = {",
+    ...keys.flatMap((k, i) => [`  "${k}": {`, `    pin: "${String(i).repeat(64)}",`, "  },"]),
+    "};",
+    "",
+  ].join("\n");
+}


### PR DESCRIPTION
Follow-up to #422. While applying that decision by hand I hit the two reasons it *had* to be by hand.

## The two defects

**1. An approved `include` was never applied end-to-end.** `includeFamilies` is membership-checksum-pinned in `logic-pin.test.ts`, but that file was not on drift-sync-check's gate-1 allowlist — so the sync could edit the registry and then had no way to move the pin. The edit landed, gate-2 went red on the stale pin, and the run reported `gate-failed` instead of `ok-applied`. The affordance the note advertises ("set `Decision: include` and the next run applies it") never worked.

**2. There was no exclude path at all.** `parseProposalDecision` recognised only `include`, and the only new-family writer targets `includeFamilies`. `Decision: exclude` parsed as `pending`, so a rejected family got re-routed to a human every run, forever. Worse, the note template offered `Decision: include` as *the* marker — following it for a rejection would file the family as one aimock mocks on the chat surface.

## What this does not change

The sync still never invents a classification. The verdict is the human's hand-written `Decision:` line. Once that exists, applying it — and moving the pin to match — is bookkeeping, not judgement. The review the pin exists to force still happens; it just happens earlier, in the note.

## Keeping the pin file narrow

Admitting `logic-pin.test.ts` to the allowlist would otherwise hand the sync the frozen *logic* too. Two independent guards prevent that:

- `updateDataFrozenPin` rewrites exactly **one** named key's pin, and refuses (`locatorMiss`) on an absent, duplicated, or unrecognisable entry.
- `onlyPinsChanged` re-reads the result and refuses the write unless every byte outside a `pin:` literal is identical.

Anything unexpected is a **refusal, not a best effort**: the registry is not written at all, so the half-applied state that motivated this change is unreachable. On gate failure both files revert together — reverting only the registry would leave the pin describing a membership that no longer exists, which is a lying canary rather than a rollback.

`excluded` joins the outcome union, counts as applied work in the commit message, and is gate-3-observable (classifying a family is precisely what stops the canary reporting it), so the live re-collect runs for it as it does for `added`.

## Red-green

Every test was observed failing first.

- `Decision: exclude` → `pending`, and the allowlist rejected the pin file (the two headline reds).
- An exclude lands in `excludeFamilies` and **not** `includeFamilies` — asserted by section, because a bare `toContain('"gpt-live"')` passes either way and would not have caught a misfiled entry.
- An approved classification re-pins in the same run, and `onlyPinsChanged` confirms the rewrite stayed inside pin literals.
- A run that *cannot* re-pin refuses and writes no registry edit (`writeRegistrySource` never called).
- Both files revert together on gate failure.
- `onlyPinsChanged` **mutation-proofed**: move one byte outside a pin literal and the guard fails.
- `computeMembershipPin` reproduces the **real** `logic-pin.test.ts` pins against the real registry, so the writer and the verifier cannot silently diverge. **Mutation-proofed** by dropping the sort, which reds it — otherwise every auto-re-pin would write a value that instantly reds gate-2, and the failure would read as a spurious membership change rather than an algorithm mismatch.

Three pre-existing tests changed behaviour and were updated deliberately rather than relaxed: two harnesses had to model the pin file (a harness that omits it now gets the correct refusal), and the revert assertions were **strengthened** to require both files.

Full suite: **183 files, 5721 tests passing**. format / lint / typecheck / build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvkmhXVLqSSEW6FvPQHSu5