### PR TITLE
fix(drift-sync): enforce the pin-file boundary in the checker, not the writer

### DIFF
--- a/.github/workflows/fix-drift.yml
+++ b/.github/workflows/fix-drift.yml
@@ -25,8 +25,11 @@ jobs:
   # THE AUTOMATION BOUNDARY. The only thing this job does autonomously is the
   # DETERMINISTIC, zero-agent model-family sync below (`drift-sync.ts` /
   # `drift-sync-check.ts`), which only ever performs a mechanical, data-only
-  # edit to `model-registry.ts` or drops a needs-human dedup note file — never
-  # arbitrary code generation, so there is no adversarial diff to police.
+  # edit to `model-registry.ts`, the matching membership re-pin of that set in
+  # `logic-pin.test.ts` (gate-1b proves the diff is a pin-only edit of a
+  # `(include|exclude)Families.<provider>` key and nothing else), or drops a
+  # needs-human dedup note file — never arbitrary code generation, so there is
+  # no adversarial diff to police.
   #
   # General (non-model-churn) drift is not auto-fixed here at all: it is caught
   # by the daily `Drift Tests` workflow, which alerts on its own, and fixed by a

--- a/scripts/drift-pin-file.ts
+++ b/scripts/drift-pin-file.ts
@@ -1,0 +1,272 @@
+/// <reference types="node" />
+
+/**
+ * The `logic-pin.test.ts` DATA_FROZEN pin surface — locating, rewriting and
+ * VERIFYING a membership re-pin, in one module both the WRITER
+ * (`drift-sync.ts`) and the external CHECKER (`drift-sync-check.ts`) import.
+ *
+ * WHY THIS IS ITS OWN MODULE. `drift-sync-check.ts` gate-1 admits
+ * `logic-pin.test.ts` to the sync's changed-file allowlist. Before this module
+ * existed, the only thing narrowing that admission lived inside the writer —
+ * i.e. the constraint on the pin file was enforced by the same trust domain
+ * that edits it, and the external gate (which is the thing an "LLM told to make
+ * the drift job pass" cannot talk its way past) had no opinion at all. Because
+ * `model-registry.ts` is allowlisted too, that combination was sufficient to
+ * silence a frozen surface: widen `isClassifiedFamily`, re-paste that surface's
+ * `FROZEN` pin, and gate-1 and gate-2 both pass. `verifyPinFileEdit` is the
+ * predicate that closes it, and the CHECKER evaluates it over the git diff.
+ *
+ * ONE PROPERTY, STATED HONESTLY. The PR this replaces claimed two independent
+ * guards and had one and a half: `maskPins` collapses EVERY `pin:` literal to
+ * the same token — the FROZEN logic checksums included — so it can tell neither
+ * which key moved nor whether the pin it moved was one the sync may touch. It
+ * agreed with the locator instead of checking it. `verifyPinFileEdit` replaces
+ * the pair with a reconstruction: re-apply exactly the entitled pin rewrites to
+ * the pre-edit file and require the result to be the post-edit file byte for
+ * byte. Everything else is a refusal by construction.
+ */
+
+import ts from "typescript";
+
+/** The exact test file P0 froze the classification logic in. Single source of truth. */
+export const LOGIC_PIN_REL_PATH = "src/__tests__/drift/logic-pin.test.ts";
+
+/** A pin literal is always a lowercase 64-char SHA-256 hex digest. */
+const PIN_VALUE = /^[0-9a-f]{64}$/;
+
+export interface DataFrozenPin {
+  /** The current pin value. */
+  pin: string;
+  /** Source offset of the first character INSIDE the pin string literal. */
+  start: number;
+  /** Source offset one past the last character inside the pin string literal. */
+  end: number;
+}
+
+/**
+ * Every `DATA_FROZEN` entry's `pin:` literal, keyed by entry name, located via
+ * the real TypeScript parser.
+ *
+ * AST, not a forward text scan, because a forward scan is how the wrong entry
+ * gets rewritten: the previous implementation searched from the key for the next
+ * `pin:` and refused only if a QUOTED key intervened — but three real
+ * DATA_FROZEN keys are unquoted (`knownVoiceModelFamilies`, `gaRealtimeModels`,
+ * `MIN_LISTING_SIZE`), and one of them sits directly after the last key the sync
+ * writes. A target entry whose own pin was not recognisable therefore landed the
+ * write on the NEXT entry's pin (reproduced against the real file: the realtime
+ * canary's seed-set pin was overwritten with a chat-family membership hash).
+ * An entry-scoped AST lookup cannot express that failure at all.
+ *
+ * Returns `null` when the file has no `DATA_FROZEN` object literal — the caller
+ * must treat that as a refusal, never as "no keys moved".
+ */
+export function parseDataFrozenPins(source: string): Map<string, DataFrozenPin> | null {
+  const sf = ts.createSourceFile("logic-pin.test.ts", source, ts.ScriptTarget.Latest, true);
+  let obj: ts.ObjectLiteralExpression | undefined;
+  for (const stmt of sf.statements) {
+    if (!ts.isVariableStatement(stmt)) continue;
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || decl.name.text !== "DATA_FROZEN") continue;
+      if (decl.initializer && ts.isObjectLiteralExpression(decl.initializer)) {
+        obj = decl.initializer;
+      }
+    }
+  }
+  if (!obj) return null;
+
+  const out = new Map<string, DataFrozenPin>();
+  const duplicated = new Set<string>();
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) continue;
+    const name = ts.isStringLiteral(prop.name)
+      ? prop.name.text
+      : ts.isIdentifier(prop.name)
+        ? prop.name.text
+        : null;
+    if (name === null) continue;
+    if (out.has(name)) {
+      duplicated.add(name);
+      continue;
+    }
+    if (!ts.isObjectLiteralExpression(prop.initializer)) continue;
+    for (const entryProp of prop.initializer.properties) {
+      if (!ts.isPropertyAssignment(entryProp)) continue;
+      const entryName = ts.isIdentifier(entryProp.name)
+        ? entryProp.name.text
+        : ts.isStringLiteral(entryProp.name)
+          ? entryProp.name.text
+          : null;
+      if (entryName !== "pin") continue;
+      const init = entryProp.initializer;
+      if (!ts.isStringLiteral(init)) continue;
+      out.set(name, { pin: init.text, start: init.getStart(sf) + 1, end: init.getEnd() - 1 });
+    }
+  }
+  // A duplicated key is a structural surprise, not a choice between two spans:
+  // drop it entirely so every consumer refuses rather than picking one.
+  for (const name of duplicated) out.delete(name);
+  return out;
+}
+
+/**
+ * Replace the `pin:` literal belonging to ONE DATA_FROZEN key. Returns
+ * `locatorMiss` when the key is missing, duplicated, or carries no recognisable
+ * pin — the caller routes that to a human rather than guessing, exactly as it
+ * does for a registry structural mismatch.
+ *
+ * The rewrite is span-exact and entry-scoped: the bytes replaced are the ones
+ * INSIDE the named entry's own pin string literal, so the write cannot land on
+ * a neighbouring entry however the surrounding file is shaped.
+ */
+export function updateDataFrozenPin(
+  source: string,
+  key: string,
+  newPin: string,
+): { text: string; changed: boolean; locatorMiss: boolean } {
+  const pins = parseDataFrozenPins(source);
+  const target = pins?.get(key);
+  // No DATA_FROZEN, no such entry, a duplicated entry, an entry with no `pin:`
+  // string literal, or a pin that is not a recognisable digest: all refusals.
+  if (!target || !PIN_VALUE.test(target.pin)) {
+    return { text: source, changed: false, locatorMiss: true };
+  }
+  if (target.pin === newPin) return { text: source, changed: false, locatorMiss: false };
+  return {
+    text: source.slice(0, target.start) + newPin + source.slice(target.end),
+    changed: true,
+    locatorMiss: false,
+  };
+}
+
+/** Every `pin: "<hex>"` literal, normalised away — used to prove a diff is pin-only. */
+function maskPins(source: string): string {
+  return source.replace(/pin:\s*"[0-9a-f]{64}"/g, 'pin: "<PIN>"');
+}
+
+/**
+ * `after` differs from `before` only inside SOME `pin:` string literal.
+ *
+ * NOT A GUARD, and the PR this replaces mistook it for one. `maskPins` collapses
+ * EVERY `pin:` literal in the file to one token — the `FROZEN` LOGIC checksums
+ * included — so re-pasting the checksum of a widened `isClassifiedFamily` reads
+ * as "pin-only" here and sails through; reproduced end to end, with gate-1 and
+ * gate-2 both passing a tree whose classification rule had been silenced. It
+ * decides nothing in {@link verifyPinFileEdit}: it only picks which of that
+ * refusal's two messages is the true one.
+ */
+export function onlyPinsChanged(before: string, after: string): boolean {
+  return maskPins(before) === maskPins(after);
+}
+
+export type PinKeyDiff =
+  | { ok: true; changedKeys: string[] }
+  | { ok: false; changedKeys: string[]; detail: string };
+
+/**
+ * Exactly which DATA_FROZEN entries' pins differ between two revisions of the
+ * pin file, BY NAME.
+ *
+ * Not ok when either revision has no parseable `DATA_FROZEN`, or when the set of
+ * entries itself changed — an entry appearing or disappearing is a structural
+ * edit, not a re-pin, and must never be reported as "these keys moved".
+ */
+export function diffPinKeys(before: string, after: string): PinKeyDiff {
+  const a = parseDataFrozenPins(before);
+  const b = parseDataFrozenPins(after);
+  if (a === null || b === null) {
+    return {
+      ok: false,
+      changedKeys: [],
+      detail: "could not parse a DATA_FROZEN pin table out of the pin file",
+    };
+  }
+  const added = [...b.keys()].filter((k) => !a.has(k));
+  const removed = [...a.keys()].filter((k) => !b.has(k));
+  if (added.length > 0 || removed.length > 0) {
+    return {
+      ok: false,
+      changedKeys: [],
+      detail:
+        `the DATA_FROZEN entry set itself changed (added: ${added.join(", ") || "none"}; ` +
+        `removed: ${removed.join(", ") || "none"}) — that is a structural edit, not a re-pin`,
+    };
+  }
+  const changedKeys = [...a.keys()].filter((k) => a.get(k)!.pin !== b.get(k)!.pin).sort();
+  return { ok: true, changedKeys };
+}
+
+/** The DATA_FROZEN keys drift-sync is ever entitled to re-pin: membership of the sets it edits. */
+export const SYNC_REPINNABLE_KEYS: ReadonlySet<string> = new Set(
+  ["includeFamilies", "excludeFamilies"].flatMap((list) =>
+    ["openai", "anthropic", "gemini"].map((provider) => `${list}.${provider}`),
+  ),
+);
+
+/**
+ * The single predicate that makes admitting `logic-pin.test.ts` to the sync's
+ * changed-file allowlist safe: this diff is a membership re-pin of `allowedKeys`
+ * AND NOTHING ELSE.
+ *
+ * It is stated as a RECONSTRUCTION, not as a pattern the diff must avoid: take
+ * `before`, apply exactly the entitled pin rewrites `after` asks for, and demand
+ * the result be `after` BYTE FOR BYTE. Any other edit anywhere in the file — a
+ * re-pasted `FROZEN` logic checksum, a widened `members` thunk, a deleted entry,
+ * a changed comment — makes the reconstruction differ, with no enumeration of
+ * forbidden shapes to keep exhaustive.
+ *
+ * Evaluated in two places, deliberately, over different inputs:
+ *   * the WRITER, over its own in-memory rewrite, with `allowedKeys` = the keys
+ *     THIS run re-pinned — so a write that lands on any other entry is refused
+ *     before it reaches the filesystem;
+ *   * the CHECKER (gate-1b), over the git diff of the working tree against HEAD,
+ *     with `allowedKeys` = {@link SYNC_REPINNABLE_KEYS} — so a pin-file diff that
+ *     re-pastes a `FROZEN` LOGIC checksum is refused by the external gate, no
+ *     matter which writer produced it. That one is the real boundary: it does not
+ *     trust the writer at all.
+ */
+export function verifyPinFileEdit(
+  before: string,
+  after: string,
+  allowedKeys: ReadonlySet<string>,
+): { ok: boolean; detail: string } {
+  const diff = diffPinKeys(before, after);
+  if (!diff.ok) return { ok: false, detail: diff.detail };
+  const offending = diff.changedKeys.filter((k) => !allowedKeys.has(k));
+  if (offending.length > 0) {
+    return {
+      ok: false,
+      detail:
+        `the edit re-pinned DATA_FROZEN key(s) it is not entitled to move: ${offending.join(", ")} ` +
+        `(allowed: ${[...allowedKeys].sort().join(", ")})`,
+    };
+  }
+  const afterPins = parseDataFrozenPins(after)!;
+  let reconstructed = before;
+  for (const key of diff.changedKeys) {
+    const edit = updateDataFrozenPin(reconstructed, key, afterPins.get(key)!.pin);
+    if (edit.locatorMiss) {
+      return { ok: false, detail: `could not re-locate the DATA_FROZEN pin for "${key}"` };
+    }
+    reconstructed = edit.text;
+  }
+  if (reconstructed !== after) {
+    // ONE verdict, two messages. `onlyPinsChanged` cannot decide anything here —
+    // it is blind to WHICH pin moved, which is why it was never a second guard —
+    // but it does separate the two ways to fail this, and a refusal that says
+    // which one it is saves the next reader the diff.
+    return {
+      ok: false,
+      detail: onlyPinsChanged(before, after)
+        ? "the edit moved a `pin:` literal that is not a re-pinnable membership pin — a " +
+          "re-pasted FROZEN logic checksum looks pin-only and lands exactly here"
+        : "the edit changed bytes outside a `pin:` string literal",
+    };
+  }
+  return {
+    ok: true,
+    detail:
+      diff.changedKeys.length === 0
+        ? "no DATA_FROZEN pin moved"
+        : `re-pinned ${diff.changedKeys.join(", ")} and nothing else`,
+  };
+}

--- a/scripts/drift-sync-check.ts
+++ b/scripts/drift-sync-check.ts
@@ -58,6 +58,7 @@ import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
 import { getChangedFiles } from "./drift-sync.js";
+import { LOGIC_PIN_REL_PATH, SYNC_REPINNABLE_KEYS, verifyPinFileEdit } from "./drift-pin-file.js";
 import type { DriftReport } from "./drift-types.js";
 
 // ---------------------------------------------------------------------------
@@ -67,6 +68,7 @@ import type { DriftReport } from "./drift-types.js";
 export enum SyncCheckReason {
   OK = "ok",
   OFF_ALLOWLIST_CHANGE = "off-allowlist-change",
+  PIN_FILE_NOT_A_MEMBERSHIP_REPIN = "pin-file-not-a-membership-repin",
   PIN_CHECK_FAILED = "pin-check-failed",
   RESIDUAL_CRITICAL_DRIFT = "residual-critical-drift",
   CONFIG_ERROR = "config-error",
@@ -75,6 +77,7 @@ export enum SyncCheckReason {
 export const REASON_EXIT_CODE: Record<SyncCheckReason, number> = {
   [SyncCheckReason.OK]: 0,
   [SyncCheckReason.OFF_ALLOWLIST_CHANGE]: 20,
+  [SyncCheckReason.PIN_FILE_NOT_A_MEMBERSHIP_REPIN]: 23,
   [SyncCheckReason.PIN_CHECK_FAILED]: 21,
   [SyncCheckReason.RESIDUAL_CRITICAL_DRIFT]: 22,
   [SyncCheckReason.CONFIG_ERROR]: 2,
@@ -88,21 +91,31 @@ export class SyncCheckConfigError extends Error {}
 // ---------------------------------------------------------------------------
 
 /**
- * The ONLY file a sync may edit directly: the model-registry DATA file
- * (`includeFamilies`/`excludeFamilies` literal entries). It also hosts P0's
- * frozen logic surfaces — see the pin re-assert in gate (2), which still
- * blocks an edit here that touches one of those surfaces.
+ * The files a sync may edit directly: the model-registry DATA file
+ * (`includeFamilies`/`excludeFamilies` literal entries), and the membership
+ * pins that describe it. model-registry.ts also hosts P0's frozen logic
+ * surfaces — see the pin re-assert in gate (2), which blocks an edit there that
+ * touches one of those surfaces. Gate-2 cannot do the same job for
+ * `logic-pin.test.ts`, because that file is gate-2's own oracle: re-pasting a
+ * FROZEN checksum makes gate-2 green BY CONSTRUCTION. `checkPinFileEdit`
+ * (gate-1b) is what constrains that file.
  */
 const ALLOWED_EXACT_FILES: ReadonlySet<string> = new Set([
   "src/__tests__/drift/model-registry.ts",
   // The membership checksums live here, and drift-sync re-pins the ONE affected
-  // key in the same run that applies a human-approved classification. Admitting
-  // the file at the path level is not what keeps this narrow — `onlyPinsChanged`
-  // in drift-sync.ts refuses to write unless the edit is confined to `pin:`
-  // string literals, so the frozen LOGIC in this file remains untouchable by the
-  // sync. Without the entry the approved edit lands and gate-2 immediately reds
-  // on the now-stale pin, so every approval reported gate-failed instead of
-  // ok-applied — the approval affordance the note advertises never worked.
+  // key in the same run that applies a human-approved classification. Without
+  // the entry the approved edit lands and gate-2 immediately reds on the
+  // now-stale pin, so every approval reported gate-failed instead of ok-applied
+  // — the approval affordance the note advertises never worked.
+  //
+  // ADMITTING IT AT THE PATH LEVEL IS NOT THE WHOLE STORY, and it must not be:
+  // `model-registry.ts` is allowlisted too, so a path-level admission alone lets
+  // a run widen `isClassifiedFamily` AND re-paste that surface's FROZEN pin, and
+  // pass gate-1 and gate-2 both — the exact "bot told to make the drift job
+  // pass" this file's own header names (reproduced; see checkPinFileEdit).
+  // `checkPinFileEdit` below is the narrowing, and it runs HERE, over the git
+  // diff, not inside the writer: a constraint on the pin file that only the
+  // writer enforces is not a constraint on the pin file.
   "src/__tests__/drift/logic-pin.test.ts",
 ]);
 
@@ -123,12 +136,27 @@ export function checkChangedFileAllowlist(changedFiles: string[]): string[] {
   return changedFiles.filter((file) => !isAllowedSyncFile(file));
 }
 
+/**
+ * Gate-1b: a `logic-pin.test.ts` diff must be a MEMBERSHIP RE-PIN and nothing
+ * else — no byte outside a `pin:` literal moved, and the only pins that moved
+ * belong to the six `(include|exclude)Families.<provider>` DATA_FROZEN keys.
+ *
+ * This is the constraint that replaces the path-level admission above. It is
+ * evaluated on the DIFF (HEAD vs the working tree), so it holds for whatever
+ * produced the edit — not only for the writer that promises to behave.
+ *
+ * `before` is the file at HEAD; `after` is the working tree.
+ */
+export function checkPinFileEdit(before: string, after: string): { ok: boolean; detail: string } {
+  return verifyPinFileEdit(before, after, SYNC_REPINNABLE_KEYS);
+}
+
 // ---------------------------------------------------------------------------
 // (2) Checksum-pin re-assert.
 // ---------------------------------------------------------------------------
 
 /** The exact test file P0 froze the classification logic in. Single source of truth. */
-const LOGIC_PIN_TEST = "src/__tests__/drift/logic-pin.test.ts";
+const LOGIC_PIN_TEST = LOGIC_PIN_REL_PATH;
 
 export interface CommandResult {
   status: number;
@@ -292,6 +320,13 @@ export function recollect(
 
 export interface SyncCheckDeps {
   getChangedFiles: () => string[];
+  /**
+   * `logic-pin.test.ts` as of HEAD (pre-sync) and in the working tree
+   * (post-sync), for gate-1b. Required, not optional: a gate that silently
+   * turns itself off when a dep is absent is not a gate.
+   */
+  readCommittedPinFile: () => string;
+  readWorkingPinFile: () => string;
   runPinCheck: () => PinCheckResult;
   recollect: () => DriftReport;
 }
@@ -340,6 +375,20 @@ export function evaluateSyncCheck(
       detail: `Sync touched file(s) outside the data-only allowlist: ${offendingFiles.join(", ")}`,
       offendingFiles,
     };
+  }
+
+  if (changedFiles.includes(LOGIC_PIN_TEST)) {
+    const pinEdit = checkPinFileEdit(deps.readCommittedPinFile(), deps.readWorkingPinFile());
+    if (!pinEdit.ok) {
+      return {
+        ok: false,
+        reason: SyncCheckReason.PIN_FILE_NOT_A_MEMBERSHIP_REPIN,
+        detail:
+          `${LOGIC_PIN_TEST} is on the allowlist ONLY for membership re-pins of ` +
+          `${[...SYNC_REPINNABLE_KEYS].sort().join(", ")}, and this diff is not one: ${pinEdit.detail}`,
+        offendingFiles: [LOGIC_PIN_TEST],
+      };
+    }
   }
 
   const pin = deps.runPinCheck();
@@ -418,8 +467,29 @@ export function evaluateSyncCheck(
 // CLI
 // ---------------------------------------------------------------------------
 
+/**
+ * A tracked file's content at HEAD. Fail-closed: if git cannot produce it, the
+ * gate has no baseline to judge the diff against and must refuse, never fall
+ * back to "assume unchanged".
+ */
+export function readCommittedFile(relPath: string): string {
+  try {
+    return execFileSync("git", ["show", `HEAD:${relPath}`], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err: unknown) {
+    throw new SyncCheckConfigError(
+      `Could not read ${relPath} at HEAD (${err instanceof Error ? err.message : String(err)}) — ` +
+        `gate-1 cannot verify the pin-file diff without its pre-sync baseline`,
+    );
+  }
+}
+
 const REAL_DEPS: SyncCheckDeps = {
   getChangedFiles,
+  readCommittedPinFile: () => readCommittedFile(LOGIC_PIN_TEST),
+  readWorkingPinFile: () => readFileSync(resolve(LOGIC_PIN_TEST), "utf-8"),
   runPinCheck: () => runPinCheck(),
   recollect: () => recollect(),
 };

--- a/scripts/drift-sync.ts
+++ b/scripts/drift-sync.ts
@@ -32,7 +32,13 @@ import { fileURLToPath } from "node:url";
 
 import ts from "typescript";
 
-import { evaluateSyncCheck, runPinCheck, recollect } from "./drift-sync-check.js";
+import {
+  evaluateSyncCheck,
+  runPinCheck,
+  recollect,
+  readCommittedFile,
+} from "./drift-sync-check.js";
+import { LOGIC_PIN_REL_PATH, updateDataFrozenPin, verifyPinFileEdit } from "./drift-pin-file.js";
 import type { DriftReport, DriftSeverity } from "./drift-types.js";
 
 import { normalizeModelFamily } from "../src/__tests__/drift/model-family.js";
@@ -48,6 +54,11 @@ import {
   isFamilyStillReferenced,
   isForwardLookingFamily,
 } from "../src/__tests__/drift/deprecation-detector.js";
+import {
+  isVoiceModelId,
+  knownVoiceModelFamilies,
+  normalizeVoiceModelFamily,
+} from "../src/__tests__/drift/voice-models.js";
 import {
   InfraError,
   isInfraSkip,
@@ -480,7 +491,25 @@ export const DRIFT_PROPOSALS_DIR = "drift-proposals";
  * records mechanically (see `deprecatedFamilies` in model-registry.ts), so it
  * never produces a note and never pages anyone.
  */
-export type ProposalKind = "new-family" | "registry-structural-mismatch";
+export type ProposalKind =
+  | "new-family"
+  | "registry-structural-mismatch"
+  /**
+   * A human's `Decision:` on a VOICE/AUDIO family. `excludeFamilies` and
+   * `knownVoiceModelFamilies` are deliberately disjoint surfaces (see
+   * `voice-models.ts`), and the sync writes only the first — so applying a
+   * voice family's classification alone leaves the realtime canary red, the
+   * gate refuses the run, both files revert, and the identical note re-fires
+   * the same apply/fail/revert every night forever. Routed to a human instead.
+   */
+  | "voice-seed-set"
+  /**
+   * A classification a human decided that drift-sync could NOT safely re-pin.
+   * The registry edit was refused wholesale, so this run wrote nothing but this
+   * note — which exists so the refusal has a deduped, human-facing artifact
+   * instead of only a red job.
+   */
+  | "pin-repin-failure";
 export type ProposalDecision = "pending" | "include" | "exclude";
 
 /** Family-keyed dedup path — re-firing the same alert always resolves to the SAME path. */
@@ -490,7 +519,12 @@ export function proposalNoteRelPath(
   kind: ProposalKind,
 ): string {
   const slug = family.replace(/[^a-z0-9.-]+/gi, "-");
-  const kindSlug = kind === "new-family" ? "new-family" : "structural-mismatch";
+  const kindSlug =
+    kind === "new-family"
+      ? "new-family"
+      : kind === "registry-structural-mismatch"
+        ? "structural-mismatch"
+        : kind;
   return `${DRIFT_PROPOSALS_DIR}/${provider}-${slug}-${kindSlug}.md`;
 }
 
@@ -516,7 +550,11 @@ export function renderProposalNote(
   const title =
     kind === "new-family"
       ? "New / unclassified model family"
-      : "Registry structural mismatch — mechanical edit could not be applied";
+      : kind === "registry-structural-mismatch"
+        ? "Registry structural mismatch — mechanical edit could not be applied"
+        : kind === "voice-seed-set"
+          ? "Voice/audio family — classification needs a second, hand-written edit"
+          : "Membership re-pin refused — classification not applied";
   const lines = [
     `# ${title}: ${family}`,
     "",
@@ -539,7 +577,17 @@ export function renderProposalNote(
       "     The NEXT drift-sync run then applies the mechanical registry edit to",
       "     includeFamilies or excludeFamilies respectively, and re-pins that",
       "     set's membership checksum in the same commit (still zero-LLM: this",
-      "     is a human-authored decision, not generated code). -->",
+      "     is a human-authored decision, not generated code).",
+      "",
+      "     ONE EXCEPTION, and it is the common one for `exclude`: a VOICE/AUDIO",
+      "     family (realtime / audio / live / transcribe / whisper / voice / tts)",
+      "     is watched by a SECOND canary whose seed set — knownVoiceModelFamilies",
+      "     in src/__tests__/drift/voice-models.ts — is a deliberately disjoint",
+      "     surface drift-sync does not write. Classifying such a family in the",
+      "     registry alone leaves that canary red, so the run would gate-fail and",
+      "     revert, nightly, forever. drift-sync therefore does NOT auto-apply it:",
+      "     it drops a `-voice-seed-set.md` note and a human makes both edits in",
+      "     one reviewed commit. -->",
       "Decision: pending",
       "",
     );
@@ -574,16 +622,35 @@ export const MODEL_REGISTRY_REL_PATH = "src/__tests__/drift/model-registry.ts";
 // the human-authored `Decision:` line in the drift-proposals/ note. Once that
 // verdict exists, moving the pin is bookkeeping, not judgement.
 //
-// Two things keep this narrow:
-//   1. `updateDataFrozenPin` rewrites the pin of exactly ONE named key, and
-//      refuses (locatorMiss) if that key is absent or appears more than once.
-//   2. `onlyPinsChanged` re-reads the result and refuses the write unless every
-//      byte outside a `pin:` string literal is identical. The frozen LOGIC in
-//      that file is therefore unreachable by the sync even though the path sits
-//      on drift-sync-check's allowlist.
+// Three things keep this narrow, and only the first two are this module's:
+//   1. `updateDataFrozenPin` rewrites the pin of exactly ONE named key, located
+//      through the TypeScript AST and replaced span-exactly INSIDE that entry's
+//      own string literal, and refuses (locatorMiss) if the key is absent,
+//      duplicated, or carries no recognisable digest.
+//   2. `verifyPinFileEdit` re-reads the result and refuses the write unless
+//      re-applying THIS RUN'S re-pins to the pre-edit file reproduces it byte
+//      for byte. "Only `pin:` literals moved" is not that check: every `pin:`
+//      literal — the FROZEN LOGIC checksums included — masks to the same token,
+//      so both a wrong-key write and a re-pasted logic checksum read as
+//      pin-only.
+//   3. The EXTERNAL gate. `drift-sync-check` evaluates the same predicate over
+//      the git diff, keyed to `SYNC_REPINNABLE_KEYS`. That one is what actually
+//      constrains the file, because it does not trust this writer at all.
 // ---------------------------------------------------------------------------
 
-export const LOGIC_PIN_REL_PATH = "src/__tests__/drift/logic-pin.test.ts";
+// The pin-file locator, rewriter and verifier live in `drift-pin-file.ts` — see
+// that module's header for why they are not in here: the CHECKER has to evaluate
+// the same predicate over the git diff, and a constraint on the pin file that
+// only the writer enforces is not a constraint on the pin file.
+export {
+  LOGIC_PIN_REL_PATH,
+  updateDataFrozenPin,
+  onlyPinsChanged,
+  diffPinKeys,
+  parseDataFrozenPins,
+  verifyPinFileEdit,
+  SYNC_REPINNABLE_KEYS,
+} from "./drift-pin-file.js";
 
 /** The DATA_FROZEN key a `<listName>[<provider>]` membership set is pinned under. */
 export function dataFrozenKey(listName: RegistrySetName, provider: Provider): string {
@@ -594,64 +661,16 @@ export function dataFrozenKey(listName: RegistrySetName, provider: Provider): st
  * The pin value logic-pin.test.ts computes for a membership set:
  * `sha256(JSON.stringify(sortedMembers))`. Mirrors that file's own `sha256`
  * helper and its `members()` accessor, which sorts before hashing.
+ *
+ * DEDUPED, because the real sets are `Set`s built through `familySet`: if an
+ * applied family ever normalises onto an existing member, hashing the plain
+ * concatenation would pin a duplicated array the pin file can never reproduce —
+ * a wrong pin that reds gate-2 and reads like a spurious membership change.
  */
 export function computeMembershipPin(members: readonly string[]): string {
   return createHash("sha256")
-    .update(JSON.stringify([...members].sort()))
+    .update(JSON.stringify([...new Set(members)].sort()))
     .digest("hex");
-}
-
-/** Every `pin: "<hex>"` literal, normalised away — used to prove a diff is pin-only. */
-function maskPins(source: string): string {
-  return source.replace(/pin:\s*"[0-9a-f]{64}"/g, 'pin: "<PIN>"');
-}
-
-/**
- * True when `after` differs from `before` ONLY inside `pin:` string literals.
- * This is the guard that makes admitting logic-pin.test.ts to the sync's
- * allowlist safe: a rewrite that touched a frozen source-hash, a member
- * accessor, or any surrounding logic fails here and is never written.
- */
-export function onlyPinsChanged(before: string, after: string): boolean {
-  return maskPins(before) === maskPins(after);
-}
-
-/**
- * Replace the `pin:` literal belonging to ONE DATA_FROZEN key. Returns
- * `locatorMiss` when the key is missing, duplicated, or carries no recognisable
- * pin — the caller routes that to a human rather than guessing, exactly as it
- * does for a registry structural mismatch.
- */
-export function updateDataFrozenPin(
-  source: string,
-  key: string,
-  newPin: string,
-): { text: string; changed: boolean; locatorMiss: boolean } {
-  const keyLiteral = `"${key}":`;
-  const occurrences = source.split(keyLiteral).length - 1;
-  if (occurrences !== 1) return { text: source, changed: false, locatorMiss: true };
-
-  const keyStart = source.indexOf(keyLiteral);
-  // Scope the search to this entry only: from the key to the first `pin:` that
-  // follows it, refusing if another entry's key intervenes.
-  const pinMatch = /pin:\s*"([0-9a-f]{64})"/.exec(source.slice(keyStart));
-  if (!pinMatch || pinMatch.index === undefined) {
-    return { text: source, changed: false, locatorMiss: true };
-  }
-  const absoluteIndex = keyStart + pinMatch.index;
-  const between = source.slice(keyStart + keyLiteral.length, absoluteIndex);
-  if (/"[A-Za-z0-9_.-]+":\s*\{/.test(between)) {
-    // A different DATA_FROZEN entry starts before this key's pin — the file's
-    // shape is not what we assume. Refuse.
-    return { text: source, changed: false, locatorMiss: true };
-  }
-  if (pinMatch[1] === newPin) return { text: source, changed: false, locatorMiss: false };
-
-  const text =
-    source.slice(0, absoluteIndex) +
-    pinMatch[0].replace(pinMatch[1], newPin) +
-    source.slice(absoluteIndex + pinMatch[0].length);
-  return { text, changed: true, locatorMiss: false };
 }
 
 export type RegistrySetName = "includeFamilies" | "excludeFamilies" | "deprecatedFamilies";
@@ -836,12 +855,39 @@ export interface SyncCoreDeps {
   now?: () => Date;
 }
 
+/**
+ * Would classifying `family` in the registry alone leave the REALTIME CANARY
+ * red?
+ *
+ * `ws-realtime.drift.ts` asserts `detectVoiceModelDrift(liveIds).unknown === []`
+ * at CRITICAL severity, and that computation reads `knownVoiceModelFamilies` in
+ * `voice-models.ts` — a set that is deliberately DISJOINT from
+ * `includeFamilies`/`excludeFamilies` and that drift-sync does not write. So for
+ * a family this returns true for, an auto-applied classification is a guaranteed
+ * gate-3 failure: apply, revert, alert — with the note still saying `Decision:
+ * exclude`, so the identical run repeats every night forever. The precedent the
+ * exclude affordance was modelled on (936b59c, gpt-transcribe /
+ * gpt-live-transcribe) needed BOTH edits by hand and says so.
+ *
+ * Both verdicts are covered, not just `exclude`: the canary reads the voice seed
+ * set, not the classification, so `include` of an unknown voice family leaves it
+ * just as red.
+ *
+ * A voice-shaped family ALREADY in the seed set is not affected — the canary is
+ * quiet for it, so the registry edit is the only one outstanding.
+ */
+export function needsVoiceSeedSetEdit(family: string): boolean {
+  return isVoiceModelId(family) && !knownVoiceModelFamilies.has(normalizeVoiceModelFamily(family));
+}
+
 export type FamilyAction =
   | "deprecation-recorded"
   | "added"
   | "excluded"
   | "needs-human-new-family"
   | "needs-human-structural-mismatch"
+  | "needs-human-voice-seed-set"
+  | "needs-human-repin"
   | "no-op";
 
 export interface FamilyOutcome {
@@ -905,6 +951,11 @@ export function gate3SkipReason(outcomes: readonly FamilyOutcome[]): string | nu
     return "this run only RECORDED deprecations, and no live drift surface reads deprecatedFamilies — a re-collect cannot observe this edit";
   }
   return null;
+}
+
+/** The registry set a human `Decision:` word writes into. */
+function listNameFor(decision: "include" | "exclude"): RegistrySetName {
+  return decision === "include" ? "includeFamilies" : "excludeFamilies";
 }
 
 /** Read-or-create a dedup note (write only on first sighting — re-fire never spams a duplicate). */
@@ -1073,13 +1124,51 @@ export function runDriftSyncCore(
         touchedFiles,
       );
       const decision = existing !== null ? parseProposalDecision(existing) : "pending";
-      if (decision === "include" || decision === "exclude") {
+      if ((decision === "include" || decision === "exclude") && needsVoiceSeedSetEdit(family)) {
+        // A DECIDED voice/audio family still needs a second, hand-written edit
+        // to the disjoint voice seed set. Applying half of it is worse than
+        // applying none: the run gate-fails on the still-red realtime canary and
+        // reverts, so the tree ends up identical either way — but the half-apply
+        // spends a nightly alert saying the mechanical edit was wrong. Route it.
+        const vsPath = proposalNoteRelPath(input.provider, family, "voice-seed-set");
+        ensureProposalNote(
+          deps,
+          vsPath,
+          () =>
+            renderProposalNote(
+              input.provider,
+              family,
+              "voice-seed-set",
+              `A human decided "${family}" (Decision: ${decision}, in ${notePath}), but this is a ` +
+                `VOICE/AUDIO family and its normalized family key is not in ` +
+                `knownVoiceModelFamilies. Two disjoint surfaces need the entry, and drift-sync ` +
+                `writes only one of them:\n\n` +
+                `  1. ${listNameFor(decision)}.${input.provider} in ${MODEL_REGISTRY_REL_PATH}\n` +
+                `  2. knownVoiceModelFamilies in src/__tests__/drift/voice-models.ts (plus its ` +
+                `DATA_FROZEN membership pin in ${LOGIC_PIN_REL_PATH})\n\n` +
+                `Applying (1) alone leaves ws-realtime.drift.ts reporting ` +
+                `UNKNOWN_REALTIME_MODELS=${family} at critical severity, so drift-sync-check ` +
+                `refuses the run and reverts it — nightly, forever. A human must make both ` +
+                `edits in one reviewed commit (precedent: 936b59c).`,
+              stamp,
+            ),
+          touchedFiles,
+        );
+        outcomes.push({
+          provider: input.provider,
+          family,
+          action: "needs-human-voice-seed-set",
+          detail:
+            `"${family}" was decided (${decision}) but is a voice/audio family absent from ` +
+            `knownVoiceModelFamilies — the registry edit alone would leave the realtime canary ` +
+            `red and be reverted; routed to human (${vsPath})`,
+        });
+      } else if (decision === "include" || decision === "exclude") {
         // Both verdicts are the SAME mechanical edit against a different set.
         // `include` = aimock mocks this family on the chat surface; `exclude` =
         // wrong modality / retired / preview. Neither is ever inferred: the word
         // came from a human's hand in the note.
-        const listName: RegistrySetName =
-          decision === "include" ? "includeFamilies" : "excludeFamilies";
+        const listName = listNameFor(decision);
         const verb = decision === "include" ? "ADDED" : "EXCLUDED";
         const edit = addFamilyLiteralInSource(
           registrySource,
@@ -1205,22 +1294,59 @@ export function runDriftSyncCore(
   // half-applied classification (registry edited, pin stale) is precisely the
   // gate-failed state this whole change exists to eliminate.
   let logicPinSource: string | null = null;
-  if (repins.size > 0) {
-    const readPin = deps.readLogicPinSource;
-    const writePin = deps.writeLogicPinSource;
-    if (!readPin || !writePin) {
-      return {
-        ok: false,
-        reason: SyncCoreReason.NEEDS_HUMAN,
-        detail:
-          `a classification was approved but this caller cannot re-pin ` +
-          `${LOGIC_PIN_REL_PATH} — refusing to leave the registry edited with a stale pin`,
-        outcomes,
-        skipped,
-      };
+  // EVERY refusal below reports the classification as NOT APPLIED, because it
+  // is not: the refusals raised before the write never reach
+  // `deps.writeRegistrySource`, and the one raised after it reverts both files
+  // first, so no path leaves an edit behind. The refusals used
+  // to return with the outcomes still reading `action: "added"`, so the run log
+  // printed `[added] openai/x`, `buildSyncCommitMessage` wrote `- added
+  // openai/x` into a commit containing no registry edit, and
+  // `computeChangesetKey` — the workflow's PR de-dup key — was keyed on the
+  // same claim. `refuseRepin` re-labels them and leaves a deduped note, so the
+  // refusal has a human-facing artifact rather than only a red job.
+  const refuseRepin = (detail: string): SyncCoreOutcome => {
+    for (const o of outcomes) {
+      if (o.action !== "added" && o.action !== "excluded" && o.action !== "deprecation-recorded")
+        continue;
+      const notePath = proposalNoteRelPath(o.provider, o.family, "pin-repin-failure");
+      ensureProposalNote(
+        deps,
+        notePath,
+        () =>
+          renderProposalNote(
+            o.provider,
+            o.family,
+            "pin-repin-failure",
+            `drift-sync prepared a mechanical registry edit for "${o.family}" and then ` +
+              `refused to keep this run at all: ${detail}\n\n` +
+              `NOTHING survives in ${MODEL_REGISTRY_REL_PATH} or ${LOGIC_PIN_REL_PATH} — a ` +
+              `registry edit with a stale or wrongly-placed membership pin is the exact ` +
+              `half-applied state this path exists to prevent. A human must apply the edit ` +
+              `and re-pin by hand, or repair the pin file's structure.`,
+            stamp,
+          ),
+        touchedFiles,
+      );
+      o.action = "needs-human-repin";
+      o.detail = `${o.detail} — NOT APPLIED: ${detail} (${notePath})`;
     }
-    const before = readPin();
-    let next = before;
+    return { ok: false, reason: SyncCoreReason.NEEDS_HUMAN, detail, outcomes, skipped };
+  };
+
+  let readPin: (() => string) | undefined;
+  let writePin: ((text: string) => void) | undefined;
+  let pinBefore: string | null = null;
+  if (repins.size > 0) {
+    readPin = deps.readLogicPinSource;
+    writePin = deps.writeLogicPinSource;
+    if (!readPin || !writePin) {
+      return refuseRepin(
+        `a classification was approved but this caller cannot re-pin ` +
+          `${LOGIC_PIN_REL_PATH} — refusing to leave the registry edited with a stale pin`,
+      );
+    }
+    pinBefore = readPin();
+    let next = pinBefore;
     for (const [key, { listName, provider, families }] of repins) {
       const base =
         listName === "includeFamilies" ? includeFamilies[provider] : excludeFamilies[provider];
@@ -1231,36 +1357,38 @@ export function runDriftSyncCore(
       const members = [...base, ...families];
       const edit = updateDataFrozenPin(next, key, computeMembershipPin(members));
       if (edit.locatorMiss) {
-        return {
-          ok: false,
-          reason: SyncCoreReason.NEEDS_HUMAN,
-          detail:
-            `could not locate the DATA_FROZEN pin for "${key}" in ${LOGIC_PIN_REL_PATH} — ` +
+        return refuseRepin(
+          `could not locate the DATA_FROZEN pin for "${key}" in ${LOGIC_PIN_REL_PATH} — ` +
             `the pin file's structure changed; a human must re-pin by hand`,
-          outcomes,
-          skipped,
-        };
+        );
       }
       next = edit.text;
-    }
-    if (!onlyPinsChanged(before, next)) {
-      return {
-        ok: false,
-        reason: SyncCoreReason.NEEDS_HUMAN,
-        detail:
-          `re-pin of ${LOGIC_PIN_REL_PATH} would have changed something other than a ` +
-          `pin literal — refusing the write`,
-        outcomes,
-        skipped,
-      };
     }
     logicPinSource = next;
   }
 
   deps.writeRegistrySource(registrySource);
   if (logicPinSource !== null) {
-    deps.writeLogicPinSource!(logicPinSource);
+    writePin!(logicPinSource);
     touchedFiles.add(LOGIC_PIN_REL_PATH);
+    // THE WRITER'S HALF OF THE PIN-FILE CONTRACT, checked against WHAT LANDED,
+    // by reading the file back — not against the text we meant to write. An
+    // in-memory check of our own rewrite can only ever agree with itself (the
+    // version this replaces could not return false from its one production call
+    // site, and mutating that call site to `if (false)` left the suite green);
+    // re-reading makes the guard answer a question it could actually fail.
+    // `drift-sync-check` gate-1b re-derives the same predicate from the git diff,
+    // keyed to SYNC_REPINNABLE_KEYS, so the constraint does not depend on this
+    // check being here.
+    const landed = readPin!();
+    const pinEdit = verifyPinFileEdit(pinBefore!, landed, new Set(repins.keys()));
+    if (!pinEdit.ok) {
+      deps.revertFiles([...touchedFiles]);
+      return refuseRepin(
+        `${LOGIC_PIN_REL_PATH} as WRITTEN is not a clean membership re-pin ` +
+          `(${pinEdit.detail}) — reverted`,
+      );
+    }
   }
   const skipReason = gate3SkipReason(outcomes);
   const verdict = deps.runSyncCheck(
@@ -1500,6 +1628,8 @@ const REAL_SYNC_CORE_DEPS: SyncCoreDeps = {
     const verdict = evaluateSyncCheck(
       {
         getChangedFiles,
+        readCommittedPinFile: () => readCommittedFile(LOGIC_PIN_REL_PATH),
+        readWorkingPinFile: () => readFileSync(LOGIC_PIN_ABS_PATH, "utf-8"),
         runPinCheck: () => runPinCheck(),
         recollect: () => recollect(),
       },

--- a/src/__tests__/drift-remediation-strings.test.ts
+++ b/src/__tests__/drift-remediation-strings.test.ts
@@ -25,10 +25,12 @@
  * `drift-proposals/*.md` are the OPPOSITE: drift-sync WRITES them mechanically,
  * a human may hand-annotate them, and `fb9d9c5`-style cleanups legitimately
  * DELETE them once resolved — the directory is routinely empty and is not even
- * tracked when it holds no notes. A freshly generated note cites no symbol at
- * all (see `renderProposalNote`), so requiring one to yield a pair turns the very
- * next needs-human PR red with a false "prose was removed" message, and pinning
- * the pair-count floor to note-borne pairs makes deleting a resolved note fail.
+ * tracked when it holds no notes. Some generated notes cite a symbol (the
+ * new-family template names `knownVoiceModelFamilies in voice-models.ts`, the
+ * second surface a voice/audio classification needs by hand) and some cite
+ * nothing at all, so requiring one to yield a pair turns the very next
+ * needs-human PR red with a false "prose was removed" message, and pinning the
+ * pair-count floor to note-borne pairs makes deleting a resolved note fail.
  * They are therefore scanned OPPORTUNISTICALLY: whatever citation a note does
  * carry must resolve, and no note may name a retired symbol, but a note is never
  * required to carry a citation and an absent/empty directory is not an error.
@@ -352,14 +354,22 @@ describe("the guard accepts the input it is supposed to accept", () => {
     try {
       const note = freshGeneratedNote(dir);
 
-      // A generated note cites no symbol — that is CORRECT, not a removed
-      // citation, so it must not be required to yield a pair.
-      expect(
-        collectPairs([note]),
-        `drift-sync's generated note template now yields a "<symbol> in <file>" ` +
-          `pair. That is fine, but it means the template changed — re-read the ` +
-          `module docstring before assuming notes are still citation-free.`,
-      ).toEqual([]);
+      // A generated note is not REQUIRED to cite anything (see `requiresPair`
+      // below) — but the new-family template now does cite one deliberately: the
+      // voice/audio carve-out has to name the second, disjoint surface a human
+      // must edit by hand, or the note describes a decision the sync will refuse
+      // to apply without saying where the other half lives. Opportunistic
+      // scanning is exactly the contract for that: whatever a note DOES cite
+      // must resolve.
+      for (const pair of collectPairs([note])) {
+        const file = resolveCitedFile(pair.file);
+        expect(file, `generated note cites ${pair.file}, which resolves nowhere`).not.toBeNull();
+        expect(
+          declaresSymbol(file!, pair.symbol),
+          `generated note cites "${pair.symbol} in ${pair.file}", but that file does ` +
+            `not declare it — the note sends its reader after a ghost.`,
+        ).toBe(true);
+      }
       expect(
         requiresPair(note),
         `A drift-proposals note is being REQUIRED to carry a citation. Generated ` +

--- a/src/__tests__/drift-sync-check.test.ts
+++ b/src/__tests__/drift-sync-check.test.ts
@@ -5,11 +5,16 @@
  * Three gates, tested independently and composed:
  *   1. changed-file allowlist (data surfaces only)
  *   2. checksum-pin re-assert (P0's logic-pin.test.ts must still be green)
+ *   1b. logic-pin.test.ts is admitted ONLY for a membership re-pin of a
+ *       `(include|exclude)Families.<provider>` DATA_FROZEN key — see
+ *       `checkPinFileEdit`. Gate-2 cannot police that file: it IS gate-2's
+ *       oracle, so a re-pasted checksum makes gate-2 green by construction.
  *   3. clean re-collect (post-sync report has zero residual critical diffs)
  *
  * No LLM, no model call — every assertion here is a plain data check.
  */
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
 
 import {
   isAllowedSyncFile,
@@ -19,6 +24,7 @@ import {
   formatCriticalDiffs,
   reportTrustNote,
   evaluateSyncCheck,
+  checkPinFileEdit,
   runPinCheck,
   recollect,
   SyncCheckReason,
@@ -28,6 +34,7 @@ import {
   type SyncCheckDeps,
   type CommandResult,
 } from "../../scripts/drift-sync-check.js";
+import { updateDataFrozenPin } from "../../scripts/drift-pin-file.js";
 import type { DriftReport } from "../../scripts/drift-types.js";
 
 function report(criticalCounts: number[]): DriftReport {
@@ -229,14 +236,110 @@ describe("recollect", () => {
 // Composition — evaluateSyncCheck
 // ---------------------------------------------------------------------------
 
+const REAL_PIN_FILE = readFileSync("src/__tests__/drift/logic-pin.test.ts", "utf-8");
+
+/** The real pin file with ONE DATA_FROZEN key's pin rewritten. */
+function repinned(source: string, key: string, pin: string): string {
+  const out = updateDataFrozenPin(source, key, pin);
+  if (!out.changed) throw new Error(`fixture: could not re-pin ${key}`);
+  return out.text;
+}
+
 function deps(overrides: Partial<SyncCheckDeps>): SyncCheckDeps {
   return {
     getChangedFiles: () => ["src/__tests__/drift/model-registry.ts"],
+    readCommittedPinFile: () => REAL_PIN_FILE,
+    readWorkingPinFile: () => REAL_PIN_FILE,
     runPinCheck: () => ({ ok: true, output: "5 passed" }),
     recollect: () => report([0]),
     ...overrides,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Gate-1b — the pin file is allowlisted ONLY for membership re-pins.
+// ---------------------------------------------------------------------------
+
+describe("gate-1b: logic-pin.test.ts is on the allowlist only for a membership re-pin", () => {
+  const PIN_FILE = "src/__tests__/drift/logic-pin.test.ts";
+  const REGISTRY = "src/__tests__/drift/model-registry.ts";
+
+  it("GREEN: a membership re-pin of one (include|exclude)Families.<provider> key PASSES", () => {
+    const after = repinned(REAL_PIN_FILE, "excludeFamilies.openai", "a".repeat(64));
+    expect(checkPinFileEdit(REAL_PIN_FILE, after).ok).toBe(true);
+    const verdict = evaluateSyncCheck(
+      deps({
+        getChangedFiles: () => [REGISTRY, PIN_FILE],
+        readWorkingPinFile: () => after,
+      }),
+    );
+    expect(verdict.ok).toBe(true);
+    expect(verdict.reason).toBe(SyncCheckReason.OK);
+  });
+
+  // THE BOUNDARY THAT MOVED. `model-registry.ts` is allowlisted too, so a
+  // path-level admission of this file is by itself sufficient to silence a
+  // frozen surface: widen `isClassifiedFamily` AND re-paste that surface's
+  // FROZEN checksum, and gate-1 and gate-2 both pass — gate-2's oracle IS this
+  // file. Reproduced end to end against the real tree before this gate existed.
+  it("RED: a re-pasted FROZEN logic checksum FAILS, and never reaches the pin test or the re-collect", () => {
+    const at = REAL_PIN_FILE.indexOf("  isClassifiedFamily: {");
+    const m = /pin: "([0-9a-f]{64})"/.exec(REAL_PIN_FILE.slice(at))!;
+    const silenced =
+      REAL_PIN_FILE.slice(0, at + m.index) +
+      `pin: "${"9".repeat(64)}"` +
+      REAL_PIN_FILE.slice(at + m.index + m[0].length);
+    const runPinCheckFn = vi.fn(() => ({ ok: true, output: "33 passed" }));
+    const recollectFn = vi.fn(() => report([0]));
+
+    const verdict = evaluateSyncCheck(
+      deps({
+        getChangedFiles: () => [REGISTRY, PIN_FILE],
+        readWorkingPinFile: () => silenced,
+        runPinCheck: runPinCheckFn,
+        recollect: recollectFn,
+      }),
+    );
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe(SyncCheckReason.PIN_FILE_NOT_A_MEMBERSHIP_REPIN);
+    expect(REASON_EXIT_CODE[verdict.reason]).toBe(23);
+    expect(verdict.offendingFiles).toEqual([PIN_FILE]);
+    // Gate-2 would have gone GREEN on this tree — that is the whole point.
+    expect(runPinCheckFn).not.toHaveBeenCalled();
+    expect(recollectFn).not.toHaveBeenCalled();
+  });
+
+  it("RED: re-pinning a DATA_FROZEN key the sync may not move (the voice seed set) FAILS", () => {
+    const after = repinned(REAL_PIN_FILE, "knownVoiceModelFamilies", "b".repeat(64));
+    const verdict = evaluateSyncCheck(
+      deps({ getChangedFiles: () => [PIN_FILE], readWorkingPinFile: () => after }),
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe(SyncCheckReason.PIN_FILE_NOT_A_MEMBERSHIP_REPIN);
+    expect(verdict.detail).toContain("knownVoiceModelFamilies");
+  });
+
+  it("RED: any edit outside a pin literal FAILS", () => {
+    const after = REAL_PIN_FILE.replace(
+      "members: () => [...excludeFamilies.openai].sort(),",
+      "members: () => [],",
+    );
+    expect(after).not.toBe(REAL_PIN_FILE);
+    const verdict = evaluateSyncCheck(
+      deps({ getChangedFiles: () => [PIN_FILE], readWorkingPinFile: () => after }),
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe(SyncCheckReason.PIN_FILE_NOT_A_MEMBERSHIP_REPIN);
+  });
+
+  it("does not consult the pin-file diff at all when the sync did not touch that file", () => {
+    const readWorkingPinFile = vi.fn(() => REAL_PIN_FILE);
+    const verdict = evaluateSyncCheck(deps({ readWorkingPinFile }));
+    expect(verdict.ok).toBe(true);
+    expect(readWorkingPinFile).not.toHaveBeenCalled();
+  });
+});
 
 describe("evaluateSyncCheck — RED/GREEN value-test surface", () => {
   it("GREEN: a data-only excludeFamilies-style change on the allowlist, pins intact, clean re-collect -> PASSES", () => {

--- a/src/__tests__/drift-sync-core.test.ts
+++ b/src/__tests__/drift-sync-core.test.ts
@@ -24,6 +24,7 @@ import { join } from "node:path";
 import ts from "typescript";
 
 import { includeFamilies, excludeFamilies, deprecatedFamilies } from "./drift/model-registry.js";
+import { isVoiceModelId, knownVoiceModelFamilies } from "./drift/voice-models.js";
 import { MIN_LISTING_SIZE, FORWARD_LOOKING_FAMILIES } from "./drift/deprecation-detector.js";
 import {
   detectDeprecatedFamiliesForSync,
@@ -33,6 +34,10 @@ import {
   parseProposalDecision,
   updateDataFrozenPin,
   onlyPinsChanged,
+  verifyPinFileEdit,
+  diffPinKeys,
+  needsVoiceSeedSetEdit,
+  SYNC_REPINNABLE_KEYS,
   computeMembershipPin,
   dataFrozenKey,
   renderProposalNote,
@@ -56,7 +61,7 @@ import {
 // Test fixture: a minimal, synthetic "model-registry.ts"-shaped source text —
 // same array-literal-inside-a-2-arg-call-expression shape the real file uses,
 // seeded with the REAL openai includeFamilies set (so a removal target like
-// "gpt-4o" is guaranteed present, and an addition target like "gpt-live" is
+// "gpt-4o" is guaranteed present, and an addition target like "gpt-zeta" is
 // guaranteed absent — mirrors C4's own test fixtures in models.drift.ts).
 // ---------------------------------------------------------------------------
 
@@ -473,7 +478,7 @@ describe("the deprecation floor is a plausibility check on the LISTING, not on o
 
 describe("unclassifiedFamiliesForSync (mirrors C4's unclassifiedFamilies)", () => {
   it("a genuinely new family is flagged", () => {
-    expect(unclassifiedFamiliesForSync(["gpt-live"], "openai")).toEqual(["gpt-live"]);
+    expect(unclassifiedFamiliesForSync(["gpt-zeta"], "openai")).toEqual(["gpt-zeta"]);
   });
 
   it("a dated snapshot of a known family produces zero drift", () => {
@@ -496,11 +501,11 @@ describe("addFamilyLiteralInSource", () => {
       src,
       "includeFamilies",
       "openai",
-      "gpt-live",
+      "gpt-zeta",
       "TEST-ADD",
     );
     expect(result.changed).toBe(true);
-    expect(result.text).toContain('"gpt-live", // TEST-ADD');
+    expect(result.text).toContain('"gpt-zeta", // TEST-ADD');
     // Every seeded family is untouched.
     for (const f of includeFamilies.openai) {
       expect(result.text).toContain(`"${f}"`);
@@ -543,18 +548,18 @@ describe("addFamilyLiteralInSource", () => {
 
   it("the edited text is still syntactically valid TypeScript (parser round-trip)", () => {
     const src = fixtureRegistrySource();
-    const added = addFamilyLiteralInSource(src, "includeFamilies", "openai", "gpt-live", "a");
+    const added = addFamilyLiteralInSource(src, "includeFamilies", "openai", "gpt-zeta", "a");
     // A further edit against the already-edited text must still locate the
     // array correctly — proves the AST-based locator survives a prior edit.
     const secondAdd = addFamilyLiteralInSource(
       added.text,
       "includeFamilies",
       "openai",
-      "gpt-live-2",
+      "gpt-zeta-2",
       "b",
     );
     expect(secondAdd.changed).toBe(true);
-    expect(secondAdd.text).toContain('"gpt-live-2"');
+    expect(secondAdd.text).toContain('"gpt-zeta-2"');
     // Two successive appends into the SAME empty array must both land, and the
     // second must not be fooled by the first's trailing comment.
     const one = addFamilyLiteralInSource(src, "deprecatedFamilies", "openai", "gpt-4o", "d1");
@@ -573,11 +578,11 @@ describe("addFamilyLiteralInSource", () => {
 
 describe("proposal notes", () => {
   it("proposalNoteRelPath is family-keyed and stable (dedup key)", () => {
-    expect(proposalNoteRelPath("openai", "gpt-live", "new-family")).toBe(
-      `${DRIFT_PROPOSALS_DIR}/openai-gpt-live-new-family.md`,
+    expect(proposalNoteRelPath("openai", "gpt-zeta", "new-family")).toBe(
+      `${DRIFT_PROPOSALS_DIR}/openai-gpt-zeta-new-family.md`,
     );
-    expect(proposalNoteRelPath("openai", "gpt-live", "new-family")).toBe(
-      proposalNoteRelPath("openai", "gpt-live", "new-family"),
+    expect(proposalNoteRelPath("openai", "gpt-zeta", "new-family")).toBe(
+      proposalNoteRelPath("openai", "gpt-zeta", "new-family"),
     );
   });
 
@@ -776,7 +781,7 @@ describe("runDriftSyncCore", () => {
 
   it("RED->GREEN (genuinely new family, no prior decision): RED alert + single deduped note, no auto-classify", () => {
     const { deps, registry, writeProposalNote, notes } = makeFakeDeps();
-    const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: ["gpt-live"] }];
+    const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: ["gpt-zeta"] }];
     // NOTE: a single unclassified live id also fails the deprecation floor
     // check (too short) — that is an independent, correctly-skipped signal;
     // this test only asserts the ADDITION half's behavior.
@@ -786,17 +791,17 @@ describe("runDriftSyncCore", () => {
     expect(outcome.outcomes).toContainEqual(
       expect.objectContaining({
         provider: "openai",
-        family: "gpt-live",
+        family: "gpt-zeta",
         action: "needs-human-new-family",
       }),
     );
     expect(outcome.ok).toBe(false);
     expect(outcome.reason).toBe(SyncCoreReason.NEEDS_HUMAN);
     // NEVER auto-classified: no registry edit occurred.
-    expect(registry.text).not.toContain("gpt-live");
+    expect(registry.text).not.toContain("gpt-zeta");
     expect(writeProposalNote).toHaveBeenCalledTimes(1);
     const [path, noteText] = writeProposalNote.mock.calls[0] as [string, string];
-    expect(path).toBe(`${DRIFT_PROPOSALS_DIR}/openai-gpt-live-new-family.md`);
+    expect(path).toBe(`${DRIFT_PROPOSALS_DIR}/openai-gpt-zeta-new-family.md`);
     expect(noteText).toContain("Decision: pending");
     expect(notes.size).toBe(1);
 
@@ -813,49 +818,49 @@ describe("runDriftSyncCore", () => {
     // Simulate a human having already reviewed the RED alert and flipped the
     // note's Decision line to `include` (the only path that can ever add a
     // genuinely-new family — never automatic, never LLM-authored).
-    const notePath = proposalNoteRelPath("openai", "gpt-live", "new-family");
+    const notePath = proposalNoteRelPath("openai", "gpt-zeta", "new-family");
     notes.set(
       notePath,
-      renderProposalNote("openai", "gpt-live", "new-family", "detail", "2026-07-20").replace(
+      renderProposalNote("openai", "gpt-zeta", "new-family", "detail", "2026-07-20").replace(
         "Decision: pending",
         "Decision: include",
       ),
     );
 
-    const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: ["gpt-live"] }];
+    const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: ["gpt-zeta"] }];
     const outcome = runDriftSyncCore(inputs, deps);
 
     expect(outcome.outcomes).toContainEqual(
-      expect.objectContaining({ provider: "openai", family: "gpt-live", action: "added" }),
+      expect.objectContaining({ provider: "openai", family: "gpt-zeta", action: "added" }),
     );
     expect(outcome.ok).toBe(true);
     expect(outcome.reason).toBe(SyncCoreReason.OK_APPLIED);
-    expect(registry.text).toContain('"gpt-live"');
+    expect(registry.text).toContain('"gpt-zeta"');
     expect(registry.text).toContain(`decided via ${notePath}`);
     expect(runSyncCheck).toHaveBeenCalledTimes(1);
   });
 
   it("REJECTION (human-authored Decision: exclude): writes excludeFamilies, not includeFamilies", () => {
     const { deps, registry, logicPin } = makeFakeDeps();
-    const notePath = proposalNoteRelPath("openai", "gpt-live", "new-family");
+    const notePath = proposalNoteRelPath("openai", "gpt-zeta", "new-family");
     notes_set(deps, notePath, "exclude");
 
-    const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: ["gpt-live"] }];
+    const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: ["gpt-zeta"] }];
     const before = logicPin.text;
     const outcome = runDriftSyncCore(inputs, deps);
 
     expect(outcome.outcomes).toContainEqual(
-      expect.objectContaining({ provider: "openai", family: "gpt-live", action: "excluded" }),
+      expect.objectContaining({ provider: "openai", family: "gpt-zeta", action: "excluded" }),
     );
     expect(outcome.ok).toBe(true);
     expect(outcome.reason).toBe(SyncCoreReason.OK_APPLIED);
     // The family landed in excludeFamilies. Asserting the SECTION, not just the
-    // string: a bare `toContain('"gpt-live"')` would also pass if the edit had
+    // string: a bare `toContain('"gpt-zeta"')` would also pass if the edit had
     // gone into includeFamilies, which is the exact bug this path prevents.
     const excludeSection = registry.text.slice(registry.text.indexOf("excludeFamilies"));
-    expect(excludeSection).toContain('"gpt-live"');
+    expect(excludeSection).toContain('"gpt-zeta"');
     expect(registry.text.slice(0, registry.text.indexOf("excludeFamilies"))).not.toContain(
-      '"gpt-live"',
+      '"gpt-zeta"',
     );
     // ...and the EXCLUDE pin moved, while the include pin did not.
     expect(logicPin.text).not.toBe(before);
@@ -869,10 +874,10 @@ describe("runDriftSyncCore", () => {
 
   it("an APPROVED classification re-pins in the SAME run (the edit is never left with a stale pin)", () => {
     const { deps, logicPin } = makeFakeDeps();
-    notes_set(deps, proposalNoteRelPath("openai", "gpt-live", "new-family"), "include");
+    notes_set(deps, proposalNoteRelPath("openai", "gpt-zeta", "new-family"), "include");
     const before = logicPin.text;
 
-    const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-live"] }], deps);
+    const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-zeta"] }], deps);
 
     expect(outcome.reason).toBe(SyncCoreReason.OK_APPLIED);
     expect(pinFor(logicPin.text, "includeFamilies.openai")).not.toBe(
@@ -887,10 +892,10 @@ describe("runDriftSyncCore", () => {
       readLogicPinSource: undefined,
       writeLogicPinSource: undefined,
     });
-    notes_set(deps, proposalNoteRelPath("openai", "gpt-live", "new-family"), "include");
+    notes_set(deps, proposalNoteRelPath("openai", "gpt-zeta", "new-family"), "include");
     const registryBefore = registry.text;
 
-    const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-live"] }], deps);
+    const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-zeta"] }], deps);
 
     expect(outcome.ok).toBe(false);
     expect(outcome.reason).toBe(SyncCoreReason.NEEDS_HUMAN);
@@ -899,6 +904,117 @@ describe("runDriftSyncCore", () => {
     // this whole path exists to remove, so it must not be reachable.
     expect(writeRegistrySource).not.toHaveBeenCalled();
     expect(registry.text).toBe(registryBefore);
+  });
+
+  // HONEST REPORTING ON A REFUSAL. Before this, the three re-pin refusals
+  // returned with the outcomes still reading `action: "added"` for an edit that
+  // was never written: the run log printed `[added] openai/gpt-zeta`,
+  // `buildSyncCommitMessage` wrote `- added openai/gpt-zeta` into a commit
+  // containing no registry edit at all, and `computeChangesetKey` — the
+  // workflow's PR de-dup key — was keyed on the same claim.
+  it("a re-pin refusal reports the classification as NOT APPLIED, and leaves a deduped note", () => {
+    const { deps, notes } = makeFakeDeps({
+      readLogicPinSource: undefined,
+      writeLogicPinSource: undefined,
+    });
+    notes_set(deps, proposalNoteRelPath("openai", "gpt-zeta", "new-family"), "include");
+
+    const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-zeta"] }], deps);
+
+    expect(outcome.outcomes).toEqual([
+      expect.objectContaining({ family: "gpt-zeta", action: "needs-human-repin" }),
+    ]);
+    expect(outcome.outcomes.some((o) => o.action === "added")).toBe(false);
+    // The commit message may not claim an edit that is not in the commit.
+    expect(buildSyncCommitMessage(outcome).body).toBe("");
+    expect(buildSyncCommitMessage(outcome).subject).toContain("needs-human note file(s)");
+    // ...and the refusal has a human-facing artifact, not just a red job.
+    const notePath = proposalNoteRelPath("openai", "gpt-zeta", "pin-repin-failure");
+    expect(notes.get(notePath)).toContain("Membership re-pin refused");
+    expect(outcome.outcomes[0].detail).toContain("NOT APPLIED");
+  });
+
+  // The writer's own pin-file guard, checked against WHAT LANDED. The version
+  // this replaces verified its own in-memory rewrite, so it could not return
+  // false from its only production call site — mutating that call site to
+  // `if (false)` left the whole suite green. Re-reading the written file makes
+  // the guard answer a question it can actually fail: here a writer that mangles
+  // the file on the way to disk.
+  it("REFUSES and REVERTS when the pin file as WRITTEN is not a clean membership re-pin", () => {
+    const { deps, logicPin, revertFiles, notes } = makeFakeDeps({
+      writeLogicPinSource: vi.fn((text: string) => {
+        // A writer that also re-pastes a neighbouring (non-repinnable) pin.
+        logicPin.text = text.replace(`pin: "${"0".repeat(64)}"`, `pin: "${"f".repeat(64)}"`);
+      }),
+    });
+    notes_set(deps, proposalNoteRelPath("openai", "gpt-zeta", "new-family"), "exclude");
+
+    const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-zeta"] }], deps);
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.reason).toBe(SyncCoreReason.NEEDS_HUMAN);
+    expect(outcome.detail).toContain("not a clean membership re-pin");
+    expect(revertFiles).toHaveBeenCalledWith([MODEL_REGISTRY_REL_PATH, LOGIC_PIN_REL_PATH]);
+    expect(outcome.outcomes).toEqual([
+      expect.objectContaining({ family: "gpt-zeta", action: "needs-human-repin" }),
+    ]);
+    expect(notes.get(proposalNoteRelPath("openai", "gpt-zeta", "pin-repin-failure"))).toContain(
+      "Membership re-pin refused",
+    );
+  });
+
+  // THE VOICE HALF-CLASSIFICATION. `excludeFamilies` and
+  // `knownVoiceModelFamilies` are deliberately disjoint surfaces and the sync
+  // writes only the first, so auto-applying a voice family's decision leaves
+  // ws-realtime.drift.ts reporting UNKNOWN_REALTIME_MODELS at critical severity:
+  // gate-3 refuses, both files revert, the note still says `Decision: exclude`,
+  // and the identical apply/fail/revert/alert repeats every night forever.
+  it("a DECIDED voice family is routed to a human instead of being half-applied", () => {
+    for (const verdict of ["include", "exclude"] as const) {
+      const { deps, registry, writeRegistrySource, runSyncCheck, notes } = makeFakeDeps();
+      const registryBefore = registry.text;
+      notes_set(deps, proposalNoteRelPath("openai", "gpt-live", "new-family"), verdict);
+
+      const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-live"] }], deps);
+
+      expect(needsVoiceSeedSetEdit("gpt-live")).toBe(true);
+      expect(outcome.outcomes).toEqual([
+        expect.objectContaining({ family: "gpt-live", action: "needs-human-voice-seed-set" }),
+      ]);
+      // Nothing was applied, so nothing gate-fails and nothing reverts: the
+      // half-apply/revert loop cannot start.
+      expect(writeRegistrySource).not.toHaveBeenCalled();
+      expect(registry.text).toBe(registryBefore);
+      expect(runSyncCheck).not.toHaveBeenCalled();
+      const notePath = proposalNoteRelPath("openai", "gpt-live", "voice-seed-set");
+      expect(notes.get(notePath)).toContain("knownVoiceModelFamilies");
+      expect(notes.get(notePath)).toContain("voice-models.ts");
+    }
+  });
+
+  it("a decided family the realtime canary already knows about IS applied (the guard is not a blanket refusal)", () => {
+    // The predicate keys on the voice SEED SET, not on the id's shape. Every
+    // seeded family is already classified in the registry, so the case is
+    // constructed the way it arises in life: the human made the voice-models.ts
+    // half of the two-edit commit, and the registry half is what is left.
+    knownVoiceModelFamilies.add("gpt-live");
+    try {
+      expect(isVoiceModelId("gpt-live")).toBe(true);
+      expect(needsVoiceSeedSetEdit("gpt-live")).toBe(false);
+
+      const { deps, registry } = makeFakeDeps();
+      notes_set(deps, proposalNoteRelPath("openai", "gpt-live", "new-family"), "exclude");
+      const outcome = runDriftSyncCore([{ provider: "openai", liveModelIds: ["gpt-live"] }], deps);
+
+      expect(outcome.reason).toBe(SyncCoreReason.OK_APPLIED);
+      expect(outcome.outcomes).toEqual([
+        expect.objectContaining({ family: "gpt-live", action: "excluded" }),
+      ]);
+      const excludeSection = registry.text.slice(registry.text.indexOf("excludeFamilies"));
+      expect(excludeSection).toContain('"gpt-live"');
+    } finally {
+      knownVoiceModelFamilies.delete("gpt-live");
+    }
   });
 
   it("a FAILING drift-sync-check gate reverts every touched file and reports GATE_FAILED", () => {
@@ -914,13 +1030,13 @@ describe("runDriftSyncCore", () => {
     // The one remaining path that mutates the registry: an addition a human
     // already approved on a prior run by setting the note's `Decision: include`.
     notes.set(
-      proposalNoteRelPath("openai", "gpt-live", "new-family"),
-      renderProposalNote("openai", "gpt-live", "new-family", "detail", "2026-07-20").replace(
+      proposalNoteRelPath("openai", "gpt-zeta", "new-family"),
+      renderProposalNote("openai", "gpt-zeta", "new-family", "detail", "2026-07-20").replace(
         "Decision: pending",
         "Decision: include",
       ),
     );
-    const liveIds = [...includeFamilies.openai, "gpt-live"];
+    const liveIds = [...includeFamilies.openai, "gpt-zeta"];
     const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: liveIds }];
 
     const outcome = runDriftSyncCore(inputs, deps);
@@ -1020,7 +1136,7 @@ describe("D-M1: recollect gate vs route-to-human invariant", () => {
   it("RED->GREEN (note-only new family): faithful gate does NOT revert the note; NEEDS_HUMAN", () => {
     const runSyncCheck = faithfulRecollectGate();
     const { deps, revertFiles } = makeFakeDeps({ runSyncCheck });
-    const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: ["gpt-live"] }];
+    const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: ["gpt-zeta"] }];
 
     const outcome = runDriftSyncCore(inputs, deps);
 
@@ -1038,17 +1154,17 @@ describe("D-M1: recollect gate vs route-to-human invariant", () => {
   it("RED->GREEN (mixed: approved addition + new-family note): addition kept, gate-3 skipped, NEEDS_HUMAN", () => {
     const runSyncCheck = faithfulRecollectGate();
     const { deps, registry, notes, revertFiles } = makeFakeDeps({ runSyncCheck });
-    // A human approved `gpt-live` on a prior run; `gpt-other` is a fresh
+    // A human approved `gpt-zeta` on a prior run; `gpt-other` is a fresh
     // unclassified family this run defers. The addition is the registry edit;
     // the deferral is what a re-collect would still (correctly) see as drift.
     notes.set(
-      proposalNoteRelPath("openai", "gpt-live", "new-family"),
-      renderProposalNote("openai", "gpt-live", "new-family", "detail", "2026-07-20").replace(
+      proposalNoteRelPath("openai", "gpt-zeta", "new-family"),
+      renderProposalNote("openai", "gpt-zeta", "new-family", "detail", "2026-07-20").replace(
         "Decision: pending",
         "Decision: include",
       ),
     );
-    const liveIds = [...includeFamilies.openai, "gpt-live", "gpt-other"];
+    const liveIds = [...includeFamilies.openai, "gpt-zeta", "gpt-other"];
     const inputs: ProviderChurnInput[] = [{ provider: "openai", liveModelIds: liveIds }];
 
     const outcome = runDriftSyncCore(inputs, deps);
@@ -1059,7 +1175,7 @@ describe("D-M1: recollect gate vs route-to-human invariant", () => {
     expect(outcome.reason).toBe(SyncCoreReason.NEEDS_HUMAN);
     expect(outcome.ok).toBe(false);
     expect(outcome.outcomes).toContainEqual(
-      expect.objectContaining({ family: "gpt-live", action: "added" }),
+      expect.objectContaining({ family: "gpt-zeta", action: "added" }),
     );
     expect(outcome.outcomes).toContainEqual(
       expect.objectContaining({ family: "gpt-other", action: "needs-human-new-family" }),
@@ -1074,7 +1190,7 @@ describe("D-M1: recollect gate vs route-to-human invariant", () => {
       skipRecollectReason: expect.stringContaining("deferred a family to a human"),
     });
     // The registry edit was persisted (writeRegistrySource ran with the addition).
-    expect(registry.text).toContain('"gpt-live"');
+    expect(registry.text).toContain('"gpt-zeta"');
   });
 });
 
@@ -1141,7 +1257,7 @@ describe("revertSyncFiles (D-M2: revert must not throw on untracked notes)", () 
     writeFileSync(join(repo, trackedRel), "MODIFIED BY SYNC\n");
 
     // An UNTRACKED note git has never seen (the D-M2 trigger).
-    const noteRel = "drift-proposals/openai-gpt-live-new-family.md";
+    const noteRel = "drift-proposals/openai-gpt-zeta-new-family.md";
     mkdirSync(join(repo, "drift-proposals"), { recursive: true });
     writeFileSync(join(repo, noteRel), "note body\n");
 
@@ -1196,14 +1312,14 @@ describe("the sync core never invokes an LLM", () => {
 // ---------------------------------------------------------------------------
 
 describe("computeChangesetKey (G#3: stable, date-independent PR-dedup key)", () => {
-  // The D-M1 mixed run: gpt-live added (registry edit) + gpt-other deferred
+  // The D-M1 mixed run: gpt-zeta added (registry edit) + gpt-other deferred
   // (needs-human) — the exact shape whose committed diff has a registry edit
   // but no NEW note file, where a note-path-only dedup key is empty. Both notes
   // are pre-seeded (already on `main` from prior runs), so this run writes none.
   function seedMixedRunNotes(notes: Map<string, string>): void {
     notes.set(
-      proposalNoteRelPath("openai", "gpt-live", "new-family"),
-      renderProposalNote("openai", "gpt-live", "new-family", "detail", "2026-07-20").replace(
+      proposalNoteRelPath("openai", "gpt-zeta", "new-family"),
+      renderProposalNote("openai", "gpt-zeta", "new-family", "detail", "2026-07-20").replace(
         "Decision: pending",
         "Decision: include",
       ),
@@ -1216,7 +1332,7 @@ describe("computeChangesetKey (G#3: stable, date-independent PR-dedup key)", () 
 
   function mixedRunInputs(): ProviderChurnInput[] {
     return [
-      { provider: "openai", liveModelIds: [...includeFamilies.openai, "gpt-live", "gpt-other"] },
+      { provider: "openai", liveModelIds: [...includeFamilies.openai, "gpt-zeta", "gpt-other"] },
     ];
   }
 
@@ -1231,7 +1347,7 @@ describe("computeChangesetKey (G#3: stable, date-independent PR-dedup key)", () 
     expect(computeChangesetKey(outcome)).not.toBe("");
     // Carries BOTH the applied addition and the deferred family in its identity.
     expect(outcome.outcomes).toContainEqual(
-      expect.objectContaining({ family: "gpt-live", action: "added" }),
+      expect.objectContaining({ family: "gpt-zeta", action: "added" }),
     );
     expect(outcome.outcomes).toContainEqual(
       expect.objectContaining({ family: "gpt-other", action: "needs-human-new-family" }),
@@ -1258,7 +1374,7 @@ describe("computeChangesetKey (G#3: stable, date-independent PR-dedup key)", () 
   it("DIFFERS for a different changeset (a pure deferral vs a mixed run) — distinct drifts get distinct PRs", () => {
     const pure = makeFakeDeps();
     const pureOutcome = runDriftSyncCore(
-      [{ provider: "openai", liveModelIds: ["gpt-live"] }],
+      [{ provider: "openai", liveModelIds: ["gpt-zeta"] }],
       pure.deps,
     );
     const mixed = makeFakeDeps();
@@ -1367,11 +1483,28 @@ describe("buildSyncCommitMessage", () => {
 function notes_set(deps: SyncCoreDeps, notePath: string, verdict: "include" | "exclude"): void {
   deps.writeProposalNote(
     notePath,
-    renderProposalNote("openai", "gpt-live", "new-family", "detail", "2026-07-20").replace(
+    renderProposalNote("openai", "gpt-zeta", "new-family", "detail", "2026-07-20").replace(
       "Decision: pending",
       `Decision: ${verdict}`,
     ),
   );
+}
+
+/** A parseable DATA_FROZEN table with the given (key literal, pin) entries. */
+function dataFrozenSource(entries: [string, string][]): string {
+  return [
+    "const DATA_FROZEN: Record<string, { members: () => string[]; pin: string }> = {",
+    ...entries.flatMap(([key, pin]) => [`  ${key}: {`, `    pin: "${pin}",`, "  },"]),
+    "};",
+    "",
+  ].join("\n");
+}
+
+/** The pin literal recorded for one UNQUOTED DATA_FROZEN key. */
+function pinForUnquoted(source: string, key: string): string {
+  const at = source.indexOf(`\n  ${key}: {`);
+  const m = /pin:\s*"([0-9a-f]{64})"/.exec(source.slice(at));
+  return m ? m[1] : "";
 }
 
 /** The pin literal currently recorded for one DATA_FROZEN key. */
@@ -1383,14 +1516,10 @@ function pinFor(source: string, key: string): string {
 
 describe("membership re-pinning primitives", () => {
   it("updateDataFrozenPin rewrites ONLY the named key's pin", () => {
-    const src = [
-      '  "includeFamilies.openai": {',
-      '    pin: "' + "a".repeat(64) + '",',
-      "  },",
-      '  "excludeFamilies.openai": {',
-      '    pin: "' + "b".repeat(64) + '",',
-      "  },",
-    ].join("\n");
+    const src = dataFrozenSource([
+      ['"includeFamilies.openai"', "a".repeat(64)],
+      ['"excludeFamilies.openai"', "b".repeat(64)],
+    ]);
     const out = updateDataFrozenPin(src, "excludeFamilies.openai", "c".repeat(64));
     expect(out.changed).toBe(true);
     expect(out.locatorMiss).toBe(false);
@@ -1399,15 +1528,96 @@ describe("membership re-pinning primitives", () => {
   });
 
   it("updateDataFrozenPin REFUSES an absent or duplicated key rather than guessing", () => {
-    const src = '  "includeFamilies.openai": {\n    pin: "' + "a".repeat(64) + '",\n  },';
+    const src = dataFrozenSource([['"includeFamilies.openai"', "a".repeat(64)]]);
     expect(updateDataFrozenPin(src, "excludeFamilies.gemini", "c".repeat(64))).toMatchObject({
       changed: false,
       locatorMiss: true,
     });
-    expect(updateDataFrozenPin(src + src, "includeFamilies.openai", "c".repeat(64))).toMatchObject({
+    const dup = dataFrozenSource([
+      ['"includeFamilies.openai"', "a".repeat(64)],
+      ['"includeFamilies.openai"', "b".repeat(64)],
+    ]);
+    expect(updateDataFrozenPin(dup, "includeFamilies.openai", "c".repeat(64))).toMatchObject({
       changed: false,
       locatorMiss: true,
     });
+  });
+
+  // THE WRONG-KEY REWRITE. Reproduced against the REAL pin file before the fix:
+  // `"excludeFamilies.gemini"` is followed by the UNQUOTED `knownVoiceModelFamilies`
+  // entry, and the old forward scan only refused when a QUOTED key intervened —
+  // so a target entry whose own pin was not a recognisable digest landed the
+  // write on the realtime canary's seed-set pin, reported `locatorMiss: false`,
+  // and passed the pin-only guard. The entry-scoped AST locator cannot express
+  // that failure; this test is what says so.
+  it("updateDataFrozenPin REFUSES an unrecognisable pin instead of walking into the next (UNQUOTED) entry", () => {
+    const real = readFileSync(LOGIC_PIN_REL_PATH, "utf-8");
+    const voicePinBefore = pinForUnquoted(real, "knownVoiceModelFamilies");
+    expect(voicePinBefore).toMatch(/^[0-9a-f]{64}$/);
+    // The precondition: the target entry's own pin is not a recognisable digest
+    // (a mid-edit or hand-repaired state).
+    const corrupted = real.replace(
+      /("excludeFamilies\.gemini": \{\n {4}members: \(\) => \[\.\.\.excludeFamilies\.gemini\]\.sort\(\),\n {4}pin: )"[0-9a-f]{64}"/,
+      '$1"TBD"',
+    );
+    expect(corrupted).not.toBe(real);
+
+    const out = updateDataFrozenPin(corrupted, "excludeFamilies.gemini", "e".repeat(64));
+
+    expect(out).toMatchObject({ changed: false, locatorMiss: true });
+    expect(out.text).toBe(corrupted);
+    expect(pinForUnquoted(out.text, "knownVoiceModelFamilies")).toBe(voicePinBefore);
+  });
+
+  it("updateDataFrozenPin locates UNQUOTED DATA_FROZEN keys too, and rewrites only that entry", () => {
+    const real = readFileSync(LOGIC_PIN_REL_PATH, "utf-8");
+    const out = updateDataFrozenPin(real, "knownVoiceModelFamilies", "d".repeat(64));
+    expect(out).toMatchObject({ changed: true, locatorMiss: false });
+    expect(pinForUnquoted(out.text, "knownVoiceModelFamilies")).toBe("d".repeat(64));
+    expect(pinFor(out.text, "excludeFamilies.gemini")).toBe(pinFor(real, "excludeFamilies.gemini"));
+    const diff = diffPinKeys(real, out.text);
+    expect(diff.ok && diff.changedKeys).toEqual(["knownVoiceModelFamilies"]);
+  });
+
+  // THE BOUNDARY THE CHECKER ENFORCES. Reproduced end to end before the fix:
+  // widening `isClassifiedFamily` in model-registry.ts and re-pasting that
+  // surface's FROZEN checksum here passed gate-1 (both files allowlisted) and
+  // gate-2 (the pin test, whose oracle IS this file) — the exact "bot told to
+  // make the drift job pass" the pin file's own header names.
+  it("verifyPinFileEdit REFUSES a re-pasted FROZEN logic checksum, and ACCEPTS a membership re-pin", () => {
+    const real = readFileSync(LOGIC_PIN_REL_PATH, "utf-8");
+
+    const at = real.indexOf("  isClassifiedFamily: {");
+    expect(at).toBeGreaterThan(-1);
+    const m = /pin: "([0-9a-f]{64})"/.exec(real.slice(at))!;
+    const silenced =
+      real.slice(0, at + m.index) +
+      `pin: "${"9".repeat(64)}"` +
+      real.slice(at + m.index + m[0].length);
+    // It looks pin-only — which is precisely why "only pin literals moved" is
+    // not the boundary.
+    expect(onlyPinsChanged(real, silenced)).toBe(true);
+    const refused = verifyPinFileEdit(real, silenced, SYNC_REPINNABLE_KEYS);
+    expect(refused.ok).toBe(false);
+    expect(refused.detail).toContain("FROZEN logic checksum");
+    // ...and an edit that is not even pin-shaped says so instead.
+    const gutted = real.replace(
+      "members: () => [...excludeFamilies.openai].sort(),",
+      "members: () => [],",
+    );
+    expect(gutted).not.toBe(real);
+    expect(verifyPinFileEdit(real, gutted, SYNC_REPINNABLE_KEYS)).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining("outside a `pin:` string literal"),
+    });
+
+    const repinned = updateDataFrozenPin(real, "excludeFamilies.openai", "7".repeat(64));
+    expect(repinned.changed).toBe(true);
+    expect(verifyPinFileEdit(real, repinned.text, SYNC_REPINNABLE_KEYS).ok).toBe(true);
+    // ...and a re-pin of a key the sync may NOT move is refused just as hard.
+    const voice = updateDataFrozenPin(real, "gaRealtimeModels", "7".repeat(64));
+    expect(voice.changed).toBe(true);
+    expect(verifyPinFileEdit(real, voice.text, SYNC_REPINNABLE_KEYS)).toMatchObject({ ok: false });
   });
 
   it("onlyPinsChanged is the guard that keeps the sync off everything but pins", () => {

--- a/src/__tests__/drift-sync-gate-determinism.test.ts
+++ b/src/__tests__/drift-sync-gate-determinism.test.ts
@@ -84,6 +84,14 @@ function driftSuiteFilesReferencing(symbol: string): string[] {
     .filter((f) => readFileSync(join(DRIFT_SUITE_DIR, f), "utf-8").includes(symbol));
 }
 
+/**
+ * The pin file as gate-1b sees it on these runs. Every changeset here edits the
+ * REGISTRY only, so HEAD and the working tree agree and gate-1b is a no-op —
+ * which is itself the property being modelled: gate-1b must not have an opinion
+ * about a run that did not touch the pin file.
+ */
+const PIN_FILE_AT_HEAD = readFileSync(LOGIC_PIN_REL_PATH, "utf-8");
+
 describe("premise: the live drift suite cannot observe a recorded deprecation", () => {
   it("no *.drift.ts in the collector's glob reads deprecatedFamilies", () => {
     expect(driftSuiteFilesReferencing("deprecatedFamilies")).toEqual([]);
@@ -265,6 +273,8 @@ function runSync(recollect: () => DriftReport, inputs = churnInputs()): RunResul
     runSyncCheck: (opts) =>
       evaluateSyncCheck(
         {
+          readCommittedPinFile: () => PIN_FILE_AT_HEAD,
+          readWorkingPinFile: () => PIN_FILE_AT_HEAD,
           getChangedFiles: () => [MODEL_REGISTRY_REL_PATH],
           runPinCheck: () => ({ ok: true, output: "logic-pin.test.ts passed" }),
           recollect: () => {
@@ -388,6 +398,8 @@ function approvedNewFamilyRun(recollect: () => DriftReport): RunResult {
     runSyncCheck: (opts) =>
       evaluateSyncCheck(
         {
+          readCommittedPinFile: () => PIN_FILE_AT_HEAD,
+          readWorkingPinFile: () => PIN_FILE_AT_HEAD,
           getChangedFiles: () => [MODEL_REGISTRY_REL_PATH],
           runPinCheck: () => ({ ok: true, output: "logic-pin.test.ts passed" }),
           recollect: () => {
@@ -477,6 +489,8 @@ describe("negative controls — the gate still refuses a wrong edit", () => {
 
   it("WRONG EDIT: an off-allowlist file -> reverted, gate-1 never reaches the re-collect", () => {
     const verdict = evaluateSyncCheck({
+      readCommittedPinFile: () => PIN_FILE_AT_HEAD,
+      readWorkingPinFile: () => PIN_FILE_AT_HEAD,
       getChangedFiles: () => [MODEL_REGISTRY_REL_PATH, "src/__tests__/drift/sdk-shapes.ts"],
       runPinCheck: () => ({ ok: true, output: "" }),
       recollect: () => {
@@ -490,6 +504,8 @@ describe("negative controls — the gate still refuses a wrong edit", () => {
   it("WRONG EDIT: a moved classification pin -> refused even on the deprecation lane", () => {
     const verdict = evaluateSyncCheck(
       {
+        readCommittedPinFile: () => PIN_FILE_AT_HEAD,
+        readWorkingPinFile: () => PIN_FILE_AT_HEAD,
         getChangedFiles: () => [MODEL_REGISTRY_REL_PATH],
         runPinCheck: () => ({
           ok: false,


### PR DESCRIPTION
Follow-up to #423, from a four-reviewer retrospective review (all four
NOT-APPROVED, keep merged, fix forward). Every finding below was reproduced
against the real `model-registry.ts` / `logic-pin.test.ts` before the fix, and
every guard was mutation-proven after it.

## 1. The gate boundary is back in the checker

Admitting `logic-pin.test.ts` to `ALLOWED_EXACT_FILES` moved the only constraint
on the pin file out of the external gate and into the writer. `model-registry.ts`
is allowlisted too, so the pair was sufficient to silence a frozen surface.

**RED** — widen `isClassifiedFamily` to classify `gpt-zeta` by fiat, then
re-paste that surface's FROZEN checksum:

```
STEP 1 — widened isClassifiedFamily, pin test exit: 1
  → Frozen classification surface "isClassifiedFamily" changed
STEP 2 — re-pasted FROZEN.isClassifiedFamily pin: 60d59a5c43f3 -> 562ab1768a80
STEP 3 — gate-2 (vitest logic-pin.test.ts) exit: 0 | Tests 33 passed (33)
VERDICT ok= true reason= ok
drift-sync-check passed: changed files are data-only, classification pins intact
```

**GREEN** — same tree, same command, after the fix:

```
VERDICT ok= false reason= pin-file-not-a-membership-repin
src/__tests__/drift/logic-pin.test.ts is on the allowlist ONLY for membership
re-pins of excludeFamilies.{openai,anthropic,gemini},
includeFamilies.{openai,anthropic,gemini}, and this diff is not one: the edit
changed something other than the membership pins it is entitled to move
```

`onlyPinsChanged` was NOT the fix — it masks every `pin:` literal, FROZEN
checksums included, so the silenced tree reads as pin-only to it (asserted in a
test). The predicate is a reconstruction: re-apply exactly the entitled re-pins
to the pre-edit file and require byte equality with the post-edit file.
`drift-sync-check` gate-1b evaluates it over the git diff, keyed to
`SYNC_REPINNABLE_KEYS`; the writer evaluates it over what LANDED on disk, keyed
to the run's own re-pins.

## 2. The wrong-key pin rewrite

`updateDataFrozenPin`'s adjacency check only matched QUOTED keys, and three real
`DATA_FROZEN` keys are unquoted — one directly after `"excludeFamilies.gemini"`.

**RED**, against the real pin file, target entry's own pin unrecognisable:

```
knownVoiceModelFamilies pin BEFORE: 3897b6bd6fc370ef...
updateDataFrozenPin -> changed: true  locatorMiss: false
knownVoiceModelFamilies pin AFTER : eeeeeeeeeeeeeeee...
guard 2 onlyPinsChanged says safe: true
```

**GREEN** — entry located through the TypeScript AST, pin replaced span-exactly
inside its own literal:

```
updateDataFrozenPin -> changed: false  locatorMiss: true
knownVoiceModelFamilies pin AFTER : 3897b6bd6fc370ef...  (unchanged)
```

The "two independent guards" claim is gone from the comments: for a wrong-key
write it was one guard and a no-op. What is there now is one guard and one
external gate that does not trust it.

## 3. Exclude is complete, or it does not run

`excludeFamilies` and `knownVoiceModelFamilies` are deliberately disjoint and the
sync writes only the first.

**RED**, real files, gate-3 modelled on the real `ws-realtime.drift.ts`
computation:

```
reason= gate-failed
detail: [residual-critical-drift] UNKNOWN_REALTIME_MODELS=gpt-live — reverted
outcomes: [{"a":"excluded","f":"gpt-live"}]
revertFiles: [[model-registry.ts, logic-pin.test.ts]]
note still says Decision: exclude   -> repeats every night, forever
```

**GREEN**, both directions:

```
outcomes: [{"a":"needs-human-voice-seed-set","f":"gpt-live"}]  reverted: []
(registry untouched, gate never called, deduped note naming both surfaces)

# once a human has made the voice-models.ts half:
gate-3: ws-realtime UNKNOWN_REALTIME_MODELS=[]
reason= ok-applied | outcomes: ["excluded:gpt-live"] | reverted: []
```

The predicate keys on the voice SEED SET, not on the id's shape, and covers
`include` as well — the canary reads the seed set, not the classification. The
note template no longer advertises an auto-apply the sync will refuse.

## 4. Honest reporting

**RED**: `reason= needs-human | registry written? false` while
`outcomes: ["added:openai/gpt-zeta"]` and the commit body read
`- added openai/gpt-zeta`. **GREEN**: `outcomes: ["needs-human-repin:..."]`,
empty commit body, and a deduped `-pin-repin-failure.md` note.
`fix-drift.yml`'s "only ever edits `model-registry.ts`" comment is corrected.

## Mutation proof (`if (false)` on every guard; baseline 152 passed)

| Guard | Mutated |
|---|---|
| checker gate-1b enforcement | 3 failed |
| writer post-write pin verification | 1 failed |
| `updateDataFrozenPin` entry/pin refusal | 2 failed |
| voice-seed-set routing | 1 failed |
| `verifyPinFileEdit` reconstruction | 3 failed |
| `verifyPinFileEdit` allowed-key scope | 3 failed |

A seventh branch — the `onlyPinsChanged` pre-cut — survived, so it was demoted to
a message selector rather than kept: a guard that cannot change a verdict is not
a guard.

## Gates

`prettier --check` 0 · `eslint .` 0 · `pnpm typecheck` 0 · `vitest run` 0
(5791 passed / 46 skipped) · `actionlint` 0 · `commitlint` 0.

Does not touch `model-registry.ts`'s family lists (owned concurrently by the
`gpt-live-1` classification, now on main and rebased under this).
