### PR TITLE
fix(ci): retry the pinned-npm-release check instead of racing the registry

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -178,12 +178,82 @@ jobs:
           package-manager-cache: false
 
       - name: Verify pinned npm release is published
+        # This gate exists to stop aimock-pytest shipping a pin to an npm
+        # version that was never published, so it MUST still fail when the
+        # version is genuinely absent. It used to ask ONCE, and so it raced the
+        # registry: on the v1.41.0 release (run 34546620094) the publish job
+        # landed 1.41.0 at 00:30:31 and this step asked for it at 00:30:49 — 18
+        # seconds later — and npm answered E404. The version existed; re-running
+        # the job unchanged passed. A release gate that cries wolf is one people
+        # stop reading, so poll to a deadline instead of asking once.
+        #
+        # 300s: ~16x the observed 18s lag, past npm's replication tail, and
+        # still small beside this job's own checkout/setup. A pin still missing
+        # after five minutes is a bad pin, not propagation, and must go red.
         run: |
           # Read the pin WITHOUT importing the package: aimock_pytest/__init__.py
           # imports _server, which imports `requests`, and no Python deps are
           # installed at this point in the job. runpy executes _version.py alone.
           VERSION=$(python -c "import runpy; print(runpy.run_path('packages/aimock-pytest/src/aimock_pytest/_version.py')['AIMOCK_VERSION'])")
-          npm view "@copilotkit/aimock@${VERSION}" version
+          PKG="@copilotkit/aimock"
+          DEADLINE=${NPM_VIEW_DEADLINE_SECONDS:-300}
+          DELAY=${NPM_VIEW_INITIAL_DELAY_SECONDS:-5}
+          MAX_DELAY=${NPM_VIEW_MAX_DELAY_SECONDS:-30}
+          START=$(date +%s)
+          ATTEMPT=0
+
+          while :; do
+            ATTEMPT=$((ATTEMPT + 1))
+            if FOUND=$(npm view "${PKG}@${VERSION}" version 2>&1); then
+              echo "attempt ${ATTEMPT}: ${PKG}@${VERSION} is published (${FOUND})"
+              exit 0
+            fi
+            echo "attempt ${ATTEMPT} (t+$(($(date +%s) - START))s): ${PKG}@${VERSION} not visible yet"
+            printf '%s\n' "${FOUND}" | sed 's/^/  | /'
+
+            # Companion query. `npm view <pkg> versions` distinguishes the two
+            # failures the per-version E404 conflates:
+            #   - the package itself is missing  -> a bad pin, never propagation
+            #   - the package lists the version  -> published; the per-version
+            #     404 was a stale packument, so stop waiting on a fact already
+            #     proven by the registry itself
+            # Anything else stays ambiguous (propagating publish vs typo'd
+            # version) and is what the deadline below is for.
+            if VERSIONS=$(npm view "${PKG}" versions --json 2>&1); then
+              if printf '%s' "${VERSIONS}" | node -e '
+                const want = process.argv[1];
+                let raw = "";
+                process.stdin.on("data", (c) => (raw += c));
+                process.stdin.on("end", () => {
+                  let list;
+                  try { list = JSON.parse(raw); } catch { process.exit(2); }
+                  if (typeof list === "string") list = [list];
+                  process.exit(Array.isArray(list) && list.includes(want) ? 0 : 1);
+                });
+              ' "${VERSION}"; then
+                echo "${PKG}@${VERSION} IS in the registry version list; the per-version 404 is propagation lag"
+                exit 0
+              fi
+              echo "  ${PKG} exists but does not list ${VERSION} yet - lag or a bad pin, still waiting"
+            elif printf '%s' "${VERSIONS}" | grep -q "E404"; then
+              echo "::error::npm has no package named ${PKG} at all, so the pin ${VERSION} in packages/aimock-pytest/src/aimock_pytest/_version.py is not a propagation delay. Failing immediately."
+              printf '%s\n' "${VERSIONS}" | sed 's/^/  | /'
+              exit 1
+            else
+              echo "  package-level query failed without a 404 - registry unreachable, treating as transient"
+              printf '%s\n' "${VERSIONS}" | sed 's/^/  | /'
+            fi
+
+            ELAPSED=$(($(date +%s) - START))
+            if [ "${ELAPSED}" -ge "${DEADLINE}" ]; then
+              echo "::error::${PKG}@${VERSION} is still not published after ${ATTEMPT} attempts over ${ELAPSED}s (deadline ${DEADLINE}s). aimock-pytest pins this version in packages/aimock-pytest/src/aimock_pytest/_version.py; refusing to publish a pin to a version npm does not have."
+              exit 1
+            fi
+            echo "  retrying in ${DELAY}s"
+            sleep "${DELAY}"
+            DELAY=$((DELAY * 2))
+            if [ "${DELAY}" -gt "${MAX_DELAY}" ]; then DELAY=${MAX_DELAY}; fi
+          done
 
       - name: Install build tools
         # HASH-PINNED, and hatchling rather than hatch. Both halves were measured

--- a/src/__tests__/npm-publish-verify-workflow.test.ts
+++ b/src/__tests__/npm-publish-verify-workflow.test.ts
@@ -227,14 +227,18 @@ describe("publish-release.yml — the race it used to lose", () => {
 
 describe("publish-release.yml — NEGATIVE CONTROLS: the guard still bites", () => {
   it("EXECUTED: a version that never appears FAILS, after waiting out the window", () => {
-    const o = observe("99.99.99", { eventually: false });
+    // 5s, not 1s: `date +%s` is whole-second, so under a loaded full-suite run
+    // a single loop pass can itself cross a 1s deadline and the body exits
+    // after ONE attempt -- which is the assertion below, flaking on machine
+    // load rather than on behaviour.
+    const o = observe("99.99.99", { eventually: false }, { NPM_VIEW_DEADLINE_SECONDS: "5" });
     expect(o.exit).toBe(1);
     // It must have actually waited — a body that failed on the first attempt
     // would be the original bug wearing a retry loop's clothes.
     expect(o.attempts).toBeGreaterThan(1);
-    // `date +%s` truncates, so a 1s deadline can be crossed a little under 1s
+    // `date +%s` truncates, so a 5s deadline can be crossed a little under 5s
     // of wall clock; the point of the bound is that it slept at all.
-    expect(o.elapsedMs).toBeGreaterThanOrEqual(800);
+    expect(o.elapsedMs).toBeGreaterThanOrEqual(4000);
     expect(o.stdout).toContain("::error::");
     expect(o.stdout).toContain("still not published after");
     expect(o.stdout).toContain("refusing to publish a pin to a version npm does not have");
@@ -262,7 +266,11 @@ describe("publish-release.yml — NEGATIVE CONTROLS: the guard still bites", () 
   });
 
   it("EXECUTED: an unreachable registry is transient, NOT a missing-package verdict", () => {
-    const o = observe("1.41.0", { eventually: false, registryUnreachable: true });
+    const o = observe(
+      "1.41.0",
+      { eventually: false, registryUnreachable: true },
+      { NPM_VIEW_DEADLINE_SECONDS: "5" },
+    );
     expect(o.exit).toBe(1);
     expect(o.attempts).toBeGreaterThan(1);
     expect(o.stdout).toContain("registry unreachable, treating as transient");

--- a/src/__tests__/npm-publish-verify-workflow.test.ts
+++ b/src/__tests__/npm-publish-verify-workflow.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Assertions on the "Verify pinned npm release is published" step of
+ * .github/workflows/publish-release.yml.
+ *
+ * That step is the gate that stops aimock-pytest shipping a pin to an npm
+ * version that was never published. It used to ask npm exactly once, so it
+ * raced the registry: on the v1.41.0 release (run 34546620094) the publish job
+ * landed 1.41.0 at 00:30:31 and this step asked for it at 00:30:49 — 18
+ * seconds later — and npm answered E404. The version existed. Re-running the
+ * job unchanged passed, publishing nothing.
+ *
+ * These guards EXECUTE the step's own `run:` body under bash against a stub
+ * `npm`, because the only claim worth pinning is behavioural. The important
+ * half is NOT that a propagating publish now survives — it is the negative
+ * controls: a retry loop that swallowed a genuinely-missing version would be a
+ * strictly worse bug than the race it fixed.
+ */
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+// Every observation runs a real retry loop with real sleeps. That is far
+// slower than a substring test, and a guard whose RED cannot be told apart
+// from a timeout proves nothing, so the budget is stated rather than inherited.
+vi.setConfig({ testTimeout: 60_000 });
+
+const WORKFLOW_PATH = resolve(__dirname, "../../.github/workflows/publish-release.yml");
+const wf = readFileSync(WORKFLOW_PATH, "utf-8");
+const STEP = "Verify pinned npm release is published";
+const PKG = "@copilotkit/aimock";
+
+/**
+ * The step's `run:` block scalar, dedented.
+ *
+ * `runBodyIsVerbatim` below re-indents the result and requires it to be a
+ * literal substring of the file, so an extractor that paraphrases — and
+ * therefore an observation that tests something other than what CI runs —
+ * cannot pass.
+ */
+function runBody(): { body: string; indent: number } {
+  const lines = wf.split("\n");
+  const at = lines.findIndex((l) => l.includes(`- name: ${STEP}`));
+  if (at === -1) throw new Error(`publish-release.yml: no step named ${STEP}`);
+  let i = at + 1;
+  while (i < lines.length && !/^\s*run: \|\s*$/.test(lines[i])) {
+    if (/^\s*- name: /.test(lines[i]))
+      throw new Error(`${STEP}: no \`run: |\` before the next step`);
+    i++;
+  }
+  if (i >= lines.length) throw new Error(`${STEP}: no \`run: |\` block found`);
+  const indent = lines[i].length - lines[i].trimStart().length + 2;
+  const out: string[] = [];
+  for (let j = i + 1; j < lines.length; j++) {
+    const l = lines[j];
+    if (!l.trim()) {
+      out.push("");
+      continue;
+    }
+    if (l.length - l.trimStart().length < indent) break;
+    out.push(l.slice(indent));
+  }
+  while (out.length && out[out.length - 1] === "") out.pop();
+  return { body: out.join("\n") + "\n", indent };
+}
+
+const tmpDirs: string[] = [];
+afterAll(() => {
+  for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+});
+
+interface Registry {
+  /** How many per-version queries answer E404 before the version appears. */
+  notFoundTimes: number;
+  /** false: the version NEVER appears, however long we wait. */
+  eventually: boolean;
+  /** false: `npm view <pkg> versions` itself 404s — the package does not exist. */
+  packageExists: boolean;
+  /** true: the package-level version list already carries the wanted version. */
+  listHasVersion: boolean;
+  /** true: the package-level query fails with something other than a 404. */
+  registryUnreachable: boolean;
+}
+
+interface Observation {
+  stdout: string;
+  exit: number;
+  /** How many times the body actually asked npm for the pinned version. */
+  attempts: number;
+  elapsedMs: number;
+}
+
+/**
+ * Write a fixture repo holding `version` in _version.py, put a stub `npm` (and
+ * a `python` that is just python3) on PATH, and run the step's own body in it.
+ */
+function observe(
+  version: string,
+  registry: Partial<Registry>,
+  env: Record<string, string> = {},
+): Observation {
+  const r: Registry = {
+    notFoundTimes: 0,
+    eventually: true,
+    packageExists: true,
+    listHasVersion: false,
+    registryUnreachable: false,
+    ...registry,
+  };
+  const dir = mkdtempSync(join(tmpdir(), "npm-publish-verify-"));
+  tmpDirs.push(dir);
+  const pkgDir = join(dir, "packages/aimock-pytest/src/aimock_pytest");
+  mkdirSync(pkgDir, { recursive: true });
+  // The real file the step reads with runpy, in the real location.
+  writeFileSync(join(pkgDir, "_version.py"), `AIMOCK_VERSION = "${version}"\n`);
+
+  const bin = join(dir, "bin");
+  mkdirSync(bin);
+  const counter = join(dir, "attempts");
+  writeFileSync(counter, "0\n");
+
+  // GitHub's setup-python provides `python`; developer machines and the ubuntu
+  // runner provide `python3`. The body genuinely executes runpy either way.
+  writeFileSync(join(bin, "python"), '#!/usr/bin/env bash\nexec python3 "$@"\n');
+  chmodSync(join(bin, "python"), 0o755);
+
+  const versionList = r.listHasVersion ? ["1.0.0", version] : ["1.0.0"];
+  writeFileSync(
+    join(bin, "npm"),
+    [
+      "#!/usr/bin/env bash",
+      '[ "$1" = view ] || { echo "stub npm: unsupported $*" >&2; exit 2; }',
+      'if [ "$3" = versions ]; then',
+      r.registryUnreachable
+        ? '  echo "npm error network request to https://registry.npmjs.org/ failed, reason: ETIMEDOUT" >&2; exit 1'
+        : r.packageExists
+          ? `  echo '${JSON.stringify(versionList)}'; exit 0`
+          : `  echo "npm error code E404" >&2; echo "npm error 404 Not Found - GET https://registry.npmjs.org/${PKG} - Not found" >&2; exit 1`,
+      "fi",
+      `n=$(cat ${JSON.stringify(counter)})`,
+      "n=$((n + 1))",
+      `echo "$n" > ${JSON.stringify(counter)}`,
+      r.eventually ? `if [ "$n" -gt ${r.notFoundTimes} ]; then echo "${version}"; exit 0; fi` : "",
+      'echo "npm error code E404" >&2',
+      `echo "npm error 404 No match found for version ${version}" >&2`,
+      "exit 1",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(join(bin, "npm"), 0o755);
+
+  const started = Date.now();
+  const proc = spawnSync("bash", ["-e", "-c", runBody().body], {
+    cwd: dir,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      // Shrink the real 300s window so the suite finishes. The DEFAULT is
+      // asserted separately below, so shrinking it here cannot hide a body
+      // that lost its retry.
+      NPM_VIEW_INITIAL_DELAY_SECONDS: "1",
+      NPM_VIEW_MAX_DELAY_SECONDS: "1",
+      NPM_VIEW_DEADLINE_SECONDS: "1",
+      ...env,
+    },
+  });
+  return {
+    stdout: (proc.stdout ?? "") + (proc.stderr ?? ""),
+    exit: proc.status ?? -1,
+    attempts: Number(readFileSync(counter, "utf-8").trim()),
+    elapsedMs: Date.now() - started,
+  };
+}
+
+describe("publish-release.yml — the run body under test is the committed one", () => {
+  it("the extracted `run:` body is a LITERAL substring of the file when re-indented", () => {
+    const { body, indent } = runBody();
+    const pad = " ".repeat(indent);
+    const reindented = body
+      .replace(/\n$/, "")
+      .split("\n")
+      .map((l) => (l === "" ? "" : pad + l))
+      .join("\n");
+    expect(wf).toContain(reindented);
+  });
+
+  it("still reads the pin with runpy rather than importing the package", () => {
+    expect(runBody().body).toContain("runpy.run_path");
+    expect(runBody().body).toContain("packages/aimock-pytest/src/aimock_pytest/_version.py");
+  });
+
+  it("ships a 300s default window, not whatever the tests happen to set", () => {
+    // A five-minute ceiling: ~16x the 18s lag that broke the v1.41.0 release,
+    // past npm's replication tail, still small beside the job's own setup.
+    expect(runBody().body).toContain("NPM_VIEW_DEADLINE_SECONDS:-300}");
+  });
+});
+
+describe("publish-release.yml — the race it used to lose", () => {
+  it("EXECUTED: a version that 404s twice and then appears is accepted", () => {
+    const o = observe("1.41.0", { notFoundTimes: 1 }, { NPM_VIEW_DEADLINE_SECONDS: "20" });
+    expect(o.exit).toBe(0);
+    expect(o.attempts).toBe(2);
+    expect(o.stdout).toContain(`${PKG}@1.41.0 is published`);
+  });
+
+  it("EXECUTED: a per-version 404 is overruled by the package's own version list", () => {
+    // The registry has already proven the version exists; nothing is gained by
+    // sitting out the rest of the window.
+    const o = observe("1.41.0", { eventually: false, listHasVersion: true });
+    expect(o.exit).toBe(0);
+    expect(o.stdout).toContain("IS in the registry version list");
+  });
+
+  it("EXECUTED: every attempt is logged, so a future failure is diagnosable", () => {
+    const o = observe("1.41.0", { notFoundTimes: 2 }, { NPM_VIEW_DEADLINE_SECONDS: "20" });
+    expect(o.stdout).toContain("attempt 1 (t+");
+    expect(o.stdout).toContain("attempt 2 (t+");
+    expect(o.stdout).toContain("attempt 3");
+    expect(o.stdout).toContain("No match found for version 1.41.0");
+    expect(o.stdout).toContain("retrying in");
+  });
+});
+
+describe("publish-release.yml — NEGATIVE CONTROLS: the guard still bites", () => {
+  it("EXECUTED: a version that never appears FAILS, after waiting out the window", () => {
+    const o = observe("99.99.99", { eventually: false });
+    expect(o.exit).toBe(1);
+    // It must have actually waited — a body that failed on the first attempt
+    // would be the original bug wearing a retry loop's clothes.
+    expect(o.attempts).toBeGreaterThan(1);
+    // `date +%s` truncates, so a 1s deadline can be crossed a little under 1s
+    // of wall clock; the point of the bound is that it slept at all.
+    expect(o.elapsedMs).toBeGreaterThanOrEqual(800);
+    expect(o.stdout).toContain("::error::");
+    expect(o.stdout).toContain("still not published after");
+    expect(o.stdout).toContain("refusing to publish a pin to a version npm does not have");
+  });
+
+  it("EXECUTED: the retry window is honoured, not multiplied by a longer deadline", () => {
+    const o = observe("99.99.99", { eventually: false }, { NPM_VIEW_DEADLINE_SECONDS: "3" });
+    expect(o.exit).toBe(1);
+    expect(o.elapsedMs).toBeGreaterThanOrEqual(2800);
+    expect(o.attempts).toBeGreaterThan(2);
+  });
+
+  it("EXECUTED: a pin to a package that does not exist FAILS FAST, without waiting", () => {
+    const o = observe(
+      "1.41.0",
+      { eventually: false, packageExists: false },
+      {
+        NPM_VIEW_DEADLINE_SECONDS: "600",
+      },
+    );
+    expect(o.exit).toBe(1);
+    expect(o.attempts).toBe(1);
+    expect(o.elapsedMs).toBeLessThan(10_000);
+    expect(o.stdout).toContain(`npm has no package named ${PKG} at all`);
+  });
+
+  it("EXECUTED: an unreachable registry is transient, NOT a missing-package verdict", () => {
+    const o = observe("1.41.0", { eventually: false, registryUnreachable: true });
+    expect(o.exit).toBe(1);
+    expect(o.attempts).toBeGreaterThan(1);
+    expect(o.stdout).toContain("registry unreachable, treating as transient");
+    expect(o.stdout).not.toContain("has no package named");
+  });
+});

--- a/src/__tests__/release-workflows.test.ts
+++ b/src/__tests__/release-workflows.test.ts
@@ -14,7 +14,10 @@ describe("release workflow sequencing", () => {
     const pytestJob = release.slice(release.indexOf("  publish-pytest:"));
     expect(pytestJob).toContain("needs: [build, publish]");
     expect(pytestJob).toContain("environment: pypi");
-    expect(pytestJob).toContain('npm view "@copilotkit/aimock@${VERSION}" version');
+    // Behaviour of this gate — including that it retries npm rather than
+    // racing it — lives in npm-publish-verify-workflow.test.ts, which executes
+    // the step's own run body. This only pins the sequencing claim.
+    expect(pytestJob).toContain('npm view "${PKG}@${VERSION}" version');
     expect(existsSync(standalonePytestPublish)).toBe(false);
   });
 });


### PR DESCRIPTION
## The defect

`publish-pytest` → **Verify pinned npm release is published** asked npm exactly once, so it raced the registry.

On the v1.41.0 release (run [34546620094](https://github.com/CopilotKit/aimock/actions/runs/34546620094)):

- `publish` published `@copilotkit/aimock@1.41.0` at `00:30:31`
- `publish-pytest` queried npm at `00:30:49` — **18 seconds later**
- npm answered `E404 No match found for version 1.41.0`
- the step exited 1 and the whole Release run went red

The version existed. Re-running the failed job unchanged passed and published nothing. It will fail on roughly any release where propagation is slow, and it makes a completely successful release look broken.

## The fix

Poll to a deadline instead of asking once. The guard is unchanged in purpose: it still exists to stop aimock-pytest shipping a pin to a version that was never published, and it still fails when the version is genuinely absent.

**Ceiling: 300s**, backoff 5s doubling to a 30s cap (~13 attempts). 300s is ~16x the observed 18s lag and past npm's replication tail, while staying small beside this job's own checkout/setup. A pin still missing after five minutes is a bad pin, not propagation, and must go red.

**Transient vs. genuine.** A per-version `E404` conflates two failures, so a companion `npm view <pkg> versions --json` splits them:

| companion query | meaning | action |
| --- | --- | --- |
| the **package** itself 404s | a bad pin — never propagation | **fail immediately**, don't wait 5 minutes |
| the version list **already carries** the version | published; the per-version 404 was a stale packument | **accept** — the registry has already proven the fact |
| package exists, version absent | genuinely ambiguous | keep waiting; this is what the deadline is for |
| package query fails **without** a 404 | registry unreachable | transient, keep waiting |

Every attempt logs its timestamp, the attempt number, and the npm error it got, so a future failure is diagnosable from the run log rather than a bare exit 1.

## Red → green

The step's own `run:` body was extracted verbatim and executed.

### RED (body on `main` @ `42eaaa2`)

Genuinely missing version, real npm:

```
$ bash -e body.sh          # _version.py pinned to 99.99.99
npm error code E404
npm error 404 No match found for version 99.99.99
RED-1 exit=1 elapsed=0s
```

The race shape — a stub that 404s on the first 2 calls then succeeds:

```
RED-2 exit=1 elapsed=0s calls=1
```

One call, zero wait, red — where call 3 would have succeeded. That is the production failure exactly.

### GREEN — the transient case now survives

```
attempt 1 (t+0s): @copilotkit/aimock@1.41.0 not visible yet
  | npm error 404 No match found for version 1.41.0
  @copilotkit/aimock exists but does not list 1.41.0 yet - lag or a bad pin, still waiting
  retrying in 1s
attempt 2 (t+2s): @copilotkit/aimock@1.41.0 not visible yet
  retrying in 1s
attempt 3: @copilotkit/aimock@1.41.0 is published (1.41.0)
GREEN-A exit=0 elapsed=3s calls=3
```

### GREEN — the half that actually matters: a genuinely missing version still FAILS

Full **default** 300s window, **real npm**, `99.99.99`:

```
::error::@copilotkit/aimock@99.99.99 is still not published after 13 attempts over 323s
(deadline 300s). aimock-pytest pins this version in
packages/aimock-pytest/src/aimock_pytest/_version.py; refusing to publish a pin to a
version npm does not have.

exit=1  elapsed=323s  attempts=13
```

And a pin to a package that does not exist fails **fast**, without burning the window:

```
attempt 1 (t+0s): @copilotkit/aimock@1.41.0 not visible yet
::error::npm has no package named @copilotkit/aimock at all, so the pin 1.41.0 in
packages/aimock-pytest/src/aimock_pytest/_version.py is not a propagation delay.
Failing immediately.
exit=1 elapsed=0s
```

## Coverage

`src/__tests__/npm-publish-verify-workflow.test.ts` follows the `unreleased-check-workflow.test.ts` idiom: it extracts the step's `run:` body, asserts the extraction is a **literal substring** of the workflow (so a paraphrasing extractor cannot pass), and executes it under bash against a stub `npm`. Four of the seven executed observations are negative controls, because a retry loop that swallowed a real bad pin would be strictly worse than the race it replaced.

**Mutation-tested — the guard bites:**

| mutation | result |
| --- | --- |
| deadline branch `exit 1` → `exit 0` (swallows a missing version) | **3 tests fail** |
| retry loop deleted, back to a single `npm view` | **8 tests fail** |

## Same pattern elsewhere?

Swept every workflow. The only other `npm view` is `publish-release.yml:33`, the `build` job's "Check if version is already published" — **not** the same pattern. It runs *before* publish, not read-after-write, and its failure means "not published yet", which is the path that proceeds to publish. Retrying there would be wrong. `publish-commit.yml` and `publish-docker.yml` do no read-after-write against a registry at all.

Worth noting separately, not fixed here: a transient 404 at line 33 would make `npm publish` run against an already-published version and fail with a conflict. That is a different race (stale-read-before-write) and out of scope for this PR.

## Gates

| gate | exit |
| --- | --- |
| `actionlint .github/workflows/publish-release.yml` | 0 |
| `prettier --check .` | 0 |
| `npx eslint .` | 0 |
| `pnpm typecheck` | 0 |
| `npx vitest run` (190 files, 5850 tests) | 0 |
| `npx commitlint --from origin/main --to HEAD` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvkmhXVLqSSEW6FvPQHSu5
