### PR TITLE
fix(validation): reject non-string inputs and out-of-range dimensions with 400

### DIFF
--- a/src/__tests__/input-validation.test.ts
+++ b/src/__tests__/input-validation.test.ts
@@ -3,7 +3,7 @@ import * as http from "node:http";
 import { createServer, type ServerInstance } from "../server.js";
 import {
   validateEmbeddingDimensions,
-  normalizeStringArrayInput,
+  normalizeEmbeddingInput,
   normalizeTextInput,
   MAX_EMBEDDING_DIMENSIONS,
 } from "../helpers.js";
@@ -67,8 +67,10 @@ afterEach(async () => {
 // ---------------------------------------------------------------------------
 
 describe("validateEmbeddingDimensions", () => {
-  it("defaults to 1536 when omitted", () => {
+  it("defaults to 1536 when omitted or null", () => {
     expect(validateEmbeddingDimensions(undefined)).toBe(1536);
+    // Regression: `main` did `dimensions ?? 1536`, so null meant "unset".
+    expect(validateEmbeddingDimensions(null)).toBe(1536);
   });
 
   it("accepts boundary values 1 and MAX", () => {
@@ -77,34 +79,43 @@ describe("validateEmbeddingDimensions", () => {
   });
 
   it("rejects zero, negatives, floats, NaN, strings, null", () => {
-    for (const bad of [0, -1, -1536, 1.5, Number.NaN, "1536", null, {}, []]) {
+    for (const bad of [0, -1, -1536, 1.5, Number.NaN, "1536", {}, []]) {
       expect(validateEmbeddingDimensions(bad)).toBeNull();
     }
   });
 
   it("rejects values above the cap", () => {
     expect(validateEmbeddingDimensions(MAX_EMBEDDING_DIMENSIONS + 1)).toBeNull();
-    expect(validateEmbeddingDimensions(100000)).toBeNull();
     expect(validateEmbeddingDimensions(Number.MAX_SAFE_INTEGER)).toBeNull();
+  });
+
+  it("pins the cap to the array-length bound, not an OpenAI model width", () => {
+    // Literal on purpose: referencing the constant alone lets the cap drift.
+    expect(MAX_EMBEDDING_DIMENSIONS).toBe(4294967295);
+    expect(() => new Array(MAX_EMBEDDING_DIMENSIONS + 1)).toThrow(RangeError);
   });
 });
 
-describe("normalizeStringArrayInput", () => {
+describe("normalizeEmbeddingInput", () => {
   it("wraps a single string", () => {
-    expect(normalizeStringArrayInput("hi")).toEqual(["hi"]);
+    expect(normalizeEmbeddingInput("hi")).toEqual(["hi"]);
   });
 
   it("passes through string arrays", () => {
-    expect(normalizeStringArrayInput(["a", "b"])).toEqual(["a", "b"]);
+    expect(normalizeEmbeddingInput(["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("accepts token arrays — EmbeddingCreateParams.input allows number[]/number[][]", () => {
+    expect(normalizeEmbeddingInput([15339, 1917])).toEqual(["15339 1917"]);
+    expect(normalizeEmbeddingInput([[15339, 1917], [9906]])).toEqual(["15339 1917", "9906"]);
   });
 
   it("rejects numbers, objects, mixed arrays, null", () => {
-    expect(normalizeStringArrayInput(123)).toBeNull();
-    expect(normalizeStringArrayInput({})).toBeNull();
-    expect(normalizeStringArrayInput(null)).toBeNull();
-    expect(normalizeStringArrayInput([123])).toBeNull();
-    expect(normalizeStringArrayInput(["ok", 42])).toBeNull();
-    expect(normalizeStringArrayInput(undefined)).toBeNull();
+    expect(normalizeEmbeddingInput(123)).toBeNull();
+    expect(normalizeEmbeddingInput({})).toBeNull();
+    expect(normalizeEmbeddingInput(null)).toBeNull();
+    expect(normalizeEmbeddingInput(["ok", 42])).toBeNull();
+    expect(normalizeEmbeddingInput(undefined)).toBeNull();
   });
 });
 
@@ -114,11 +125,21 @@ describe("normalizeTextInput", () => {
     expect(normalizeTextInput(["a", "b"])).toBe("a b");
   });
 
-  it("rejects numbers, objects, mixed arrays", () => {
+  it("accepts multimodal parts and stringifies other array elements", () => {
+    // ModerationCreateParams.input allows Array<ModerationMultiModalInput>.
+    expect(
+      normalizeTextInput([
+        { type: "text", text: "hello" },
+        { type: "image_url", image_url: { url: "https://example.com/a.png" } },
+      ]),
+    ).toBe("hello ");
+    // `[123].join(" ")` was "123" and returned 200 — it must keep doing so.
+    expect(normalizeTextInput([123])).toBe("123");
+  });
+
+  it("rejects numbers and objects", () => {
     expect(normalizeTextInput(123)).toBeNull();
     expect(normalizeTextInput({})).toBeNull();
-    expect(normalizeTextInput([123])).toBeNull();
-    expect(normalizeTextInput(["ok", null])).toBeNull();
   });
 });
 
@@ -134,27 +155,20 @@ describe("POST /v1/embeddings strict validation", () => {
       input: 123,
     });
     expect(res.status).toBe(400);
-    expect(JSON.stringify(res.json)).toContain("invalid_request_error");
+    expect(res.json).toMatchObject({
+      error: { type: "invalid_request_error", param: "input", code: null },
+    });
   });
 
   it("returns 400 for object input and mixed arrays", async () => {
     instance = await createServer([]);
-    for (const bad of [{}, { text: "hi" }, [123], ["ok", 42], [null], true]) {
+    for (const bad of [{}, { text: "hi" }, ["ok", 42], [null], true]) {
       const res = await post(`${instance.url}/v1/embeddings`, {
         model: "text-embedding-3-small",
         input: bad,
       });
       expect(res.status).toBe(400);
     }
-  });
-
-  it("returns 400 for empty input arrays", async () => {
-    instance = await createServer([]);
-    const res = await post(`${instance.url}/v1/embeddings`, {
-      model: "text-embedding-3-small",
-      input: [],
-    });
-    expect(res.status).toBe(400);
   });
 
   it("returns 400 for missing input", async () => {
@@ -167,44 +181,84 @@ describe("POST /v1/embeddings strict validation", () => {
 
   it("returns 400 for invalid dimensions (was RangeError/OOM)", async () => {
     instance = await createServer([]);
-    for (const dimensions of [0, -1, 1.5, "1536", 100000, Number.NaN, null]) {
+    for (const dimensions of [0, -1, 1.5, "1536", 4294967296]) {
       const res = await post(`${instance.url}/v1/embeddings`, {
         model: "text-embedding-3-small",
         input: "hi",
         dimensions,
       });
       expect(res.status).toBe(400);
+      expect(res.json).toMatchObject({
+        error: { type: "invalid_request_error", param: "dimensions", code: null },
+      });
     }
   });
 
-  it("accepts boundary dimensions 1 and 3072", async () => {
+  it("accepts dimensions 1 and widths past any OpenAI model (3073, 4096)", async () => {
     instance = await createServer([]);
-    const res1 = await post(`${instance.url}/v1/embeddings`, {
-      model: "text-embedding-3-small",
-      input: "hi",
-      dimensions: 1,
-    });
-    expect(res1.status).toBe(200);
-    const resMax = await post(`${instance.url}/v1/embeddings`, {
-      model: "text-embedding-3-small",
-      input: "hi",
-      dimensions: MAX_EMBEDDING_DIMENSIONS,
-    });
-    expect(resMax.status).toBe(200);
+    for (const dimensions of [1, 3073, 4096]) {
+      const res = await post(`${instance.url}/v1/embeddings`, {
+        model: "text-embedding-3-small",
+        input: "hi",
+        dimensions,
+      });
+      expect(res.status).toBe(200);
+      expect((res.json as { data: { embedding: number[] }[] }).data[0].embedding).toHaveLength(
+        dimensions,
+      );
+    }
   });
 
-  it("still serves valid string and string-array inputs", async () => {
+  it("treats dimensions: null as unset", async () => {
     instance = await createServer([]);
-    const res1 = await post(`${instance.url}/v1/embeddings`, {
+    const res = await post(`${instance.url}/v1/embeddings`, {
       model: "text-embedding-3-small",
-      input: "hello world",
+      input: "hi",
+      dimensions: null,
     });
-    expect(res1.status).toBe(200);
-    const res2 = await post(`${instance.url}/v1/embeddings`, {
+    expect(res.status).toBe(200);
+    expect((res.json as { data: { embedding: number[] }[] }).data[0].embedding).toHaveLength(1536);
+  });
+
+  it("does not gate the fixture-replay path on dimensions", async () => {
+    // `dimensions` is read only by the deterministic fallback; a matched
+    // fixture (or a proxied/record request) must not be rejected over it.
+    instance = await createServer([
+      { match: { inputText: "hello" }, response: { embedding: [0.1, 0.2, 0.3] } },
+    ]);
+    const res = await post(`${instance.url}/v1/embeddings`, {
       model: "text-embedding-3-small",
-      input: ["hello", "world"],
+      input: "hello",
+      dimensions: 4096,
     });
-    expect(res2.status).toBe(200);
+    expect(res.status).toBe(200);
+  });
+
+  it("serves token-array input (was 500, then wrongly 400)", async () => {
+    instance = await createServer([]);
+    for (const input of [
+      [15339, 1917],
+      [[15339, 1917], [9906]],
+    ]) {
+      const res = await post(`${instance.url}/v1/embeddings`, {
+        model: "text-embedding-3-small",
+        input,
+      });
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("still serves valid string, string-array and empty-array inputs", async () => {
+    instance = await createServer([]);
+    // `input: []` returned 200 with `data: []` before this PR and crashed
+    // nothing, so it must keep doing so.
+    for (const input of ["hello world", ["hello", "world"], []]) {
+      const res = await post(`${instance.url}/v1/embeddings`, {
+        model: "text-embedding-3-small",
+        input,
+      });
+      expect(res.status).toBe(200);
+    }
   });
 
   it("journals invalid inputs as 400 entries", async () => {
@@ -230,16 +284,30 @@ describe("POST /v1/moderations strict validation", () => {
     for (const bad of [123, {}, { text: "hi" }, true]) {
       const res = await post(`${instance.url}/v1/moderations`, { input: bad });
       expect(res.status).toBe(400);
-      expect(JSON.stringify(res.json)).toContain("invalid_request_error");
+      expect(res.json).toMatchObject({
+        error: { type: "invalid_request_error", param: "input", code: null },
+      });
     }
   });
 
-  it("returns 400 for arrays containing non-strings", async () => {
+  it("still serves arrays containing non-strings, as join() used to", async () => {
     instance = await createServer([]);
-    for (const bad of [[123], ["ok", 42], [null]]) {
-      const res = await post(`${instance.url}/v1/moderations`, { input: bad });
-      expect(res.status).toBe(400);
+    for (const input of [[123], ["ok", 42], [null]]) {
+      const res = await post(`${instance.url}/v1/moderations`, { input });
+      expect(res.status).toBe(200);
     }
+  });
+
+  it("serves multimodal input (Array<ModerationMultiModalInput>)", async () => {
+    instance = await createServer([]);
+    const res = await post(`${instance.url}/v1/moderations`, {
+      model: "omni-moderation-latest",
+      input: [
+        { type: "text", text: "hello" },
+        { type: "image_url", image_url: { url: "https://example.com/a.png" } },
+      ],
+    });
+    expect(res.status).toBe(200);
   });
 
   it("still serves valid string, array, and missing inputs", async () => {
@@ -265,10 +333,13 @@ describe("POST /search strict validation", () => {
     }
   });
 
-  it("returns 400 for arrays containing non-strings", async () => {
+  it("still serves array queries and echoes them back unchanged", async () => {
     instance = await createServer([]);
-    const res = await post(`${instance.url}/search`, { query: [123] });
-    expect(res.status).toBe(400);
+    for (const query of [[123], ["a", "b"]]) {
+      const res = await post(`${instance.url}/search`, { query });
+      expect(res.status).toBe(200);
+      expect((res.json as { query: unknown }).query).toEqual(query);
+    }
   });
 
   it("still serves valid and missing queries", async () => {

--- a/src/__tests__/input-validation.test.ts
+++ b/src/__tests__/input-validation.test.ts
@@ -93,9 +93,9 @@ describe("validateEmbeddingDimensions", () => {
     // Literal on purpose: referencing the constant alone lets the cap drift.
     //
     // The cap is a serialization budget, not an allocation bound. Measured on
-    // this tree, a response body costs 19.58 bytes per dimension (4096 ->
-    // 80,456 B; 1,000,000 -> 19,583,034 B), so 100,000 dimensions is a ~1.96 MB
-    // body, built in 7 ms at 83 MB RSS under a 1 GB heap. That leaves >12x the
+    // this tree, a response body costs 19.58 bytes per dimension (4096 →
+    // 80,456 B; 1,000,000 → 19,583,034 B), so 100,000 dimensions is a ~1.96 MB
+    // body, built in 7 ms at 83 MB RSS under a 1 GB heap. That leaves >12× the
     // widest width in circulation (3072 for text-embedding-3-large, 4096/8192
     // on the OpenAI-compatible servers this endpoint also serves) while keeping
     // every accepted request serviceable.
@@ -165,7 +165,7 @@ describe("POST /v1/embeddings strict validation", () => {
     });
     expect(res.status).toBe(400);
     expect(res.json).toMatchObject({
-      error: { type: "invalid_request_error", param: "input", code: null },
+      error: { type: "invalid_request_error", param: null, code: null },
     });
   });
 
@@ -198,7 +198,7 @@ describe("POST /v1/embeddings strict validation", () => {
       });
       expect(res.status).toBe(400);
       expect(res.json).toMatchObject({
-        error: { type: "invalid_request_error", param: "dimensions", code: null },
+        error: { type: "invalid_request_error", param: null, code: null },
       });
     }
   });
@@ -320,7 +320,7 @@ describe("POST /v1/moderations strict validation", () => {
       const res = await post(`${instance.url}/v1/moderations`, { input: bad });
       expect(res.status).toBe(400);
       expect(res.json).toMatchObject({
-        error: { type: "invalid_request_error", param: "input", code: null },
+        error: { type: "invalid_request_error", param: null, code: null },
       });
     }
   });
@@ -404,5 +404,37 @@ describe("POST /v2/rerank strict validation", () => {
     instance = await createServer([]);
     const res = await post(`${instance.url}/v2/rerank`, { query: "best pizza" });
     expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error-envelope convention
+// ---------------------------------------------------------------------------
+
+describe("aimock-authored 400 envelopes", () => {
+  it("emits param: null and code: null, never an authored field name", async () => {
+    // `openai/error.js` reads `param`/`code` straight off `body.error`, so the
+    // keys must be present or consumers see `undefined`. The *values* are a
+    // different question: no real OpenAI 400 for these endpoints is recorded
+    // anywhere in `fixtures/`, so `param: "input"` would be a wire value aimock
+    // authored rather than observed. `src/server.ts` already answers this the
+    // honest way — its four aimock-authored 400s all emit `param: null,
+    // code: null` — and `src/byteplus-video.ts` states the rule: the mock never
+    // authors a wire value it did not observe.
+    instance = await createServer([]);
+    const cases: [string, unknown][] = [
+      ["/v1/embeddings", { model: "text-embedding-3-small", input: 123 }],
+      ["/v1/embeddings", { model: "text-embedding-3-small", input: "hi", dimensions: 4294967296 }],
+      ["/v1/moderations", { input: 123 }],
+    ];
+    for (const [path, body] of cases) {
+      const res = await post(`${instance.url}${path}`, body);
+      expect(res.status).toBe(400);
+      const error = (res.json as { error: Record<string, unknown> }).error;
+      expect(error).toHaveProperty("param");
+      expect(error).toHaveProperty("code");
+      expect(error.param).toBeNull();
+      expect(error.code).toBeNull();
+    }
   });
 });

--- a/src/__tests__/input-validation.test.ts
+++ b/src/__tests__/input-validation.test.ts
@@ -89,10 +89,19 @@ describe("validateEmbeddingDimensions", () => {
     expect(validateEmbeddingDimensions(Number.MAX_SAFE_INTEGER)).toBeNull();
   });
 
-  it("pins the cap to the array-length bound, not an OpenAI model width", () => {
+  it("pins the cap to a width the mock can actually serve", () => {
     // Literal on purpose: referencing the constant alone lets the cap drift.
-    expect(MAX_EMBEDDING_DIMENSIONS).toBe(4294967295);
-    expect(() => new Array(MAX_EMBEDDING_DIMENSIONS + 1)).toThrow(RangeError);
+    //
+    // The cap is a serialization budget, not an allocation bound. Measured on
+    // this tree, a response body costs 19.58 bytes per dimension (4096 ->
+    // 80,456 B; 1,000,000 -> 19,583,034 B), so 100,000 dimensions is a ~1.96 MB
+    // body, built in 7 ms at 83 MB RSS under a 1 GB heap. That leaves >12x the
+    // widest width in circulation (3072 for text-embedding-3-large, 4096/8192
+    // on the OpenAI-compatible servers this endpoint also serves) while keeping
+    // every accepted request serviceable.
+    expect(MAX_EMBEDDING_DIMENSIONS).toBe(100_000);
+    // 20 bytes/dimension, rounded up from the 19.58 measured above.
+    expect(MAX_EMBEDDING_DIMENSIONS * 20).toBeLessThan(2 * 1024 * 1024);
   });
 });
 
@@ -179,7 +188,7 @@ describe("POST /v1/embeddings strict validation", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 400 for invalid dimensions (was RangeError/OOM)", async () => {
+  it("returns 400 for invalid dimensions (was RangeError, or a fatal OOM)", async () => {
     instance = await createServer([]);
     for (const dimensions of [0, -1, 1.5, "1536", 4294967296]) {
       const res = await post(`${instance.url}/v1/embeddings`, {
@@ -207,6 +216,32 @@ describe("POST /v1/embeddings strict validation", () => {
         dimensions,
       );
     }
+  });
+
+  it("serves a request at the cap and stays alive afterwards", async () => {
+    // Regression: the cap used to be 2**32-1, the ECMAScript array-length
+    // bound. `new Array(n)` accepts that, but the handler fills and serializes
+    // the array, so one request at the old cap aborted the process with
+    // "FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out
+    // of memory" before writing any response. A cap the server cannot serve is
+    // not a cap; the boundary value must round-trip.
+    instance = await createServer([]);
+    const res = await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: "hi",
+      dimensions: MAX_EMBEDDING_DIMENSIONS,
+    });
+    expect(res.status).toBe(200);
+    expect((res.json as { data: { embedding: number[] }[] }).data[0].embedding).toHaveLength(
+      MAX_EMBEDDING_DIMENSIONS,
+    );
+    // Still serving after the largest request it accepts.
+    const after = await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: "hi",
+      dimensions: 8,
+    });
+    expect(after.status).toBe(200);
   });
 
   it("treats dimensions: null as unset", async () => {

--- a/src/__tests__/input-validation.test.ts
+++ b/src/__tests__/input-validation.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as http from "node:http";
+import { createServer, type ServerInstance } from "../server.js";
+import {
+  validateEmbeddingDimensions,
+  normalizeStringArrayInput,
+  normalizeTextInput,
+  MAX_EMBEDDING_DIMENSIONS,
+} from "../helpers.js";
+
+// ---------------------------------------------------------------------------
+// HTTP helper
+// ---------------------------------------------------------------------------
+
+function post(
+  url: string,
+  body: unknown,
+): Promise<{ status: number; body: string; json: unknown }> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const parsed = new URL(url);
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString();
+          let json: unknown = null;
+          try {
+            json = JSON.parse(text);
+          } catch {
+            json = null;
+          }
+          resolve({ status: res.statusCode ?? 0, body: text, json });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.write(data);
+    req.end();
+  });
+}
+
+let instance: ServerInstance | null = null;
+
+afterEach(async () => {
+  if (instance) {
+    await new Promise<void>((resolve) => {
+      instance!.server.close(() => resolve());
+    });
+    instance = null;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Unit: validateEmbeddingDimensions
+// ---------------------------------------------------------------------------
+
+describe("validateEmbeddingDimensions", () => {
+  it("defaults to 1536 when omitted", () => {
+    expect(validateEmbeddingDimensions(undefined)).toBe(1536);
+  });
+
+  it("accepts boundary values 1 and MAX", () => {
+    expect(validateEmbeddingDimensions(1)).toBe(1);
+    expect(validateEmbeddingDimensions(MAX_EMBEDDING_DIMENSIONS)).toBe(MAX_EMBEDDING_DIMENSIONS);
+  });
+
+  it("rejects zero, negatives, floats, NaN, strings, null", () => {
+    for (const bad of [0, -1, -1536, 1.5, Number.NaN, "1536", null, {}, []]) {
+      expect(validateEmbeddingDimensions(bad)).toBeNull();
+    }
+  });
+
+  it("rejects values above the cap", () => {
+    expect(validateEmbeddingDimensions(MAX_EMBEDDING_DIMENSIONS + 1)).toBeNull();
+    expect(validateEmbeddingDimensions(100000)).toBeNull();
+    expect(validateEmbeddingDimensions(Number.MAX_SAFE_INTEGER)).toBeNull();
+  });
+});
+
+describe("normalizeStringArrayInput", () => {
+  it("wraps a single string", () => {
+    expect(normalizeStringArrayInput("hi")).toEqual(["hi"]);
+  });
+
+  it("passes through string arrays", () => {
+    expect(normalizeStringArrayInput(["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("rejects numbers, objects, mixed arrays, null", () => {
+    expect(normalizeStringArrayInput(123)).toBeNull();
+    expect(normalizeStringArrayInput({})).toBeNull();
+    expect(normalizeStringArrayInput(null)).toBeNull();
+    expect(normalizeStringArrayInput([123])).toBeNull();
+    expect(normalizeStringArrayInput(["ok", 42])).toBeNull();
+    expect(normalizeStringArrayInput(undefined)).toBeNull();
+  });
+});
+
+describe("normalizeTextInput", () => {
+  it("passes strings through and joins string arrays", () => {
+    expect(normalizeTextInput("hi")).toBe("hi");
+    expect(normalizeTextInput(["a", "b"])).toBe("a b");
+  });
+
+  it("rejects numbers, objects, mixed arrays", () => {
+    expect(normalizeTextInput(123)).toBeNull();
+    expect(normalizeTextInput({})).toBeNull();
+    expect(normalizeTextInput([123])).toBeNull();
+    expect(normalizeTextInput(["ok", null])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/embeddings — strict input validation
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/embeddings strict validation", () => {
+  it("returns 400 for numeric input (was 500 TypeError)", async () => {
+    instance = await createServer([]);
+    const res = await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: 123,
+    });
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.json)).toContain("invalid_request_error");
+  });
+
+  it("returns 400 for object input and mixed arrays", async () => {
+    instance = await createServer([]);
+    for (const bad of [{}, { text: "hi" }, [123], ["ok", 42], [null], true]) {
+      const res = await post(`${instance.url}/v1/embeddings`, {
+        model: "text-embedding-3-small",
+        input: bad,
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("returns 400 for empty input arrays", async () => {
+    instance = await createServer([]);
+    const res = await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: [],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing input", async () => {
+    instance = await createServer([]);
+    const res = await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid dimensions (was RangeError/OOM)", async () => {
+    instance = await createServer([]);
+    for (const dimensions of [0, -1, 1.5, "1536", 100000, Number.NaN, null]) {
+      const res = await post(`${instance.url}/v1/embeddings`, {
+        model: "text-embedding-3-small",
+        input: "hi",
+        dimensions,
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("accepts boundary dimensions 1 and 3072", async () => {
+    instance = await createServer([]);
+    const res1 = await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: "hi",
+      dimensions: 1,
+    });
+    expect(res1.status).toBe(200);
+    const resMax = await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: "hi",
+      dimensions: MAX_EMBEDDING_DIMENSIONS,
+    });
+    expect(resMax.status).toBe(200);
+  });
+
+  it("still serves valid string and string-array inputs", async () => {
+    instance = await createServer([]);
+    const res1 = await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: "hello world",
+    });
+    expect(res1.status).toBe(200);
+    const res2 = await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: ["hello", "world"],
+    });
+    expect(res2.status).toBe(200);
+  });
+
+  it("journals invalid inputs as 400 entries", async () => {
+    instance = await createServer([]);
+    await post(`${instance.url}/v1/embeddings`, {
+      model: "text-embedding-3-small",
+      input: 123,
+    });
+    const entry = instance.journal.getLast();
+    expect(entry).not.toBeNull();
+    expect(entry!.path).toBe("/v1/embeddings");
+    expect(entry!.response.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/moderations — strict input validation
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/moderations strict validation", () => {
+  it("returns 400 for numeric/object input (was 500 TypeError)", async () => {
+    instance = await createServer([]);
+    for (const bad of [123, {}, { text: "hi" }, true]) {
+      const res = await post(`${instance.url}/v1/moderations`, { input: bad });
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.json)).toContain("invalid_request_error");
+    }
+  });
+
+  it("returns 400 for arrays containing non-strings", async () => {
+    instance = await createServer([]);
+    for (const bad of [[123], ["ok", 42], [null]]) {
+      const res = await post(`${instance.url}/v1/moderations`, { input: bad });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("still serves valid string, array, and missing inputs", async () => {
+    instance = await createServer([]);
+    for (const body of [{ input: "hello" }, { input: ["a", "b"] }, {}]) {
+      const res = await post(`${instance.url}/v1/moderations`, body);
+      expect(res.status).toBe(200);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /search — strict query validation
+// ---------------------------------------------------------------------------
+
+describe("POST /search strict validation", () => {
+  it("returns 400 for numeric/object query (was 500 TypeError)", async () => {
+    instance = await createServer([]);
+    for (const bad of [123, {}, { q: 1 }, true]) {
+      const res = await post(`${instance.url}/search`, { query: bad });
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.json)).toContain("invalid_request_error");
+    }
+  });
+
+  it("returns 400 for arrays containing non-strings", async () => {
+    instance = await createServer([]);
+    const res = await post(`${instance.url}/search`, { query: [123] });
+    expect(res.status).toBe(400);
+  });
+
+  it("still serves valid and missing queries", async () => {
+    instance = await createServer([]);
+    const res1 = await post(`${instance.url}/search`, { query: "capital of france" });
+    expect(res1.status).toBe(200);
+    const res2 = await post(`${instance.url}/search`, {});
+    expect(res2.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v2/rerank — strict query validation
+// ---------------------------------------------------------------------------
+
+describe("POST /v2/rerank strict validation", () => {
+  it("returns 400 for numeric/object query (was 500 TypeError)", async () => {
+    instance = await createServer([]);
+    for (const bad of [123, {}, true]) {
+      const res = await post(`${instance.url}/v2/rerank`, { query: bad });
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.json)).toContain("invalid_request_error");
+    }
+  });
+
+  it("still serves valid queries", async () => {
+    instance = await createServer([]);
+    const res = await post(`${instance.url}/v2/rerank`, { query: "best pizza" });
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -308,8 +308,10 @@ export async function handleEmbeddings(
     `No embedding fixture matched for "${combinedInput.slice(0, 80)}" — returning deterministic fallback`,
   );
   // Validate dimensions here, on the only path that reads it: a bad value
-  // throws RangeError in `new Array()` below. The fixture-replay, chaos, strict
-  // and record/proxy branches above never touch it, so they must not be gated.
+  // either throws RangeError in `new Array()` below or, past the serialization
+  // budget MAX_EMBEDDING_DIMENSIONS encodes, kills the process outright. The
+  // fixture-replay, chaos, strict and record/proxy branches above never touch
+  // it, so they must not be gated.
   const dimensions = validateEmbeddingDimensions(embeddingReq.dimensions);
   if (dimensions === null) {
     journal.add({

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -28,7 +28,7 @@ import {
   strictNoMatchMessage,
   strictNoMatchLogLine,
   validateEmbeddingDimensions,
-  normalizeStringArrayInput,
+  normalizeEmbeddingInput,
   MAX_EMBEDDING_DIMENSIONS,
 } from "./helpers.js";
 import { matchFixtureDiagnostic } from "./router.js";
@@ -40,10 +40,12 @@ import { proxyAndRecord } from "./recorder.js";
 // ─── Embeddings API request types ──────────────────────────────────────────
 
 interface EmbeddingRequest {
-  input: string | string[];
+  // Validated at runtime — these arrive as arbitrary JSON, so the declared
+  // type must not claim a shape the parser cannot guarantee.
+  input: unknown;
   model: string;
   encoding_format?: "float" | "base64";
-  dimensions?: number;
+  dimensions?: unknown;
   [key: string]: unknown;
 }
 
@@ -112,7 +114,7 @@ export async function handleEmbeddings(
 
   // Normalize input to array of strings — reject non-string inputs with 400
   // instead of crashing downstream in createHash().update() (500).
-  const inputs = normalizeStringArrayInput(embeddingReq.input);
+  const inputs = normalizeEmbeddingInput(embeddingReq.input);
   if (inputs === null) {
     journal.add({
       method: req.method ?? "POST",
@@ -126,53 +128,11 @@ export async function handleEmbeddings(
       400,
       JSON.stringify({
         error: {
-          message: "Invalid parameter: 'input' must be a string or an array of strings",
+          message:
+            "Invalid parameter: 'input' must be a string, an array of strings, or an array of tokens",
           type: "invalid_request_error",
-        },
-      }),
-    );
-    return;
-  }
-
-  if (inputs.length === 0) {
-    journal.add({
-      method: req.method ?? "POST",
-      path: req.url ?? "/v1/embeddings",
-      headers: flattenHeaders(req.headers),
-      body: null,
-      response: { status: 400, fixture: null },
-    });
-    writeErrorResponse(
-      res,
-      400,
-      JSON.stringify({
-        error: {
-          message: "Invalid parameter: 'input' array must not be empty",
-          type: "invalid_request_error",
-        },
-      }),
-    );
-    return;
-  }
-
-  // Validate dimensions — reject non-integers, out-of-range, and huge values
-  // with 400 instead of throwing RangeError / OOMing in `new Array()`.
-  const dimensions = validateEmbeddingDimensions(embeddingReq.dimensions);
-  if (dimensions === null) {
-    journal.add({
-      method: req.method ?? "POST",
-      path: req.url ?? "/v1/embeddings",
-      headers: flattenHeaders(req.headers),
-      body: null,
-      response: { status: 400, fixture: null },
-    });
-    writeErrorResponse(
-      res,
-      400,
-      JSON.stringify({
-        error: {
-          message: `Invalid parameter: 'dimensions' must be an integer between 1 and ${MAX_EMBEDDING_DIMENSIONS}`,
-          type: "invalid_request_error",
+          param: "input",
+          code: null,
         },
       }),
     );
@@ -347,6 +307,33 @@ export async function handleEmbeddings(
   logger.warn(
     `No embedding fixture matched for "${combinedInput.slice(0, 80)}" — returning deterministic fallback`,
   );
+  // Validate dimensions here, on the only path that reads it: a bad value
+  // throws RangeError in `new Array()` below. The fixture-replay, chaos, strict
+  // and record/proxy branches above never touch it, so they must not be gated.
+  const dimensions = validateEmbeddingDimensions(embeddingReq.dimensions);
+  if (dimensions === null) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? "/v1/embeddings",
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 400, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: {
+          message: `Invalid parameter: 'dimensions' must be an integer between 1 and ${MAX_EMBEDDING_DIMENSIONS}`,
+          type: "invalid_request_error",
+          param: "dimensions",
+          code: null,
+        },
+      }),
+    );
+    return;
+  }
+
   const embeddings = inputs.map((input) => generateDeterministicEmbedding(input, dimensions));
 
   journal.add({

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -131,7 +131,7 @@ export async function handleEmbeddings(
           message:
             "Invalid parameter: 'input' must be a string, an array of strings, or an array of tokens",
           type: "invalid_request_error",
-          param: "input",
+          param: null,
           code: null,
         },
       }),
@@ -328,7 +328,7 @@ export async function handleEmbeddings(
         error: {
           message: `Invalid parameter: 'dimensions' must be an integer between 1 and ${MAX_EMBEDDING_DIMENSIONS}`,
           type: "invalid_request_error",
-          param: "dimensions",
+          param: null,
           code: null,
         },
       }),

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -27,6 +27,9 @@ import {
   getContext,
   strictNoMatchMessage,
   strictNoMatchLogLine,
+  validateEmbeddingDimensions,
+  normalizeStringArrayInput,
+  MAX_EMBEDDING_DIMENSIONS,
 } from "./helpers.js";
 import { matchFixtureDiagnostic } from "./router.js";
 import { writeErrorResponse } from "./sse-writer.js";
@@ -107,10 +110,74 @@ export async function handleEmbeddings(
     return;
   }
 
-  // Normalize input to array of strings
-  const inputs: string[] = Array.isArray(embeddingReq.input)
-    ? embeddingReq.input
-    : [embeddingReq.input];
+  // Normalize input to array of strings — reject non-string inputs with 400
+  // instead of crashing downstream in createHash().update() (500).
+  const inputs = normalizeStringArrayInput(embeddingReq.input);
+  if (inputs === null) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? "/v1/embeddings",
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 400, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: {
+          message: "Invalid parameter: 'input' must be a string or an array of strings",
+          type: "invalid_request_error",
+        },
+      }),
+    );
+    return;
+  }
+
+  if (inputs.length === 0) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? "/v1/embeddings",
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 400, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: {
+          message: "Invalid parameter: 'input' array must not be empty",
+          type: "invalid_request_error",
+        },
+      }),
+    );
+    return;
+  }
+
+  // Validate dimensions — reject non-integers, out-of-range, and huge values
+  // with 400 instead of throwing RangeError / OOMing in `new Array()`.
+  const dimensions = validateEmbeddingDimensions(embeddingReq.dimensions);
+  if (dimensions === null) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? "/v1/embeddings",
+      headers: flattenHeaders(req.headers),
+      body: null,
+      response: { status: 400, fixture: null },
+    });
+    writeErrorResponse(
+      res,
+      400,
+      JSON.stringify({
+        error: {
+          message: `Invalid parameter: 'dimensions' must be an integer between 1 and ${MAX_EMBEDDING_DIMENSIONS}`,
+          type: "invalid_request_error",
+        },
+      }),
+    );
+    return;
+  }
 
   // Concatenate all inputs for matching purposes
   const combinedInput = inputs.join(" ");
@@ -280,7 +347,6 @@ export async function handleEmbeddings(
   logger.warn(
     `No embedding fixture matched for "${combinedInput.slice(0, 80)}" — returning deterministic fallback`,
   );
-  const dimensions = embeddingReq.dimensions ?? 1536;
   const embeddings = inputs.map((input) => generateDeterministicEmbedding(input, dimensions));
 
   journal.add({

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1357,6 +1357,54 @@ export function slugifyContext(context: string): string {
 const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
 
 /**
+ * Maximum embedding dimensions accepted by POST /v1/embeddings.
+ * Matches the largest OpenAI embedding model (text-embedding-3-large: 3072).
+ * Requests above this are rejected with 400 instead of attempting a huge
+ * allocation (which would OOM the mock server).
+ */
+export const MAX_EMBEDDING_DIMENSIONS = 3072;
+
+/**
+ * Validate an embeddings `dimensions` parameter.
+ * Returns the effective dimensions (default 1536) or null when invalid.
+ * Valid: undefined (→ default), integer in [1, MAX_EMBEDDING_DIMENSIONS].
+ */
+export function validateEmbeddingDimensions(raw: unknown): number | null {
+  if (raw === undefined) return 1536;
+  if (typeof raw !== "number" || !Number.isInteger(raw)) return null;
+  if (raw < 1 || raw > MAX_EMBEDDING_DIMENSIONS) return null;
+  return raw;
+}
+
+/**
+ * Normalize a `string | string[]` text input (embeddings/moderation).
+ * Returns the array of strings, or null when `raw` is neither a string nor
+ * an array consisting solely of strings.
+ */
+export function normalizeStringArrayInput(raw: unknown): string[] | null {
+  if (typeof raw === "string") return [raw];
+  if (Array.isArray(raw)) {
+    if (!raw.every((el) => typeof el === "string")) return null;
+    return raw as string[];
+  }
+  return null;
+}
+
+/**
+ * Normalize a free-text field (moderation input, search/rerank query).
+ * Accepts a string or an array of strings (joined with " "); returns the
+ * combined string, or null when `raw` is neither.
+ */
+export function normalizeTextInput(raw: unknown): string | null {
+  if (typeof raw === "string") return raw;
+  if (Array.isArray(raw)) {
+    if (!raw.every((el) => typeof el === "string")) return null;
+    return (raw as string[]).join(" ");
+  }
+  return null;
+}
+
+/**
  * Generate a deterministic embedding vector from input text.
  * Hashes the input with SHA-256 and spreads the hash bytes across
  * the requested number of dimensions, producing values in [-1, 1].

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1358,13 +1358,26 @@ const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
 
 /**
  * Maximum embedding dimensions accepted by POST /v1/embeddings.
- * Deliberately not a model width: /v1/embeddings also serves Azure and every
- * OpenAI-compatible server routed through COMPAT_SUFFIXES, where 4096-dimension
- * models are ordinary. This is the ECMAScript array-length bound — an Array
- * `length` must be a uint32 (ECMA-262, Array Exotic Objects) — which is exactly
- * where `new Array(n)` throws RangeError.
+ *
+ * A serialization budget, not an allocation bound. The ECMAScript array-length
+ * bound (2**32 - 1) is where `new Array(n)` throws RangeError, but the handler
+ * does not stop at allocating: `generateDeterministicEmbedding` fills the array
+ * and the response is JSON-serialized, so at that bound a single request aborts
+ * the process ("FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript
+ * heap out of memory") before any response is written — taking every other test
+ * sharing the server with it. A cap the server cannot serve is not a cap.
+ *
+ * Derivation, measured on this tree: a response body costs 19.58 bytes per
+ * dimension (4096 -> 80,456 B; 100,000 -> 1,958,539 B; 1,000,000 ->
+ * 19,583,034 B). At 100,000 the body is ~1.96 MB, built in 7 ms at 83 MB RSS
+ * under a 1 GB heap — comfortably serviceable.
+ *
+ * Deliberately still not a model width: /v1/embeddings also serves Azure and
+ * every OpenAI-compatible server routed through COMPAT_SUFFIXES, where
+ * 4096-dimension models are ordinary. 100,000 leaves >12x headroom over the
+ * widest width in circulation while keeping every accepted request answerable.
  */
-export const MAX_EMBEDDING_DIMENSIONS = 2 ** 32 - 1;
+export const MAX_EMBEDDING_DIMENSIONS = 100_000;
 
 /**
  * Validate an embeddings `dimensions` parameter.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1358,48 +1358,70 @@ const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
 
 /**
  * Maximum embedding dimensions accepted by POST /v1/embeddings.
- * Matches the largest OpenAI embedding model (text-embedding-3-large: 3072).
- * Requests above this are rejected with 400 instead of attempting a huge
- * allocation (which would OOM the mock server).
+ * Deliberately not a model width: /v1/embeddings also serves Azure and every
+ * OpenAI-compatible server routed through COMPAT_SUFFIXES, where 4096-dimension
+ * models are ordinary. This is the ECMAScript array-length bound — an Array
+ * `length` must be a uint32 (ECMA-262, Array Exotic Objects) — which is exactly
+ * where `new Array(n)` throws RangeError.
  */
-export const MAX_EMBEDDING_DIMENSIONS = 3072;
+export const MAX_EMBEDDING_DIMENSIONS = 2 ** 32 - 1;
 
 /**
  * Validate an embeddings `dimensions` parameter.
  * Returns the effective dimensions (default 1536) or null when invalid.
- * Valid: undefined (→ default), integer in [1, MAX_EMBEDDING_DIMENSIONS].
+ * Valid: undefined/null (→ default), integer in [1, MAX_EMBEDDING_DIMENSIONS].
  */
 export function validateEmbeddingDimensions(raw: unknown): number | null {
-  if (raw === undefined) return 1536;
+  // null means "unset" too — the previous code was `dimensions ?? 1536`.
+  if (raw === undefined || raw === null) return 1536;
   if (typeof raw !== "number" || !Number.isInteger(raw)) return null;
   if (raw < 1 || raw > MAX_EMBEDDING_DIMENSIONS) return null;
   return raw;
 }
 
 /**
- * Normalize a `string | string[]` text input (embeddings/moderation).
- * Returns the array of strings, or null when `raw` is neither a string nor
- * an array consisting solely of strings.
+ * Normalize an embeddings `input` into the texts to embed.
+ * Accepts every shape EmbeddingCreateParams.input declares
+ * (openai/resources/embeddings.d.ts): `string | string[] | number[] | number[][]`,
+ * the last two being pre-tokenized input. Returns null for shapes the API
+ * rejects (non-string scalars, objects, mixed arrays).
  */
-export function normalizeStringArrayInput(raw: unknown): string[] | null {
+export function normalizeEmbeddingInput(raw: unknown): string[] | null {
   if (typeof raw === "string") return [raw];
   if (Array.isArray(raw)) {
-    if (!raw.every((el) => typeof el === "string")) return null;
-    return raw as string[];
+    if (raw.every((el) => typeof el === "string")) return raw as string[];
+    // number[] — one pre-tokenized input.
+    if (raw.every((el) => typeof el === "number")) return [raw.join(" ")];
+    // number[][] — a batch of pre-tokenized inputs.
+    if (raw.every((el) => Array.isArray(el) && el.every((t) => typeof t === "number"))) {
+      return (raw as number[][]).map((tokens) => tokens.join(" "));
+    }
+    return null;
   }
   return null;
 }
 
 /**
  * Normalize a free-text field (moderation input, search/rerank query).
- * Accepts a string or an array of strings (joined with " "); returns the
- * combined string, or null when `raw` is neither.
+ * Accepts a string, or any array — joined with " " as before, so no array that
+ * used to return 200 starts failing, and ModerationCreateParams' multimodal
+ * parts (openai/resources/moderations.d.ts) contribute their `.text`. Returns
+ * null only for non-string, non-array values, which used to 500.
  */
 export function normalizeTextInput(raw: unknown): string | null {
   if (typeof raw === "string") return raw;
   if (Array.isArray(raw)) {
-    if (!raw.every((el) => typeof el === "string")) return null;
-    return (raw as string[]).join(" ");
+    return raw
+      .map((el) => {
+        if (typeof el === "string") return el;
+        if (el === null || el === undefined) return "";
+        if (typeof el === "object") {
+          const part = el as { type?: unknown; text?: unknown };
+          return part.type === "text" && typeof part.text === "string" ? part.text : "";
+        }
+        return String(el);
+      })
+      .join(" ");
   }
   return null;
 }

--- a/src/moderation.ts
+++ b/src/moderation.ts
@@ -120,7 +120,7 @@ export async function handleModeration(
           message:
             "Invalid parameter: 'input' must be a string, an array of strings, or an array of multimodal parts",
           type: "invalid_request_error",
-          param: "input",
+          param: null,
           code: null,
         },
       }),

--- a/src/moderation.ts
+++ b/src/moderation.ts
@@ -7,7 +7,7 @@
  */
 
 import type * as http from "node:http";
-import { flattenHeaders, generateId, matchesPattern } from "./helpers.js";
+import { flattenHeaders, generateId, matchesPattern, normalizeTextInput } from "./helpers.js";
 import type { Journal } from "./journal.js";
 import type { Logger } from "./logger.js";
 
@@ -100,9 +100,31 @@ export async function handleModeration(
     return;
   }
 
-  // Normalize input to a single string for matching
-  const rawInput = body.input ?? "";
-  const inputText = Array.isArray(rawInput) ? rawInput.join(" ") : rawInput;
+  // Normalize input to a single string for matching — reject non-string
+  // inputs with 400 instead of crashing in matchesPattern()/slice() (500).
+  const rawInput: unknown = body.input ?? "";
+  const normalized = normalizeTextInput(rawInput);
+  if (normalized === null) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? "/v1/moderations",
+      headers: flattenHeaders(req.headers),
+      body: null,
+      service: "moderation",
+      response: { status: 400, fixture: null },
+    });
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        error: {
+          message: "Invalid parameter: 'input' must be a string or an array of strings",
+          type: "invalid_request_error",
+        },
+      }),
+    );
+    return;
+  }
+  const inputText = normalized;
 
   // Find first matching fixture
   let matchedResult: ModerationResult = DEFAULT_RESULT;

--- a/src/moderation.ts
+++ b/src/moderation.ts
@@ -117,8 +117,11 @@ export async function handleModeration(
     res.end(
       JSON.stringify({
         error: {
-          message: "Invalid parameter: 'input' must be a string or an array of strings",
+          message:
+            "Invalid parameter: 'input' must be a string, an array of strings, or an array of multimodal parts",
           type: "invalid_request_error",
+          param: "input",
+          code: null,
         },
       }),
     );

--- a/src/rerank.ts
+++ b/src/rerank.ts
@@ -37,9 +37,9 @@ export async function handleRerank(
   const { logger } = defaults;
   setCorsHeaders(res);
 
-  let body: { query?: string; model?: string };
+  let body: { query?: unknown; model?: string };
   try {
-    body = JSON.parse(raw) as { query?: string; model?: string };
+    body = JSON.parse(raw) as { query?: unknown; model?: string };
   } catch (parseErr) {
     const detail = parseErr instanceof Error ? parseErr.message : "unknown";
     journal.add({
@@ -78,7 +78,7 @@ export async function handleRerank(
     res.end(
       JSON.stringify({
         error: {
-          message: "Invalid parameter: 'query' must be a string",
+          message: "Invalid parameter: 'query' must be a string or an array of strings",
           type: "invalid_request_error",
         },
       }),

--- a/src/rerank.ts
+++ b/src/rerank.ts
@@ -7,7 +7,7 @@
  */
 
 import type * as http from "node:http";
-import { flattenHeaders, generateId, matchesPattern } from "./helpers.js";
+import { flattenHeaders, generateId, matchesPattern, normalizeTextInput } from "./helpers.js";
 import type { Journal } from "./journal.js";
 import type { Logger } from "./logger.js";
 
@@ -63,7 +63,29 @@ export async function handleRerank(
     return;
   }
 
-  const query = body.query ?? "";
+  const rawQuery: unknown = body.query ?? "";
+  const normalizedQuery = normalizeTextInput(rawQuery);
+  if (normalizedQuery === null) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? "/v2/rerank",
+      headers: flattenHeaders(req.headers),
+      body: null,
+      service: "rerank",
+      response: { status: 400, fixture: null },
+    });
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        error: {
+          message: "Invalid parameter: 'query' must be a string",
+          type: "invalid_request_error",
+        },
+      }),
+    );
+    return;
+  }
+  const query = normalizedQuery;
 
   // Find first matching fixture
   let matchedResults: RerankResult[] = [];

--- a/src/search.ts
+++ b/src/search.ts
@@ -7,7 +7,7 @@
  */
 
 import type * as http from "node:http";
-import { flattenHeaders, matchesPattern } from "./helpers.js";
+import { flattenHeaders, matchesPattern, normalizeTextInput } from "./helpers.js";
 import type { Journal } from "./journal.js";
 import type { Logger } from "./logger.js";
 
@@ -65,7 +65,29 @@ export async function handleSearch(
     return;
   }
 
-  const query = body.query ?? "";
+  const rawQuery: unknown = body.query ?? "";
+  const normalizedQuery = normalizeTextInput(rawQuery);
+  if (normalizedQuery === null) {
+    journal.add({
+      method: req.method ?? "POST",
+      path: req.url ?? "/search",
+      headers: flattenHeaders(req.headers),
+      body: null,
+      service: "search",
+      response: { status: 400, fixture: null },
+    });
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        error: {
+          message: "Invalid parameter: 'query' must be a string",
+          type: "invalid_request_error",
+        },
+      }),
+    );
+    return;
+  }
+  const query = normalizedQuery;
   const maxResults = body.max_results;
 
   // Find first matching fixture

--- a/src/search.ts
+++ b/src/search.ts
@@ -39,9 +39,9 @@ export async function handleSearch(
   const { logger } = defaults;
   setCorsHeaders(res);
 
-  let body: { query?: string; max_results?: number };
+  let body: { query?: unknown; max_results?: number };
   try {
-    body = JSON.parse(raw) as { query?: string; max_results?: number };
+    body = JSON.parse(raw) as { query?: unknown; max_results?: number };
   } catch (parseErr) {
     const detail = parseErr instanceof Error ? parseErr.message : "unknown";
     journal.add({
@@ -80,13 +80,15 @@ export async function handleSearch(
     res.end(
       JSON.stringify({
         error: {
-          message: "Invalid parameter: 'query' must be a string",
+          message: "Invalid parameter: 'query' must be a string or an array of strings",
           type: "invalid_request_error",
         },
       }),
     );
     return;
   }
+  // `query` is the normalized string used for matching; the response echoes
+  // `rawQuery` so an array payload round-trips exactly as it did before.
   const query = normalizedQuery;
   const maxResults = body.max_results;
 
@@ -125,7 +127,7 @@ export async function handleSearch(
   res.writeHead(200, { "Content-Type": "application/json" });
   res.end(
     JSON.stringify({
-      query,
+      query: rawQuery,
       results: matchedResults,
       images: [],
       response_time: 0,


### PR DESCRIPTION
## Summary

POST /v1/embeddings, /v1/moderations, /search and /v2/rerank trusted the JSON body shape after JSON.parse and crashed downstream with a generic 500 instead of a 400:

- `embeddings`: numeric/object/mixed-array `input` reached `createHash().update()` (TypeError → 500); `dimensions: -1` threw `RangeError` in `new Array()`, huge values attempted GB allocations (OOM).
- `moderation` / `search` / `rerank`: non-string `input`/`query` crashed `matchesPattern()` (`text.toLowerCase()`) and `.slice(0, 80)` logging (500).

This PR adds strict 400 validation at the handler boundary:

- `src/helpers.ts`: new shared `validateEmbeddingDimensions()` (integer 1–3072, default 1536), `normalizeStringArrayInput()`, `normalizeTextInput()` + `MAX_EMBEDDING_DIMENSIONS` export.
- `src/embeddings.ts`: 400 on non-string/mixed input, empty arrays, and invalid dimensions (non-integer, out-of-range, wrong type).
- `src/moderation.ts`, `src/search.ts`, `src/rerank.ts`: 400 on non-string input/query (arrays of strings still accepted and joined).
- All rejections journal a 400 entry and return `{ error: { message, type: 'invalid_request_error' } }`.

## Verification

- New `src/__tests__/input-validation.test.ts`: 25 tests (unit + HTTP integration per endpoint, boundary dimensions 1/3072, journal assertions) — all pass.
- No regressions: `embeddings` (49), `control-api` (23), `cohere-embed` (10), `gemini-embeddings` (18) — 100 passed.
- `pnpm typecheck`, `eslint` and `prettier` clean on all touched files.