### PR TITLE
chore: release v1.41.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "npm",
         "package": "@copilotkit/aimock",
-        "version": "^1.40.0"
+        "version": "^1.41.0"
       },
       "description": "Fixture authoring skill for @copilotkit/aimock — LLM, multimedia (image/TTS/transcription/video), MCP, A2A, AG-UI, vector, embeddings, structured output, sequential responses, streaming physics, record/replay, agent loop patterns, and debugging"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aimock",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "Fixture authoring guidance for @copilotkit/aimock — LLM, multimedia, MCP, A2A, AG-UI, vector, and service mocking",
   "author": {
     "name": "CopilotKit"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -45,7 +45,7 @@ jobs:
             const lines = fs.readFileSync('README.md','utf-8').split('\n');
             for (const line of lines) {
               const t = line.trim();
-              if (!t || t.startsWith('#') || t.startsWith('[') || t.startsWith('http') || t.startsWith('![')) continue;
+              if (!t || t.startsWith('#') || t.startsWith('[') || t.startsWith('<') || t.startsWith('http') || t.startsWith('![')) continue;
               pkg.description = t.replace(/[*_\`]/g,'').replace(/\s+/g,' ').trim();
               break;
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [1.41.0] - 2026-09-10
+
+### Added
+
+- **BytePlus Ark (Seedance) video record/replay** — submit, poll, retrieve raw Ark tasks (#424)
+- New `--provider-byteplus` flag to proxy BytePlus Ark to an upstream base (#424)
+
+### Changed
+
+- `/api/v3` chat and image requests are attributed to the `byteplus` provider (#424)
+- `aimock-pytest` now defaults to `@copilotkit/aimock` 1.41.0.
+
+### Fixed
+
+- aimock now fails at startup if a BytePlus base already ends in `/api/v3` (#424)
+
 ## [1.40.0] - 2026-09-08
 
 ### Added

--- a/charts/aimock/Chart.yaml
+++ b/charts/aimock/Chart.yaml
@@ -3,4 +3,4 @@ name: aimock
 description: Mock infrastructure for AI application testing (OpenAI, Anthropic, Gemini, MCP, A2A, vector)
 type: application
 version: 0.1.0
-appVersion: "1.40.0"
+appVersion: "1.41.0"

--- a/docs/index.html
+++ b/docs/index.html
@@ -2659,7 +2659,7 @@
             <div class="demo-body">
               <pre><span class="t-green">$</span> npx @copilotkit/aimock --config aimock.json
 
-<span class="t-blue">&#9889;</span> aimock v1.40.0
+<span class="t-blue">&#9889;</span> aimock v1.41.0
 
 <span class="t-green">&#10003;</span> LLM    <span class="t-dim">mounted at</span>  /v1/chat/completions
 <span class="t-green">&#10003;</span> LLM    <span class="t-dim">mounted at</span>  /v1/messages

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@copilotkit/aimock",
-  "version": "1.40.0",
-  "description": "Mock infrastructure for AI application testing — LLM APIs, image generation, image editing, text-to-speech, transcription, audio translation, audio generation, video generation, embeddings, MCP tools, A2A agents, AG-UI event streams, vector databases, search, rerank, and moderation. One package, one port, zero dependencies.",
+  "version": "1.41.0",
+  "description": "Mock infrastructure for AI application testing — point your SDK at one local port and every provider, protocol, and service answers deterministically.",
   "license": "MIT",
   "keywords": [
     "mock",

--- a/packages/aimock-pytest/README.md
+++ b/packages/aimock-pytest/README.md
@@ -80,7 +80,7 @@ aimock.reset_fixtures()    # alias for reset() — a full reset, despite the nam
 
 ```
 --aimock-node PATH       Path to node binary
---aimock-version VER     aimock npm version (default: 1.40.0)
+--aimock-version VER     aimock npm version (default: 1.41.0)
 --aimock-api-key KEY     Inbound API key for the aimock child process
 ```
 

--- a/packages/aimock-pytest/src/aimock_pytest/_version.py
+++ b/packages/aimock-pytest/src/aimock_pytest/_version.py
@@ -11,4 +11,4 @@ npm publication and verifies that this pin exists before it builds or uploads
 a wheel. Keep it tracking npm releases.
 """
 
-AIMOCK_VERSION = "1.40.0"
+AIMOCK_VERSION = "1.41.0"

--- a/scripts/drift-sync.ts
+++ b/scripts/drift-sync.ts
@@ -283,7 +283,9 @@ function syncDescriptionFromReadme(pkg: { description?: string; [key: string]: u
   const readmePath = resolve("README.md");
   try {
     const readme = readFileSync(readmePath, "utf-8");
-    // The description is the first non-empty, non-heading, non-badge, non-video line
+    // The description is the first non-empty, non-heading, non-badge, non-video,
+    // non-HTML line. The README opens with a raw <div align="center"> wrapper,
+    // which is not prose and must not become the published description.
     const lines = readme.split("\n");
     for (const line of lines) {
       const trimmed = line.trim();
@@ -293,6 +295,7 @@ function syncDescriptionFromReadme(pkg: { description?: string; [key: string]: u
         trimmed.startsWith("[![") ||
         trimmed.startsWith("![") ||
         trimmed.startsWith("[") ||
+        trimmed.startsWith("<") ||
         trimmed.startsWith("http")
       ) {
         continue;


### PR DESCRIPTION
Cuts the accumulated `[Unreleased]` work. **MINOR** — a new provider surface (BytePlus Ark video) and new endpoints, no breaking changes.

**Prepared, not merged.** `publish-release.yml` fires on push-to-main, so merging this publishes to npm, tags `v1.41.0`, cuts the GitHub Release, dispatches the Docker build, and posts to Slack. Merge when you want it live.

## What ships

Only **#424** (plus its follow-up **#429**, which fixes the same never-released BytePlus code) touches the published package. Verified against `package.json` `files` + `tsconfig` include/exclude:

```
git log v1.40.0..origin/main --oneline -- src/ ':(exclude)src/__tests__/' fixtures/ .claude-plugin/ skills/ CHANGELOG.md
```

…returns byteplus commits only. #422, #423, #425, #426, #427, #428 touch scripts/, .github/ and docs/ exclusively and are deliberately **not** in the CHANGELOG.

### Added
- BytePlus Ark (Seedance) video record/replay — submit, poll and retrieve, stored as the raw Ark task envelope
- `--provider-byteplus` flag

### Changed
- `/api/v3` chat and image requests are attributed to the `byteplus` provider
- `aimock-pytest` pin moves to 1.41.0

### Fixed
- Startup error when a BytePlus provider base already ends in `/api/v3`

## Version surfaces — seven, all bumped

Found by grepping the tree for `1.40.0`, not from a checklist. **Zero occurrences of the old string remain** (excluding `CHANGELOG.md` history, `fixtures/` and `pnpm-lock.yaml`):

| File | Field | 1.40.0 → 1.41.0 |
| --- | --- | --- |
| `package.json` | `version` | ✔ |
| `charts/aimock/Chart.yaml` | `appVersion` (chart `version` stays `0.1.0`) | ✔ |
| `.claude-plugin/plugin.json` | `version` | ✔ |
| `.claude-plugin/marketplace.json` | `plugins[0].source.version` (`^1.41.0`) | ✔ |
| `docs/index.html` | demo banner `aimock v…` | ✔ |
| `packages/aimock-pytest/src/aimock_pytest/_version.py` | `AIMOCK_VERSION` npm pin | ✔ |
| `packages/aimock-pytest/README.md` | `--aimock-version` default | ✔ |

`AIMOCK_VERSION` **must** move this release: `/api/v3/contents/generations/tasks` is a new server route, so a default-download pytest user on the 1.40.0 pin would run a server without it. `packages/aimock-pytest/pyproject.toml` is deliberately untouched — that package versions on its own PyPI cadence.

There is **no version constant in `src/cli.ts`** and **no `metadata.version` in `marketplace.json`** in this tree; both surfaces exist only in the release checklist, not in the repo.

## Drive-by: the npm description has been `<div align="center">` since the README got a centered header

`npm view @copilotkit/aimock@1.40.0 description` returns the literal string `<div align="center">`.

Both README-subtitle extractors — the inline `node -e` in `publish-release.yml` and `syncDescriptionFromReadme()` in `scripts/drift-sync.ts` — skip `#`, `[`, `![` and `http` lines but not raw HTML, so they latch onto the README's opening `<div>` wrapper instead of the bold subtitle two lines below. Both now also skip `<`, and `package.json.description` is synced to what the fixed extractor yields:

> Mock infrastructure for AI application testing — point your SDK at one local port and every provider, protocol, and service answers deterministically.

Without this the v1.41.0 npm page ships the same broken description.

## Gates (raw exit codes, local)

| Gate | Exit |
| --- | --- |
| `prettier --check .` | 0 |
| `npx eslint .` | 0 |
| `pnpm typecheck` | 0 |
| `npx vitest run` (5794 passed, 46 skipped, 189 files) | 0 |
| `pnpm build` | 0 |
| `npx commitlint --from origin/main --to HEAD` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvkmhXVLqSSEW6FvPQHSu5
