### PR TITLE
fix(drift): classify gpt-live-1 as excludeFamilies (full-duplex voice)

### DIFF
--- a/drift-proposals/openai-gpt-live-1-new-family.md
+++ b/drift-proposals/openai-gpt-live-1-new-family.md
@@ -8,46 +8,67 @@ This model family appeared in a live /models listing but matches no classificati
 
 ## Decision
 
-<!-- drift-sync never auto-classifies a new family. A HUMAN decides, by
-     changing the line below to either:
+<!-- drift-sync never auto-classifies a new family. To approve adding it to
+     the registry, a HUMAN changes the line below to `Decision: include` or
+     `Decision: exclude` — the NEXT drift-sync run then applies the mechanical
+     registry edit (still zero-LLM: this is a human-authored decision, not
+     generated code). -->
 
-       Decision: include   — aimock mocks this family on the chat surface
-       Decision: exclude   — wrong modality / retired / preview; not ours
+<!-- DELIBERATELY NOT USING THE `Decision:` MARKER. Read this before adding one.
 
-     The NEXT drift-sync run then applies the mechanical registry edit to
-     includeFamilies or excludeFamilies respectively, and re-pins that
-     set's membership checksum in the same commit (still zero-LLM: this
-     is a human-authored decision, not generated code). -->
+     PR #423 mechanized the `exclude` verdict (before it, `exclude` fail-closed
+     to `pending` and only `include` was automated). But that automated path is
+     INCOMPLETE FOR VOICE/AUDIO FAMILIES, which is exactly what this one is:
 
-<!-- NOTE: the `Decision: exclude` marker below is drift-sync's AUTOMATED path,
-     added in PR #423 (before that, only `Decision: include` was mechanized and
-     `exclude` fail-closed to `pending`). It is recorded here for the record and
-     for durability, but nothing in this change RELIES on it: the registry edit,
-     the membership re-pin and the offline /models wave update were all applied
-     by hand in the same commit. Because `gpt-live-1` is classified as of that
-     commit, `unclassifiedFamiliesForSync` will never return it again, so the
-     addition half of drift-sync never revisits this note — the marker is inert
-     unless the exclude entry is ever removed, in which case re-applying it is
-     the correct behavior. -->
+       - It writes `excludeFamilies[provider]` and re-pins that set. It NEVER
+         writes `knownVoiceModelFamilies` (voice-models.ts).
+       - `isVoiceModelId("gpt-live-1")` is true, so `ws-realtime.drift.ts` — which
+         is in drift-sync's gate-3 re-collect — would still report
+         `UNKNOWN_REALTIME_MODELS=gpt-live-1` and emit a CRITICAL.
+       - Gate-3 red REVERTS both edited files, so the run ends `gate-failed`. The
+         automated path would therefore APPLY AND REVERT, every run, forever —
+         and it looks like it worked.
 
-Decision: exclude (applied 2026-09-10 — excludeFamilies.openai in
-`src/__tests__/drift/model-registry.ts`, plus the static OpenAI /models wave in
-`src/__tests__/drift/models.drift.ts`, plus the `excludeFamilies.openai`
-membership pin in `src/__tests__/drift/logic-pin.test.ts`).
+     Verified empirically here: with `gpt-live-1` in `excludeFamilies.openai` but
+     NOT in `knownVoiceModelFamilies`, `detectVoiceModelDrift(["gpt-realtime",
+     "gpt-live-1"])` returns `unknown = ["gpt-live-1"]` — the exact value
+     ws-realtime.drift.ts asserts is empty.
+
+     So this decision is recorded in PROSE and applied BY HAND to both sets, the
+     way commit 936b59c did for the gpt-transcribe / gpt-live-transcribe pair:
+     "The two sets are deliberately disjoint surfaces, so both need the entry."
+
+     A literal `Decision: exclude` line here would be a live hazard, not just
+     inert bookkeeping: if the exclude entry were ever removed, the next
+     drift-sync run would re-add it to `excludeFamilies` ONLY and wedge the job
+     on gate-3. Until #423's apply half also writes `knownVoiceModelFamilies`
+     for voice families, do not put one here. -->
+
+DECISION: **EXCLUDE** — applied by hand on 2026-09-10 to BOTH disjoint surfaces:
+
+- `excludeFamilies.openai` in `src/__tests__/drift/model-registry.ts`
+  (silences the `/models` classification check in `models.drift.ts`)
+- `knownVoiceModelFamilies` in `src/__tests__/drift/voice-models.ts`
+  (silences the realtime/voice canary in `ws-realtime.drift.ts`)
+- both `DATA_FROZEN` membership pins re-pinned in
+  `src/__tests__/drift/logic-pin.test.ts`
+- the id added to the static OpenAI `/models` wave in
+  `src/__tests__/drift/models.drift.ts`, so the offline test grades it
 
 Rationale: wrong modality AND wrong endpoint. `gpt-live-1` is OpenAI's
 GPT-Live-1, a full-duplex voice model served on the NEW `/v1/live/sessions`
 endpoint. It is a SIBLING of the Realtime API, not a successor — its model page
 marks Realtime as "Not supported" — and it never answers on
-/v1/chat/completions, so it can never be text-generation drift. This mirrors the
-treatment every other voice/audio/realtime family already gets here
+`/v1/chat/completions`, so it can never be text-generation drift. This mirrors
+the treatment every other voice/audio/realtime family already gets
 (`gpt-realtime*`, `gpt-audio*`, `gpt-transcribe`, `gpt-live-transcribe`,
 `tts-1`, `whisper-1`), recorded in
-drift-proposals/openai-gpt-live-transcribe-new-family.md (PR #343).
+drift-proposals/openai-gpt-live-transcribe-new-family.md (PR #343, commit
+936b59c).
 
-Membership in `excludeFamilies` is a CLASSIFICATION for the `/models` listing
-check in models.drift.ts and nothing more: it says the family is accounted for,
-NOT which endpoints aimock implements for it.
+Membership in these sets is a CLASSIFICATION for the two listing canaries and
+nothing more: it says the family is accounted for, NOT which endpoints aimock
+implements for it.
 
 ## Scope: aimock does NOT mock /v1/live, and this note does not propose that
 
@@ -56,29 +77,22 @@ it (no open issue; the only realtime ask closed in May), and a real mock would
 need a new route, a sideband socket and full-duplex framing. This note records a
 classification, not a roadmap item.
 
-## Deliberately NOT added to `knownVoiceModelFamilies`
+## `gpt-live-1-mini` is deliberately left UNCLASSIFIED
 
-`knownVoiceModelFamilies` (src/\_\_tests\_\_/drift/voice-models.ts) is a
-DIFFERENT canary's inventory: the realtime/voice canary in ws-realtime.drift.ts,
-which asks "does the account's listing carry a voice family this repo has not
-seen before". Two reasons `gpt-live-1` stays out of it:
+Only `gpt-live-1` was decided. `gpt-live-1-mini` has not been observed in a live
+listing; it appears in this repo solely as the realtime canary's NEW-FAMILY
+negative control (`ws-realtime-canary.test.ts`, `logic-pin.test.ts`). Leaving it
+unclassified keeps that control live — it is what still proves the matcher
+reaches a voice id carrying no "realtime" substring, and that the new
+`gpt-live-1` key does not swallow families that merely EXTEND it. If OpenAI ships
+a real `gpt-live-1-mini`, it flags, and that is its own decision with its own
+note.
 
-1. Different meaning. Membership there asserts the realtime canary RECOGNIZES
-   the family as part of the surface it watches over `/v1/realtime`. `gpt-live-1`
-   lives on `/v1/live/sessions`, which aimock does not implement and does not
-   intend to — marking it "known" would assert coverage that does not exist. The
-   `excludeFamilies` entry makes the accurate, narrower statement ("not
-   chat-surface drift").
-2. Blast radius. `gpt-live-1` is the canonical worked EXAMPLE of "a genuinely new
-   voice family" throughout the voice canary and its frozen-logic pins —
-   ws-realtime-canary.test.ts (the `knownVoiceModelFamilies.has(...) === false`
-   negative control), logic-pin.test.ts, model-family.test.ts, and the docblocks
-   in voice-models.ts and model-family.ts. Adding it would require rewriting the
-   canary's own negative control, which is a larger and riskier edit than the
-   classification this note is about.
+## Follow-up: #423's automated exclude path should write both sets
 
-Whether `gpt-live-1` actually appears in this account's live `GET /v1/models`
-payload — and therefore whether the voice canary will emit an
-`UNKNOWN_REALTIME_MODELS=` marker for it — has NOT been observed here. If and
-when the nightly voice canary does flag it, that is a separate decision and gets
-its own note.
+The gate-3 defect described above is a real gap in `scripts/drift-sync.ts`, not
+a quirk of this family: any future voice/audio family a human marks
+`Decision: exclude` will apply-then-revert the same way. The durable fix is for
+the apply half to also add the family literal to `knownVoiceModelFamilies` (and
+re-pin it) when `isVoiceModelId(family)` is true. That is out of scope here and
+is not attempted by this change.

--- a/drift-proposals/openai-gpt-live-1-new-family.md
+++ b/drift-proposals/openai-gpt-live-1-new-family.md
@@ -1,0 +1,84 @@
+# New / unclassified model family: gpt-live-1
+
+Provider: openai
+Detected: 2026-09-10
+Status: RESOLVED — decision recorded below and applied to the registry
+
+This model family appeared in a live /models listing but matches no classification rule (include, exclude, -preview, gemma). drift-sync never silently classifies a new family.
+
+## Decision
+
+<!-- drift-sync never auto-classifies a new family. A HUMAN decides, by
+     changing the line below to either:
+
+       Decision: include   — aimock mocks this family on the chat surface
+       Decision: exclude   — wrong modality / retired / preview; not ours
+
+     The NEXT drift-sync run then applies the mechanical registry edit to
+     includeFamilies or excludeFamilies respectively, and re-pins that
+     set's membership checksum in the same commit (still zero-LLM: this
+     is a human-authored decision, not generated code). -->
+
+<!-- NOTE: the `Decision: exclude` marker below is drift-sync's AUTOMATED path,
+     added in PR #423 (before that, only `Decision: include` was mechanized and
+     `exclude` fail-closed to `pending`). It is recorded here for the record and
+     for durability, but nothing in this change RELIES on it: the registry edit,
+     the membership re-pin and the offline /models wave update were all applied
+     by hand in the same commit. Because `gpt-live-1` is classified as of that
+     commit, `unclassifiedFamiliesForSync` will never return it again, so the
+     addition half of drift-sync never revisits this note — the marker is inert
+     unless the exclude entry is ever removed, in which case re-applying it is
+     the correct behavior. -->
+
+Decision: exclude (applied 2026-09-10 — excludeFamilies.openai in
+`src/__tests__/drift/model-registry.ts`, plus the static OpenAI /models wave in
+`src/__tests__/drift/models.drift.ts`, plus the `excludeFamilies.openai`
+membership pin in `src/__tests__/drift/logic-pin.test.ts`).
+
+Rationale: wrong modality AND wrong endpoint. `gpt-live-1` is OpenAI's
+GPT-Live-1, a full-duplex voice model served on the NEW `/v1/live/sessions`
+endpoint. It is a SIBLING of the Realtime API, not a successor — its model page
+marks Realtime as "Not supported" — and it never answers on
+/v1/chat/completions, so it can never be text-generation drift. This mirrors the
+treatment every other voice/audio/realtime family already gets here
+(`gpt-realtime*`, `gpt-audio*`, `gpt-transcribe`, `gpt-live-transcribe`,
+`tts-1`, `whisper-1`), recorded in
+drift-proposals/openai-gpt-live-transcribe-new-family.md (PR #343).
+
+Membership in `excludeFamilies` is a CLASSIFICATION for the `/models` listing
+check in models.drift.ts and nothing more: it says the family is accounted for,
+NOT which endpoints aimock implements for it.
+
+## Scope: aimock does NOT mock /v1/live, and this note does not propose that
+
+Mocking `/v1/live/sessions` is explicitly out of scope. There is no demand for
+it (no open issue; the only realtime ask closed in May), and a real mock would
+need a new route, a sideband socket and full-duplex framing. This note records a
+classification, not a roadmap item.
+
+## Deliberately NOT added to `knownVoiceModelFamilies`
+
+`knownVoiceModelFamilies` (src/\_\_tests\_\_/drift/voice-models.ts) is a
+DIFFERENT canary's inventory: the realtime/voice canary in ws-realtime.drift.ts,
+which asks "does the account's listing carry a voice family this repo has not
+seen before". Two reasons `gpt-live-1` stays out of it:
+
+1. Different meaning. Membership there asserts the realtime canary RECOGNIZES
+   the family as part of the surface it watches over `/v1/realtime`. `gpt-live-1`
+   lives on `/v1/live/sessions`, which aimock does not implement and does not
+   intend to — marking it "known" would assert coverage that does not exist. The
+   `excludeFamilies` entry makes the accurate, narrower statement ("not
+   chat-surface drift").
+2. Blast radius. `gpt-live-1` is the canonical worked EXAMPLE of "a genuinely new
+   voice family" throughout the voice canary and its frozen-logic pins —
+   ws-realtime-canary.test.ts (the `knownVoiceModelFamilies.has(...) === false`
+   negative control), logic-pin.test.ts, model-family.test.ts, and the docblocks
+   in voice-models.ts and model-family.ts. Adding it would require rewriting the
+   canary's own negative control, which is a larger and riskier edit than the
+   classification this note is about.
+
+Whether `gpt-live-1` actually appears in this account's live `GET /v1/models`
+payload — and therefore whether the voice canary will emit an
+`UNKNOWN_REALTIME_MODELS=` marker for it — has NOT been observed here. If and
+when the nightly voice canary does flag it, that is a separate decision and gets
+its own note.

--- a/src/__tests__/drift/logic-pin.test.ts
+++ b/src/__tests__/drift/logic-pin.test.ts
@@ -433,7 +433,7 @@ const DATA_FROZEN: Record<string, { members: () => string[]; pin: string }> = {
   },
   "excludeFamilies.openai": {
     members: () => [...excludeFamilies.openai].sort(),
-    pin: "f54fe5d9552e4149cb7178fce6316c702fb5f0b00293c2299dfc9f7c64e02baa",
+    pin: "ccf086b3e7f07b6698f0c875088bd59f1250833d4248e0d624e87c6f592e4021",
   },
   "excludeFamilies.anthropic": {
     members: () => [...excludeFamilies.anthropic].sort(),

--- a/src/__tests__/drift/logic-pin.test.ts
+++ b/src/__tests__/drift/logic-pin.test.ts
@@ -325,8 +325,9 @@ describe("classification-logic checksum freeze (Phase-0 anti-silence guard)", ()
     // normalized, so this is the only thing standing in its way.
     expect(normalizeVoiceModelFamily("gpt-audio-2025-08-28")).toBe("gpt-audio");
     expect(normalizeVoiceModelFamily("tts-1-1106")).toBe("tts-1");
-    // A single-digit tail is deliberately NOT stripped: `gpt-live-1` must stay an
-    // UNKNOWN family. Over-stripping here silences the exact case the canary was
+    // A single-digit tail is deliberately NOT stripped: `gpt-live-1-mini` must
+    // stay an UNKNOWN family rather than collapsing onto the now-classified
+    // `gpt-live-1`. Over-stripping here silences the exact case the canary was
     // broadened for.
     expect(normalizeVoiceModelFamily("gpt-live-1")).toBe("gpt-live-1");
     expect(normalizeVoiceModelFamily("gpt-live-1-mini")).toBe("gpt-live-1-mini");
@@ -338,11 +339,12 @@ describe("classification-logic checksum freeze (Phase-0 anti-silence guard)", ()
     const { candidateModels, unknown } = detectVoiceModelDrift([
       "gpt-4o", // not voice — must not be a candidate at all
       "gpt-realtime-2025-08-28", // known family via a dated snapshot
-      "gpt-live-1", // NEW family — the whole point of the canary
+      "gpt-live-1", // classified voice family (2026-09-10) — must NOT be unknown
+      "gpt-live-1-mini", // NEW family — the whole point of the canary
     ]);
-    expect(candidateModels).toEqual(["gpt-realtime-2025-08-28", "gpt-live-1"]);
+    expect(candidateModels).toEqual(["gpt-realtime-2025-08-28", "gpt-live-1", "gpt-live-1-mini"]);
     // `unknown = []` is the one-line way to silence the canary. It must fail here.
-    expect(unknown).toEqual(["gpt-live-1"]);
+    expect(unknown).toEqual(["gpt-live-1-mini"]);
   });
 
   it("keeps detectVoiceModelDrift reporting hasGA=false when the GA family is gone", () => {
@@ -452,7 +454,7 @@ const DATA_FROZEN: Record<string, { members: () => string[]; pin: string }> = {
   // to make impossible.
   knownVoiceModelFamilies: {
     members: () => [...knownVoiceModelFamilies].sort(),
-    pin: "3897b6bd6fc370ef14f080f4717dde653f2ae6029501d55c4cbda89523f9f3c6",
+    pin: "221ae974089cb3d6d0f0a200a3d1f31a7bac7f26551f7c317aac0fe2e7b20a5e",
   },
   gaRealtimeModels: {
     members: () => [...gaRealtimeModels].sort(),

--- a/src/__tests__/drift/model-family.ts
+++ b/src/__tests__/drift/model-family.ts
@@ -18,7 +18,8 @@
  * Both are anchored to the end and applied in a loop so a trailing dated
  * snapshot that itself follows a build tag is fully reduced. A short numeric
  * suffix like `gpt-live-1`'s trailing `-1` is a SINGLE digit and is deliberately
- * NOT stripped, so `gpt-live-1` normalizes to `gpt-live-1` — an unknown family —
+ * NOT stripped, so `gpt-live-1-mini` normalizes to `gpt-live-1-mini` rather than
+ * collapsing onto the classified `gpt-live-1` — it stays an unknown family —
  * and stays flagged (the whole point of the canary).
  *
  * The `provider` argument selects a per-provider EXTRA rule on top of the shared

--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -277,6 +277,18 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     "gpt-realtime-1.5",
     "gpt-realtime-translate",
     "gpt-realtime-whisper",
+    // 2026-09-10 full-duplex voice line. `gpt-live-1` is OpenAI's GPT-Live-1,
+    // a voice model on the NEW `/v1/live/sessions` endpoint — a SIBLING of the
+    // Realtime API, not a successor (its model page marks Realtime "Not
+    // supported"). It never answers on /v1/chat/completions, so it can never be
+    // text-generation drift, and aimock implements no `/v1/live` surface at all.
+    // Membership here is a CLASSIFICATION for the `/models` listing check only —
+    // it says the family is accounted for, NOT that aimock mocks it (same
+    // reading as the gpt-transcribe / gpt-live-transcribe block above).
+    //
+    // Decision: EXCLUDE, recorded in
+    // drift-proposals/openai-gpt-live-1-new-family.md.
+    "gpt-live-1",
     // NOTE: `-preview` families (gpt-4o-realtime-preview,
     // gpt-4o-mini-realtime-preview, gpt-4o-search-preview,
     // gpt-4o-mini-search-preview, computer-use-preview, …) are auto-excluded by

--- a/src/__tests__/drift/model-registry.ts
+++ b/src/__tests__/drift/model-registry.ts
@@ -286,6 +286,15 @@ export const excludeFamilies: Record<Provider, Set<string>> = {
     // it says the family is accounted for, NOT that aimock mocks it (same
     // reading as the gpt-transcribe / gpt-live-transcribe block above).
     //
+    // PAIRED ENTRY: `gpt-live-1` is ALSO in `knownVoiceModelFamilies`
+    // (voice-models.ts). The two sets are deliberately DISJOINT surfaces — this
+    // one silences the `/models` classification check in models.drift.ts, that
+    // one silences the realtime canary in ws-realtime.drift.ts — so a VOICE
+    // family needs the entry in BOTH or the half it is missing from stays red.
+    // Same pairing as the gpt-transcribe / gpt-live-transcribe block above
+    // (936b59c: "the two sets are deliberately disjoint surfaces, so both need
+    // the entry").
+    //
     // Decision: EXCLUDE, recorded in
     // drift-proposals/openai-gpt-live-1-new-family.md.
     "gpt-live-1",

--- a/src/__tests__/drift/models.drift.ts
+++ b/src/__tests__/drift/models.drift.ts
@@ -211,7 +211,12 @@ describe("model-family pipeline (injected /models)", () => {
     // Guard the other side: the canary must still fire for a real new family.
     expect(unclassifiedFamilies(["gpt-live"], "openai")).toEqual(["gpt-live"]);
     // Single-digit trailing suffix is NOT a build tag, so it stays unknown.
-    expect(unclassifiedFamilies(["gpt-live-1"], "openai")).toEqual(["gpt-live-1"]);
+    // (`gpt-live-1` itself is an EXCLUDE key as of 2026-09-10 — the full-duplex
+    // /v1/live/sessions voice family — so the exemplar here is an unclassified
+    // sibling, and `gpt-live-1-mini` guards against the new key swallowing
+    // families that merely EXTEND it.)
+    expect(unclassifiedFamilies(["gpt-live-9"], "openai")).toEqual(["gpt-live-9"]);
+    expect(unclassifiedFamilies(["gpt-live-1-mini"], "openai")).toEqual(["gpt-live-1-mini"]);
   });
 });
 
@@ -336,6 +341,8 @@ describe("full live /models wave is fully classified (2026-07-16 drift)", () => 
       "gpt-image-2.5-sunburst",
       "sora-2",
       "sora-2-pro",
+      // voice / full-duplex live (realtime-canary domain, excluded here)
+      "gpt-live-1",
       "omni-moderation",
       "omni-moderation-latest",
       // bare chat alias (fixture-vs-live gap: present in live /models, was absent

--- a/src/__tests__/drift/text-drift.test.ts
+++ b/src/__tests__/drift/text-drift.test.ts
@@ -80,7 +80,14 @@ describe("openai transcription line is classified as EXCLUDED (PR #343)", () => 
     expect(unclassifiedFamilies(["gpt-live-transcribe-mini"], "openai")).toEqual([
       "gpt-live-transcribe-mini",
     ]);
-    expect(unclassifiedFamilies(["gpt-live-1"], "openai")).toEqual(["gpt-live-1"]);
+    // Single-digit trailing suffix is NOT a build tag, so a family carrying one
+    // is normalized to itself and stays unknown. `gpt-live-1` itself is now an
+    // EXCLUDE key (2026-09-10, /v1/live/sessions — see model-registry.ts), so the
+    // unknown-side exemplar is an unclassified sibling; `gpt-live-1-mini` also
+    // proves the new exclude key does not swallow families that EXTEND it.
+    expect(unclassifiedFamilies(["gpt-live-9"], "openai")).toEqual(["gpt-live-9"]);
+    expect(unclassifiedFamilies(["gpt-live-1-mini"], "openai")).toEqual(["gpt-live-1-mini"]);
+    expect(unclassifiedFamilies(["gpt-live-1"], "openai")).toEqual([]);
   });
 
   it("every enumerated openai exclude family survives normalization from a dated id", () => {

--- a/src/__tests__/drift/voice-models.ts
+++ b/src/__tests__/drift/voice-models.ts
@@ -36,14 +36,15 @@ export const gaRealtimeModels = [
  * `gpt-audio-2025-08-28`, `gpt-4o-mini-tts-2025-12-15`, …); appending every one
  * to a known-ID set never converges and turns the daily drift job permanently
  * red on false positives. Comparing the NORMALIZED family instead means only a
- * genuinely new family (e.g. `gpt-live`) is ever flagged.
+ * genuinely new family (e.g. `gpt-live-1-mini`) is ever flagged.
  *
  * This is a thin OpenAI-provider wrapper over the shared `normalizeModelFamily`
  * primitive (see `model-family.ts`), which owns the dated-snapshot/build-tag
  * strip loop. Behavior is byte-identical to the historical inline implementation
  * — a short numeric suffix like `gpt-live-1`'s trailing `-1` is a SINGLE digit
- * and is deliberately NOT stripped, so `gpt-live-1` normalizes to `gpt-live-1`
- * — an unknown family — and stays flagged (the whole point of the canary).
+ * and is deliberately NOT stripped, so `gpt-live-1-mini` normalizes to
+ * `gpt-live-1-mini` — an unknown family — and stays flagged, rather than being
+ * over-stripped onto the now-known `gpt-live-1` (the whole point of the canary).
  */
 export function normalizeVoiceModelFamily(id: string): string {
   return normalizeModelFamily(id, "openai");
@@ -83,6 +84,19 @@ export const knownVoiceModelFamilies = new Set(
     "gpt-4o-transcribe-diarize",
     "gpt-transcribe",
     "gpt-live-transcribe",
+    // 2026-09-10 full-duplex voice line. `gpt-live-1` (GPT-Live-1, the
+    // `/v1/live/sessions` endpoint) is ALSO in `excludeFamilies.openai`. The two
+    // sets are deliberately DISJOINT surfaces — this one silences the realtime
+    // canary in ws-realtime.drift.ts, that one silences the `/models`
+    // classification check in models.drift.ts — so a voice family needs the
+    // entry in BOTH or the half it is missing from stays red. Same treatment as
+    // the gpt-transcribe / gpt-live-transcribe pair above (936b59c).
+    // Decision: EXCLUDE, recorded in
+    // drift-proposals/openai-gpt-live-1-new-family.md.
+    // NOTE: `gpt-live-1-mini` is deliberately NOT here — it has not been
+    // observed and is not classified, so it remains this canary's live
+    // negative control.
+    "gpt-live-1",
     "whisper-1",
     // Legacy preview models (may still appear)
     "gpt-4o-realtime-preview",
@@ -98,8 +112,8 @@ export const knownVoiceModelFamilies = new Set(
  * Match a model id that belongs to the voice/audio family the realtime canary
  * is responsible for. This is DELIBERATELY broader than the old
  * `id.includes("realtime")` filter: a new full-duplex voice family whose id
- * lacks the "realtime" substring (e.g. OpenAI's `gpt-live-1` / `gpt-live-1-mini`)
- * would previously never enter the unknown-model computation and so slip past
+ * lacks the "realtime" substring (e.g. OpenAI's `gpt-live-1` line) would
+ * previously never enter the unknown-model computation and so slip past
  * the canary silently. Matching on the broader voice/audio vocabulary closes
  * that blind spot generally — the point is "a new audio/voice model family the
  * account hasn't seen before gets flagged", not a one-off hardcode of gpt-live.

--- a/src/__tests__/ws-realtime-canary.test.ts
+++ b/src/__tests__/ws-realtime-canary.test.ts
@@ -67,7 +67,12 @@ const REPRESENTATIVE_MODELS = [
   "text-embedding-3-large",
   "text-embedding-3-small",
   "omni-moderation-latest",
-  // --- NEW voice family with no "realtime" substring (the blind spot) ---
+  // --- voice family with no "realtime" substring (the blind spot) ---
+  // `gpt-live-1` was classified EXCLUDE on 2026-09-10 and is now in
+  // knownVoiceModelFamilies, so it is the KNOWN half of this pair. The
+  // unclassified `gpt-live-1-mini` is the NEW-family negative control: it keeps
+  // proving the matcher reaches a voice id lacking "realtime", and that the
+  // `gpt-live-1` key does not swallow families that merely EXTEND it.
   "gpt-live-1",
   "gpt-live-1-mini",
 ];
@@ -76,9 +81,11 @@ describe("ws-realtime known-voice-models canary detection", () => {
   it("flags a new voice family whose id lacks the 'realtime' substring (gpt-live-*)", () => {
     const { unknown } = detectVoiceModelDrift(REPRESENTATIVE_MODELS);
 
-    // The whole point: the new gpt-live-* family is surfaced as unknown drift.
-    expect(unknown).toContain("gpt-live-1");
+    // The whole point: an UNCLASSIFIED gpt-live-* family is surfaced as unknown
+    // drift even though its id carries no "realtime" substring.
     expect(unknown).toContain("gpt-live-1-mini");
+    // ...and the classified sibling does NOT false-positive.
+    expect(unknown).not.toContain("gpt-live-1");
   });
 
   it("does not flag legitimately-known voice/audio models (no false positives)", () => {
@@ -120,11 +127,14 @@ describe("ws-realtime known-voice-models canary detection", () => {
       "gpt-4o-mini-transcribe",
     );
     expect(normalizeVoiceModelFamily("gpt-4o-mini-tts-2025-03-20")).toBe("gpt-4o-mini-tts");
-    // A single-digit trailing tag is NOT a build tag: gpt-live-1 stays a new
-    // family and must remain flaggable.
+    // A single-digit trailing tag is NOT a build tag, so neither id collapses
+    // onto a shorter key. `gpt-live-1` is a classified family as of 2026-09-10;
+    // `gpt-live-1-mini` is not, and must remain flaggable — over-stripping it
+    // onto `gpt-live-1` would silence it.
     expect(normalizeVoiceModelFamily("gpt-live-1")).toBe("gpt-live-1");
     expect(normalizeVoiceModelFamily("gpt-live-1-mini")).toBe("gpt-live-1-mini");
-    expect(knownVoiceModelFamilies.has("gpt-live-1")).toBe(false);
+    expect(knownVoiceModelFamilies.has("gpt-live-1")).toBe(true);
+    expect(knownVoiceModelFamilies.has("gpt-live-1-mini")).toBe(false);
   });
 
   it("is byte-identical to the shared normalizeModelFamily(id, 'openai') primitive", () => {
@@ -168,10 +178,11 @@ describe("ws-realtime known-voice-models canary detection", () => {
     expect(hasGA).toBe(true);
   });
 
-  it("gpt-live-* is the ONLY unknown in the representative payload", () => {
-    // Confirms the matcher is neither too narrow (misses gpt-live) nor too broad
-    // (drags in non-voice models). The unknown set is exactly the new family.
+  it("the unclassified gpt-live-* is the ONLY unknown in the representative payload", () => {
+    // Confirms the matcher is neither too narrow (misses gpt-live-*) nor too
+    // broad (drags in non-voice models). The unknown set is exactly the one
+    // family that is still unclassified.
     const { unknown } = detectVoiceModelDrift(REPRESENTATIVE_MODELS);
-    expect([...unknown].sort()).toEqual(["gpt-live-1", "gpt-live-1-mini"]);
+    expect([...unknown].sort()).toEqual(["gpt-live-1-mini"]);
   });
 });


### PR DESCRIPTION
## Decision: EXCLUDE

OpenAI shipped **GPT-Live-1**, a full-duplex voice model on the NEW `v1/live/sessions` endpoint. Its model page marks Realtime as "Not supported", so it is a **sibling** of the Realtime API, not a successor.

It never answers on `/v1/chat/completions`, and aimock implements no `/v1/live` surface, so it can never be text-generation drift. Every other voice/audio/realtime family in the registry is already excluded — `gpt-realtime*`, `gpt-audio*`, `gpt-transcribe`, `gpt-live-transcribe`, `tts-1`, `whisper-1` — and this gets the same treatment.

Classifying it now is the point: without it the nightly drift pipeline flags `gpt-live-1` as an unclassified new family and opens a needs-human PR, exactly as it did for the two OpenAI image families in #422.

**Mocking `/v1/live` is explicitly NOT proposed** — no demand (no open issue; the only realtime ask closed in May), and a real mock needs a new route, a sideband socket and full-duplex framing.

## Changes

- `model-registry.ts` — `gpt-live-1` added to `excludeFamilies.openai`'s voice cluster, with a dated rationale comment naming the paired entry
- `voice-models.ts` — `gpt-live-1` added to `knownVoiceModelFamilies` (the second, disjoint surface)
- `logic-pin.test.ts` — **both** membership pins re-pinned: `excludeFamilies.openai` (46 -> 47) and `knownVoiceModelFamilies` (22 -> 23)
- `models.drift.ts` — id added to the static OpenAI `/models` wave so the offline coverage test grades it
- `models.drift.ts` / `text-drift.test.ts` — the two assertions that used `gpt-live-1` as the "single-digit tail stays unknown" exemplar now use the still-unclassified `gpt-live-9`, plus `gpt-live-1-mini` to prove the new exclude key does not swallow families that merely EXTEND it
- `ws-realtime-canary.test.ts` / `logic-pin.test.ts` / `model-family.ts` — canary negative controls and docblocks re-pointed at `gpt-live-1-mini`
- `drift-proposals/openai-gpt-live-1-new-family.md` — decision recorded in prose (no `Decision:` marker), status RESOLVED

The pin was reviewed, not chased: each sorted-membership delta printed by the red freeze test is exactly this one addition, and each new hash was recomputed from the module rather than pasted out of the failure message.

## The automated `Decision: exclude` path (#423) is INCOMPLETE for voice families — not used

#423 mechanized the `exclude` verdict (before it, `exclude` fail-closed to `pending`). It is **not** usable here, and the reason is a real defect worth recording:

- Its apply half writes `excludeFamilies[provider]` and re-pins that set. It **never writes `knownVoiceModelFamilies`**.
- `isVoiceModelId("gpt-live-1")` is `true`, and `ws-realtime.drift.ts` sits in drift-sync's **gate-3 re-collect**. A voice family present in one set but not the other still reports `UNKNOWN_REALTIME_MODELS=` and emits a **critical**.
- Gate-3 red reverts both edited files → `gate-failed`. The automated path would **apply and revert, every run, forever** — while looking like it worked.

Verified directly, against the real registry, with the entry in `excludeFamilies` only:

```
excludeFamilies.openai has gpt-live-1  : true
knownVoiceModelFamilies has gpt-live-1 : false
UNKNOWN_REALTIME_MODELS=gpt-live-1
gate3 (ws-realtime.drift.ts re-collect): RED (critical)
```

So the decision is recorded **in prose** and applied **by hand to both sets**, the way `936b59c` did. The note carries **no `Decision:` marker at all** — `parseProposalDecision` on the committed note returns `pending`, confirmed. A literal `Decision: exclude` line would be a live hazard, not inert bookkeeping: if the exclude entry were ever removed, the next run would re-add it to `excludeFamilies` only and wedge the job on gate-3.

**Follow-up (not attempted here):** #423's apply half should also write and re-pin `knownVoiceModelFamilies` when `isVoiceModelId(family)` is true. Any future voice family marked `Decision: exclude` hits this same wall.

## `knownVoiceModelFamilies`: ADDED — mandatory, not optional

`936b59c` — the direct precedent, and a **voice** family — settled this:

> Add both families to excludeFamilies.openai's transcribe cluster [...] **and to knownVoiceModelFamilies' transcription group. The two sets are deliberately disjoint surfaces, so both need the entry.**

`c4582e5` did not touch `knownVoiceModelFamilies` only because image families are not voice. `gpt-live-1` is. The two sets silence two different canaries — `excludeFamilies` → the `/models` check in `models.drift.ts`; `knownVoiceModelFamilies` → the realtime canary in `ws-realtime.drift.ts` — so a voice family needs both.

**Gate-3 proof after the fix**, plus a repo-wide half-classification audit:

```
excludeFamilies.openai has gpt-live-1  : true
knownVoiceModelFamilies has gpt-live-1 : true
UNKNOWN_REALTIME_MODELS=
gate3 (ws-realtime.drift.ts re-collect): GREEN — no critical for gpt-live-1
voice families in excludeFamilies.openai: 21
HALF-CLASSIFIED (exclude but not known-voice): []
```

## `gpt-live-1-mini` stays deliberately unclassified

Only `gpt-live-1` was decided. `gpt-live-1-mini` has not been observed in a live listing; it exists in this repo solely as the realtime canary's **new-family negative control**. Leaving it unclassified keeps that control live — it is what still proves the matcher reaches a voice id carrying no `realtime` substring, and that the new `gpt-live-1` key does not swallow families that merely EXTEND it. The controls in `ws-realtime-canary.test.ts` and `logic-pin.test.ts` were **re-pointed at it, not deleted**.

## Red-green

**1. Offline classification coverage** (`models.drift.ts`) — id added to the wave, not yet classified:

```
FAIL  src/__tests__/drift/models.drift.ts > full live /models wave is fully classified (2026-07-16 drift) > OpenAI: every live family is classified (zero unclassified)
AssertionError: expected [ 'gpt-live-1' ] to deeply equal []
- []
+ [
+   "gpt-live-1",
+ ]
 Test Files  1 failed (1)
      Tests  1 failed | 24 skipped (25)
```

Green after the `excludeFamilies` entry: `Test Files 1 passed (1) / Tests 22 passed | 3 skipped (25)`.

**2. Membership freeze** (`logic-pin.test.ts`) — red on the registry edit:

```
FAIL  freezes excludeFamilies.openai membership
Frozen data set "excludeFamilies.openai" membership changed (now: [... "gpt-image-2.5-sunburst","gpt-live-1","gpt-live-transcribe" ...])
Expected: "f54fe5d9552e4149cb7178fce6316c702fb5f0b00293c2299dfc9f7c64e02baa"
Received: "ccf086b3e7f07b6698f0c875088bd59f1250833d4248e0d624e87c6f592e4021"
```

Green after the re-pin: `Tests 33 passed (33)`.

## Mutation

**A — delete the `excludeFamilies.openai` entry**, everything else left in place:

```
AssertionError: expected [ 'gpt-live-1' ] to deeply equal []
      Tests  1 failed | 24 skipped (25)
```

**B — delete the `knownVoiceModelFamilies` entry** instead:

```
→ expected [ 'gpt-live-1', 'gpt-live-1-mini' ] to not include 'gpt-live-1'
→ expected false to be true
→ expected [ 'gpt-live-1', 'gpt-live-1-mini' ] to deeply equal [ 'gpt-live-1-mini' ]
⎯⎯⎯ Failed Tests 3 ⎯⎯⎯
```

Both halves go red and name `gpt-live-1` — neither guard is vacuous, and neither set alone is sufficient. Restored: full suite green.

## Gates (raw exit codes)

| gate | exit |
| --- | --- |
| `prettier --check .` | 0 |
| `npx eslint .` | 0 |
| `pnpm typecheck` | 0 |
| `npx vitest run` | 0 — 183 files passed, **5689 tests passed** / 46 skipped |
| `npx vitest run --config vitest.config.drift.ts` | 0 — 19 files passed, 135 tests passed / 57 skipped |

---

**Correction note:** the first commit on this branch (`6962f07`) shipped the `excludeFamilies`-only half-classification described above, and its CI was green — because `ws-realtime.drift.ts` is a live-gated canary that does not run as a required PR check. `388c0b6` pairs the entry into `knownVoiceModelFamilies` and removes the `Decision:` marker. The end state is what this description documents.
