### PR TITLE
test(adoption-wall): give each vitest worker its own sandbox root

### DIFF
--- a/src/__tests__/adoption-wall.test.ts
+++ b/src/__tests__/adoption-wall.test.ts
@@ -2996,8 +2996,19 @@ const AW_SCRIPT_SRC = fileURLToPath(new URL("scripts/update-adoption-wall.ts", A
  * ignore it, and a script copied there still resolves the repo's own `prettier`
  * and finds the repo's `.prettierrc` by walking up — so the child formats the
  * page exactly the way a real run does.
+ *
+ * It is mkdtemp'd PER WORKER, and the `afterAll` hooks below delete only this
+ * worker's own directory. A fixed shared path was a cross-process race: two
+ * runs of this file against one checkout — two agents, or a `vitest` run
+ * overlapping a watch — put their sandboxes in the same tree, and whichever
+ * suite finished first `rmSync`'d the whole tree out from under the other,
+ * which surfaced as ENOENT on `docs/index.html` in whichever `main()` cases
+ * happened to be in flight. That failure is load-dependent, so it reads as a
+ * regression in the code under test rather than as harness self-interference.
  */
-const AW_SANDBOX_HOME = fileURLToPath(new URL("node_modules/.aw-main-test/", AW_REPO_ROOT));
+const AW_SANDBOX_ROOT = fileURLToPath(new URL("node_modules/.aw-main-test/", AW_REPO_ROOT));
+mkdirSync(AW_SANDBOX_ROOT, { recursive: true });
+const AW_SANDBOX_HOME = mkdtempSync(join(AW_SANDBOX_ROOT, "worker-"));
 
 /**
  * What the child actually starts. It stubs the run's `fetch` (no network in the


### PR DESCRIPTION
## The premise was wrong; the flake is real

This started as "`adoption-wall.test.ts` probes live avatar URLs and GitHub's CDN
rate-limits us under concurrent load". **It does not touch the network at all.**

Verified by preloading a spy that records every `net.Socket.connect` and `dns.lookup`
(and which propagates into the `tsx` sandbox children the `main()` cases spawn):

```
$ NODE_OPTIONS="--import .../netspy.mjs" npx vitest run src/__tests__/adoption-wall.test.ts
 Tests  270 passed (270)
=== netspy hits ===
48903 DNSP localhost          # <- the only line
```

Positive control, same spy, one real `fetch`:

```
50003 CONNECT avatars.githubusercontent.com:443
50003 DNS lookup avatars.githubusercontent.com
```

Every probe is already stubbed — `withFetch` for the unit cases, the `AW_RUNNER`
`globalThis.fetch` stub for the child process. The 6.3 s case is not network; it is
the script's own `CHECK_RETRY_BASE_MS` backoff (1 s + 2 s + 4 s) being spent for real
inside the child on the `avatarStatus: 429` path.

## What actually breaks

`AW_SANDBOX_HOME` was a **fixed** path, `node_modules/.aw-main-test/`, and two
`afterAll` hooks `rmSync`'d that whole directory. Two runs of this file against one
checkout — two agents, or a `vitest` run overlapping a watch — share that tree, and
whichever suite finishes first deletes the other's live sandboxes mid-run.

## RED

Six staggered concurrent runs of the file, before the change:

```
run1 exit=1   Tests  2 failed | 268 passed (270)
run2 exit=1   Tests  4 failed | 266 passed (270)
run3 exit=1   Tests  4 failed | 266 passed (270)
run4 exit=1   Tests  4 failed | 266 passed (270)
run5 exit=1   Tests  4 failed | 266 passed (270)
run6 exit=1   Tests  3 failed | 267 passed (270)
```

Every failure is the same, and it names the mechanism:

```
FAIL ... > exits 20 and emits a scrapeable reason per problem when a tile disappears
Error: ENOENT: no such file or directory, open
  '.../node_modules/.aw-main-test/run-VkEXm4/docs/index.html'
FAIL ... > recovers a state file that has aged past MAX_STATE_AGE_DAYS in one run
FAIL ... > does NOT advance lastScan when the avatar probes reached no verdict
FAIL ... > does NOT advance lastScan when a repo returned no usable metadata
```

Run alone the file is 270/270, which is why this reads as a regression in the code
under test rather than as the harness deleting its own files.

## GREEN

Same six-way concurrency, three rounds, after the change: **18/18 runs `exit=0`,
270/270 each**.

## Mutation proof

Green is worthless if it is green for the wrong reason, so each affected case was
re-checked against a deliberate break of the guard it covers, in
`scripts/update-adoption-wall.ts`:

| Mutation | Case | Result |
| --- | --- | --- |
| `if (!verdict.ok)` → `if (false)` (neuters the `scanIsConclusive` stamp gate) | `does NOT advance lastScan when the avatar probes reached no verdict` | **RED** |
| same | `does NOT advance lastScan when a repo returned no usable metadata` | **RED** |
| drop `writeFileSync(statePath, ...)` | `recovers a state file that has aged past MAX_STATE_AGE_DAYS in one run` | **RED** |
| drop `reasons.push("${repo} is on the wall today but absent...")` | `exits 20 and emits a scrapeable reason per problem when a tile disappears` | **RED** |

The 21-day-fuse guard still bites.

## The change

`mkdtemp` the worker's sandbox root *under* that path and let each `afterAll` delete
only its own. Nothing else moves — the sandbox still lives under `node_modules`, so
git, prettier and eslint ignore it and the child still resolves the repo's own
`prettier` and `.prettierrc` by walking up. One test file touched; no production code,
no assertion, no stub changed.

## Nothing was stubbed, nothing left live

No test was converted, so no coverage moved. The four real failure classes stay
covered exactly as they were: 403/429 (`fetchRepoMetaRest` rejects `/403/`, `/429/`;
`checkLogo` calls 429/500/503 `inconclusive`), network error, non-image content-type
(`200 text/html` → dead), and a missing owner (`api.github.com/user/<id>` → 404).

## Runtime

Unchanged — the fix is a path, not a timing change. `11.11 s` before, `11.02 s` after
for the file alone; `22.14 s` wall for the full 5732-test suite.

## Gates (raw exit codes)

| gate | code |
| --- | --- |
| `prettier --check .` | 0 |
| `npx eslint .` | 0 |
| `pnpm typecheck` | 0 |
| `npx vitest run` (5686 passed, 46 skipped) | 0 |
