### PR TITLE
fix(byteplus): restore the docs content class and stop capturing a malformed status

### DIFF
--- a/docs/byteplus-video/index.html
+++ b/docs/byteplus-video/index.html
@@ -47,7 +47,7 @@
     <div class="docs-layout">
       <aside class="sidebar" id="sidebar"></aside>
 
-      <main class="content">
+      <main class="docs-content">
         <h1>BytePlus Ark (Seedance) Video</h1>
 
         <p>
@@ -225,9 +225,10 @@
         <p>
           Ark's <code>content.video_url</code> dies 24 hours after the task produced it, and the
           task record itself is gone in 7 days. aimock serves the recorded URL as-is and warns once
-          per job when it is past its expiry — it does not substitute a placeholder, because a URL
-          aimock invented is harder to debug than a named warning. If your suite starts failing on a
-          download, re-record.
+          per fixture envelope when it is past its expiry — every job replaying that same envelope
+          shares the one warning, and a new envelope object can warn again. It does not substitute a
+          placeholder, because a URL aimock invented is harder to debug than a named warning. If
+          your suite starts failing on a download, re-record.
         </p>
 
         <h2>Known limits</h2>

--- a/src/__tests__/byteplus-video-record.test.ts
+++ b/src/__tests__/byteplus-video-record.test.ts
@@ -28,6 +28,12 @@ const UPSTREAM_TASK_ID = "cgt-upstream-1";
 interface ArkUpstreamOptions {
   /** Widened past the vendor's four so an UNRECOGNIZED terminal state is testable. */
   finalStatus?: string;
+  /**
+   * Corrupt the terminal poll body's `status` the way only a MALFORMED upstream
+   * could: drop it entirely, or send a number. Neither is a shape Ark is known
+   * to emit — this exists solely to pin the handler's robustness to it.
+   */
+  malformedTerminalStatus?: "omit" | "numeric";
   pollsBeforeTerminal?: number;
   submitHttpStatus?: number;
   pollHttpStatus?: number;
@@ -156,6 +162,8 @@ function startArkUpstream(opts: ArkUpstreamOptions = {}): Promise<ArkUpstream> {
           } else if (finalStatus === "failed") {
             terminal.error = { code: "QuotaExceeded", message: "no quota" };
           }
+          if (opts.malformedTerminalStatus === "omit") delete terminal.status;
+          else if (opts.malformedTerminalStatus === "numeric") terminal.status = 123;
           send(200, terminal);
           return;
         }
@@ -865,5 +873,94 @@ describe("BytePlus video record — capture correctness", () => {
     const body = (await (await fetch(`${mock.url}${SUBMIT}/${res.json.id}`)).json()) as ArkBody;
     expect(body.status).toBe("succeeded");
     expect(readFixtures(dir)).toHaveLength(1);
+  });
+});
+
+// ─── Malformed upstream status ──────────────────────────────────────────────
+// A 2xx JSON object poll body whose `status` is absent or non-string is NOT a
+// shape BytePlus Ark is known to emit; these pin robustness to it, nothing
+// more. The pre-fix handler coerced such a body with `String(status ?? "")`,
+// and because terminal is the COMPLEMENT of queued/running, the coerced value
+// read as terminal. That captured the malformed envelope as a fixture and
+// swapped the job to replay — after which every later poll 502s on that same
+// envelope and the corrected upstream response is never fetched for the job.
+// The status a capture stores must satisfy what replay demands of it: a
+// non-empty string. Anything else is not terminal, so it is relayed and the
+// job stays upstream-backed.
+
+describe("BytePlus video record — a malformed upstream status is never captured", () => {
+  let mock: LLMock | undefined;
+  let upstream: ArkUpstream | undefined;
+  let dir: string | undefined;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await mock?.stop();
+    await upstream?.close();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+    mock = upstream = undefined;
+    dir = undefined;
+  });
+
+  test.each([
+    ["absent", "omit" as const],
+    ["numeric", "numeric" as const],
+  ])(
+    "a %s status keeps the job upstream-backed instead of persisting an unusable fixture",
+    async (_label, malformedTerminalStatus) => {
+      upstream = await startArkUpstream({ malformedTerminalStatus });
+      dir = tmpFixtureDir();
+      mock = new LLMock({
+        port: 0,
+        record: { providers: { byteplus: upstream.url }, fixturePath: dir },
+      });
+      await mock.start();
+
+      const submitted = await submit(mock, goBody);
+      expect(submitted.status).toBe(200);
+
+      // Poll 1 relays the malformed body verbatim, as every non-terminal poll does.
+      const first = await fetch(`${mock.url}${SUBMIT}/${submitted.json.id}`);
+      expect(first.status).toBe(200);
+
+      // Poll 2 must reach UPSTREAM again. Pre-fix it 502'd off a captured
+      // replay envelope, and upstream was never asked a second time.
+      const second = await fetch(`${mock.url}${SUBMIT}/${submitted.json.id}`);
+      expect(second.status).toBe(200);
+      expect(upstream.paths.poll.length).toBe(2);
+
+      // Nothing unusable reached disk.
+      expect(readFixtures(dir)).toEqual([]);
+    },
+  );
+
+  test("a corrected upstream status on a LATER poll still records normally", async () => {
+    // The point of not capturing: the job is still upstream-backed, so when the
+    // upstream starts answering properly the recording happens as it should.
+    // The helper closes over this object, so clearing the flag mid-test is what
+    // "the upstream started answering properly" looks like on the wire.
+    const upstreamOpts: ArkUpstreamOptions = { malformedTerminalStatus: "omit" };
+    upstream = await startArkUpstream(upstreamOpts);
+    dir = tmpFixtureDir();
+    mock = new LLMock({
+      port: 0,
+      record: { providers: { byteplus: upstream.url }, fixturePath: dir },
+    });
+    await mock.start();
+
+    const submitted = await submit(mock, goBody);
+    await fetch(`${mock.url}${SUBMIT}/${submitted.json.id}`);
+    expect(readFixtures(dir)).toEqual([]);
+
+    // Upstream is fixed mid-flight.
+    upstreamOpts.malformedTerminalStatus = undefined;
+
+    const recovered = await fetch(`${mock.url}${SUBMIT}/${submitted.json.id}`);
+    expect(recovered.status).toBe(200);
+    expect((await recovered.json()).status).toBe("succeeded");
+
+    const fixtures = readFixtures(dir);
+    expect(fixtures.length).toBe(1);
+    expect(fixtures[0].response.json.status).toBe("succeeded");
   });
 });

--- a/src/byteplus-video.ts
+++ b/src/byteplus-video.ts
@@ -292,9 +292,11 @@ function unresolvedPartToken(raw: unknown): string {
 /**
  * The synthetic user message a submit is matched on.
  *
- * Concatenated text of every `type: "text"` part, then ALWAYS a newline and
+ * Concatenated text of every `type: "text"` part, then ALWAYS
  * `[media: <role>:<sha256 first 12 hex>, …]` — one entry per non-text part in
- * array order, `[media: ]` when there are none.
+ * array order, `[media: ]` when there are none. The separating newline is
+ * present only when there IS text: a key with no text part is the bare
+ * `[media: …]` suffix, unprefixed.
  *
  * WHY the digest: a Seedance image-to-video job carries NO text part, so a
  * text-only key would record `{ endpoint, model }` — a wildcard matching every
@@ -1270,9 +1272,24 @@ async function proxyBytePlusVideoRecordPoll(args: {
   // Terminal is derived from the NON-terminal pair, not from a second copy of
   // the four terminal tokens: a vendor-added end state is captured rather than
   // proxied until the client gives up.
-  const upstreamStatus = String(upstreamBody.status ?? "");
+  //
+  // The status must FIRST clear what replay demands of it — a non-empty string,
+  // the exact predicate `serializeBytePlusVideoTask` applies. Coercing instead
+  // (`String(status ?? "")`) turned an absent status into `""` and a numeric
+  // `123` into `"123"`, and since terminal is the COMPLEMENT of the non-terminal
+  // pair, both read as terminal. Capture then wrote an envelope replay cannot
+  // serve and swapped the job to replay, so every later poll 502s on that same
+  // envelope and a corrected upstream response is never fetched for the job —
+  // and the unusable fixture is on disk. Treating it as NOT terminal relays it
+  // verbatim and leaves the job upstream-backed, which is also what lets a
+  // later well-formed response record normally.
+  //
+  // Scope: this is malformed-upstream robustness only. Ark is not known to emit
+  // such a body, and non-2xx / non-JSON / non-object bodies are rejected above.
+  const rawStatus = upstreamBody.status;
+  const upstreamStatus = typeof rawStatus === "string" ? rawStatus : "";
 
-  if (!isBytePlusTerminalStatus(upstreamStatus)) {
+  if (!upstreamStatus || !isBytePlusTerminalStatus(upstreamStatus)) {
     if (jobs.get(key) === job) jobs.set(key, job); // TTL refresh
     relayJson(relayBody);
     return;


### PR DESCRIPTION
Three defects an independent review found on `main` after PR #424 merged. All three were reproduced on `origin/main` @ `7040a2d` before any change was made.

## 1. P2 — the docs page is visually broken

`docs/byteplus-video/index.html` used `<main class="content">`. Every other page in `docs/` uses `docs-content` — a sweep of all 40+ pages found this one as the sole exception, so it is template drift, not an alternate layout.

`docs/style.css` puts the content margin, padding, sizing, max/min width and word-wrapping on `.docs-content`, and `docs/sidebar.js:151` selects `.docs-content` and returns early when it is absent, before assigning heading ids or building the TOC. One root cause, two visible effects.

Verified by Playwright screenshots on a locally served `docs/` tree at 1440x900, 375x667 and 430x932, with `docs/video/` as the control, and the images inspected directly rather than trusting measurements.

**Before** — 1440x900: the fixed sidebar overlays the content; the title renders as "…eedance) Video" with its left half hidden, and every paragraph and code block is clipped on the left. 375x667 and 430x932: content has no gutter at all, starting flush at x=0, and every line runs off the right edge.

**After** — 1440x900: full title, padded content column clear of the sidebar, and the "ON THIS PAGE" TOC rendered on the right, matching the control. 375x667 and 430x932: proper gutters, title and prose wrap, nothing clipped.

| | before | after | control (`/video/`) |
|---|---|---|---|
| TOC links | 0 | 6 | 8 |
| populated h2 ids | 0 / 6 | 6 / 6 | 6 / 6 |
| `.docs-content` found | no | yes | yes |

Residual horizontal overflow from long `<pre>` lines at mobile widths is pre-existing and site-wide (`grok-video` 527px, `veo-video` 905px, `fal-ai` 726px against a 375px viewport), unrelated to this class, and left alone.

## 2. P2 — a malformed poll status persists an unusable fixture

`src/byteplus-video.ts` coerced the upstream status with `String(upstreamBody.status ?? "")`, so an absent status became `""` and a numeric `123` became `"123"`. Terminal is derived as the complement of the non-terminal pair, so both coerced values read as terminal. Record mode then persisted an envelope that `serializeBytePlusVideoTask` rejects and swapped the job to replay — so every later poll 502s on that same envelope and a corrected upstream response is never fetched for that job, with the unusable fixture left on disk.

The status now has to clear the same predicate replay applies — a non-empty string — before it can be terminal. Otherwise it is relayed verbatim and the job stays upstream-backed.

**Scope, stated honestly:** this is malformed-upstream robustness only. There is no evidence Ark emits such a body. 4xx/5xx, non-JSON and non-object bodies are out of scope and are already rejected upstream of this check.

### The reviewer's own repro, before and after

Run with the repo's `tsx` against a real aimock server, a real HTTP upstream, the real recorder and real filesystem persistence.

Before:
```
missing: submit 200; poll 1 200; poll 2 502   upstreamPolls 1   persisted {"json":{}}
numeric: submit 200; poll 1 200; poll 2 502   upstreamPolls 1   persisted {"json":{"status":123}}
valid:   submit 200; poll 1 200; poll 2 200   upstreamPolls 1   persisted {"json":{"status":"cancelled"}}
```

After:
```
missing: submit 200; poll 1 200; poll 2 200   upstreamPolls 2   persisted (nothing)
numeric: submit 200; poll 1 200; poll 2 200   upstreamPolls 2   persisted (nothing)
valid:   submit 200; poll 1 200; poll 2 200   upstreamPolls 1   persisted {"json":{"status":"cancelled"}}
```

`upstreamPolls` going 1 -> 2 is the job staying upstream-backed. The valid control is unchanged.

### Regression test, observed red before the fix

Three tests added to `src/__tests__/byteplus-video-record.test.ts`, run against the unmodified handler first:

```
× a absent status keeps the job upstream-backed instead of persisting an unusable fixture
  → expected 502 to be 200
× a numeric status keeps the job upstream-backed instead of persisting an unusable fixture
  → expected 502 to be 200
× a corrected upstream status on a LATER poll still records normally
  → expected [ { match: {…}, response: {…} } ] to deeply equal []
Tests  3 failed | 28 skipped (31)
```

After the fix, on the same tests:

```
✓ src/__tests__/byteplus-video-record.test.ts (31 tests | 28 skipped)
Tests  3 passed | 28 skipped (31)
```

## 3. P3 — two inaccurate descriptions

Neither is a runtime change.

The docs said aimock "warns once **per job**" on an expired URL. The implementation latches per shared fixture envelope object, and the existing test named *"the staleness warn latches per FIXTURE"* submits four jobs and asserts exactly one warning — the test contradicts the doc. Corrected to "once per fixture envelope", noting a new envelope object can warn again.

The `buildBytePlusMatchText` docblock promised "ALWAYS a newline and `[media: …]`", but the code is `return text ? \`\${text}\n\${suffix}\` : suffix` — a text-free key is the bare suffix with no newline. Corrected to say the separator is present only when there is text.

## Gates

Raw exit codes, all from the worktree root:

| gate | exit |
|---|---|
| `prettier --check .` | 0 |
| `npx eslint .` | 0 |
| `pnpm typecheck` | 0 |
| `npx vitest run` | 0 — 188 files passed, 5782 tests passed, 46 skipped |